### PR TITLE
add custom error for unsupported command.

### DIFF
--- a/examples/multi_device_plugin/devices/air8884.go
+++ b/examples/multi_device_plugin/devices/air8884.go
@@ -18,5 +18,5 @@ func (d *Air8884) Read(in sdk.Device) (sdk.ReadResource, error) {
 }
 
 func (d *Air8884) Write(in sdk.Device, data *sdk.WriteData) (error) {
-	return nil
+	return &sdk.UnsupportedCommandError{}
 }

--- a/examples/multi_device_plugin/devices/temp2010.go
+++ b/examples/multi_device_plugin/devices/temp2010.go
@@ -18,5 +18,5 @@ func (d *Temp2010) Read(in sdk.Device) (sdk.ReadResource, error) {
 }
 
 func (d *Temp2010) Write(in sdk.Device, data *sdk.WriteData) (error) {
-	return nil
+	return &sdk.UnsupportedCommandError{}
 }

--- a/examples/multi_device_plugin/devices/volt1103.go
+++ b/examples/multi_device_plugin/devices/volt1103.go
@@ -18,5 +18,5 @@ func (d *Volt1103) Read(in sdk.Device) (sdk.ReadResource, error) {
 }
 
 func (d *Volt1103) Write(in sdk.Device, data *sdk.WriteData) (error) {
-	return nil
+	return &sdk.UnsupportedCommandError{}
 }

--- a/examples/multi_device_plugin/plugin.go
+++ b/examples/multi_device_plugin/plugin.go
@@ -28,7 +28,7 @@ type ExamplePluginHandler struct {}
 func (h *ExamplePluginHandler) Read(in sdk.Device) (sdk.ReadResource, error) {
 	handler := lookup[in.Model()]
 	if handler == nil {
-		log.Fatalf("Unsupported device model: %v", in.Model())
+		log.Fatalf("Unsupported device model: %+v", in)
 	}
 	return handler.Read(in)
 }
@@ -36,7 +36,7 @@ func (h *ExamplePluginHandler) Read(in sdk.Device) (sdk.ReadResource, error) {
 func (h *ExamplePluginHandler) Write(in sdk.Device, data *sdk.WriteData) (error) {
 	handler := lookup[in.Model()]
 	if handler == nil {
-		log.Fatalf("Unsupported device model: %v", in.Model())
+		log.Fatalf("Unsupported device model: %+v", in)
 	}
 	return handler.Write(in, data)
 }

--- a/sdk/errors.go
+++ b/sdk/errors.go
@@ -1,0 +1,12 @@
+package sdk
+
+
+// UnsupportedCommandError is an error that can be used to designate that
+// a given device does not support an operation, e.g. write. Write is required
+// by the PluginHandler interface, but if a device (e.g. a temperature sensor)
+// doesn't support writing, this error can be returned.
+type UnsupportedCommandError struct {}
+
+func (e *UnsupportedCommandError) Error() string {
+	return "Command not supported for given device."
+}

--- a/sdk/rw.go
+++ b/sdk/rw.go
@@ -47,6 +47,7 @@ func (rwl *RWLoop) run() {
 					err := rwl.handler.Write(rwl.devices[w.device], data)
 					if err != nil {
 						UpdateTransactionState(w.transaction.id, ERROR)
+						w.transaction.message = err.Error()
 						Logger.Errorf("Failed to write to device %v: %v", w.device, err)
 					}
 					UpdateTransactionStatus(w.transaction.id, DONE)


### PR DESCRIPTION
this also fixes a bug where error message was not included in WriteResponse. updates an example to use custom error.

fixes #18 