### PR TITLE
CLI updates

### DIFF
--- a/client/cli.go
+++ b/client/cli.go
@@ -297,7 +297,7 @@ func makeAPIClient() {
 		}),
 	)
 	if err != nil {
-		cliError(fmt.Errorf("unable to connect: %v\n", err))
+		cliError(fmt.Errorf("unable to connect: %v", err))
 	}
 	c = synse.NewInternalApiClient(conn)
 }


### PR DESCRIPTION
the simple cli that was included here for debug/testing/dev was missing some write functionality - namely: it only supported the 'action' slot of a write, but not the 'raw' slot. 

this doesn't totally solve it (doesn't allow for multiple raw packets at once), but it does now allow someone to support raw data, e.g. now we can use the CLI to send an {Action: "state", Raw: []byte{"o", "n"}}, e.g. set the state to "on".

This also adds some formatted output so its easier to see the responses, especially for metainfo.

*metainfo*
```
$ ./pcli --name i2c metainfo
ID                                      TYPE           MODEL          PROTOCOL  INFO                          
b4bf920c24ad7c2e23360ffcda9f4b5d        temperature    MAX11610       i2c       Rack Temperature Top Right    
b0efdac41dfc7e8261dfd4bd2369b161        temperature    MAX11610       i2c       Rack Temperature Middle Left  
5beec8c6db5445fd164566478997ff30        temperature    MAX11610       i2c       Rack Temperature Bottom Left  
1e93da83dd383757474f539314446c3d        temperature    MAX11610       i2c       Rack Temperature Spare        
c5d8272bc1106aa12225850d33483f33        temperature    MAX11610       i2c       Rack Temperature Top Rear     
e955c02a134ff2ac6e9e3a9dedc67dc1        temperature    MAX11610       i2c       Rack Temperature Bottom Rear  
2079f261767869c929e01ba10132eceb        temperature    MAX11610       i2c       Rack Temperature Spare        
3f336eb0bb188de8c72650d406225ffa        temperature    MAX11610       i2c       Rack Temperature Top Left     
18185208cbc0e5a4700badd6e39bb12d        temperature    MAX11610       i2c       Rack Temperature Middle Rear  
80de4a2b73c41cf71ef7d30e1f2b9494        temperature    MAX11610       i2c       Rack Temperature Middle Right 
fa941bad2325cb097deb97743007ff36        temperature    MAX11610       i2c       Rack Temperature Bottom Right 
645a790d97fc93ee12ec5fbb514230d7        temperature    MAX11610       i2c       Rack Temperature Spare        
4f1cd148cf0aa2dcb2dbd6f00403119c        led            PCA9632        i2c       chamber LED    
```

*read*
```
$ ./pcli --name i2c read 4f1cd148cf0aa2dcb2dbd6f00403119c
DEVICE                                  TYPE      READING   
4f1cd148cf0aa2dcb2dbd6f00403119c        color     33ffaa    
4f1cd148cf0aa2dcb2dbd6f00403119c        state     off       
4f1cd148cf0aa2dcb2dbd6f00403119c        blink     steady
```

*write*
```
$ ./pcli --name i2c write 4f1cd148cf0aa2dcb2dbd6f00403119c color 00ff55
TRANSACTION              ACTION              RAW                 
b80ad34op3am832pmip0     color               00ff55            
```

*transaction*
```
$ ./pcli --name i2c transaction b80ad34op3am832pmip0
TRANSACTION              STATUS    STATE     CREATED             UPDATED             
b80ad34op3am832pmip0     DONE      OK        2017-11-06 13:14:36.619783456 -0500 EST m=+224.7574138242017-11-06 13:14:37.2326403 -0500 EST m=+225.370270728
```


the formatting of the timestamps on the transaction are still weird and I need to figure that out.
