### PR TITLE
update sdk to allow for configurable grpc server comms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,15 @@ dep:  ## Ensure and prune dependencies
 	dep ensure -v
 	dep prune
 
+.PHONY: examples
+examples:  ## Build the examples
+	@for d in examples/*/ ; do \
+		echo "\n\033[32m$$d\033[0m" ; \
+		cd $$d ; \
+		go build -v -o plugin ; \
+		cd ../.. ; \
+	done
+
 .PHONY: fmt
 fmt:  ## Run goimports on all go files
 	find . -name '*.go' -not -wholename './vendor/*' | while read -r file; do goimports -w "$$file"; done

--- a/examples/auto_enumerate/plugin.yml
+++ b/examples/auto_enumerate/plugin.yml
@@ -1,6 +1,9 @@
 name: auto-enum-plugin
 version: 1.0.0
 debug: true
+socket:
+  network: unix
+  address: auto-enum-plugin.sock
 settings:
   loop_delay: 500
   read:

--- a/examples/c_plugin/plugin.yml
+++ b/examples/c_plugin/plugin.yml
@@ -1,2 +1,5 @@
 name: c-plugin
 version: 1.0.0
+socket:
+  network: unix
+  address: c-plugin.sock

--- a/examples/multi_device_plugin/plugin.yml
+++ b/examples/multi_device_plugin/plugin.yml
@@ -1,6 +1,9 @@
 name: example-plugin
 version: 1.0.0
 debug: true
+socket:
+  network: unix
+  address: example-plugin.sock
 settings:
   loop_delay: 100
   read:

--- a/examples/simple_plugin/plugin.go
+++ b/examples/simple_plugin/plugin.go
@@ -100,6 +100,10 @@ func main() {
 		Name:    "simple-plugin",
 		Version: "1.0.0",
 		Debug:   true,
+		Socket:  sdk.PluginConfigSocket{
+			Network: "tcp",
+			Address: ":50051",
+		},
 	}
 
 	p, err := sdk.NewPlugin(

--- a/sdk/config_test.go
+++ b/sdk/config_test.go
@@ -65,6 +65,9 @@ func TestPluginConfig_FromFile3(t *testing.T) {
 	cfgFile := `name: test-plugin
 version: 1.0
 debug: false
+socket:
+  network: unix
+  address: /vapor/test.sock
 settings:
   loop_delay: 10
   read:
@@ -105,6 +108,14 @@ context:
 
 	if c.Debug {
 		t.Error("Unexpected value in the Debug field.")
+	}
+
+	if c.Socket.Network != "unix" {
+		t.Error("Unexpected value in the Socket Network field.")
+	}
+
+	if c.Socket.Address != "/vapor/test.sock" {
+		t.Error("Unexpected value in the Socket Address field.")
 	}
 
 	if c.Settings.LoopDelay != 10 {

--- a/sdk/server.go
+++ b/sdk/server.go
@@ -133,14 +133,23 @@ func (ps *PluginServer) Run() error {
 	// start the RW loop
 	ps.rwLoop.run()
 
-	// create the socket used to communicate with the gRPC server
-	socket, err := setupSocket(ps.name)
-	if err != nil {
-		return err
+	// set up the gRPC server
+	var address string
+	var err error
+	if Config.Socket.Network == "unix" {
+		// if we are configuring for unix socket communication, we first need
+		// to create the socket.
+		address, err = setupSocket(Config.Socket.Address)
+		if err != nil {
+			return err
+		}
+	} else {
+		// otherwise, we will just use the address specified in the configuration
+		address = Config.Socket.Address
 	}
 
-	Logger.Infof("[grpc] listening on socket %v", socket)
-	lis, err := net.Listen("unix", socket)
+	Logger.Infof("[grpc] listening on network %v with address %v", Config.Socket.Network, address)
+	lis, err := net.Listen(Config.Socket.Network, address)
 	if err != nil {
 		Logger.Fatalf("Failed to listen: %v", err)
 		return err

--- a/sdk/utils.go
+++ b/sdk/utils.go
@@ -56,7 +56,7 @@ func makeDevices(deviceConfigs []*DeviceConfig, protoConfigs []*PrototypeConfig,
 // setupSocket is used to make sure the unix socket used for gRPC communication
 // is set up and accessible locally.
 func setupSocket(name string) (string, error) {
-	socket := fmt.Sprintf("%s/%s.sock", sockPath, name)
+	socket := fmt.Sprintf("%s/%s", sockPath, name)
 
 	_, err := os.Stat(sockPath)
 	if err != nil {

--- a/sdk/utils_test.go
+++ b/sdk/utils_test.go
@@ -105,7 +105,7 @@ func TestSetupSocket(t *testing.T) {
 		t.Errorf("Expected path to not exist, got error: %v", err)
 	}
 
-	sock, err := setupSocket("test")
+	sock, err := setupSocket("test.sock")
 
 	if err != nil {
 		t.Error(err)
@@ -136,7 +136,7 @@ func TestSetupSocket2(t *testing.T) {
 		t.Errorf("Expected file to exist, but does not.")
 	}
 
-	sock, err := setupSocket("test")
+	sock, err := setupSocket("test.sock")
 
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
fixes #47 
fixes #46

- adds a 'socket' group to the config that allows you to specify the network and address that the grpc server should listen on (e.g. "unix", "/synse/test.sock" or "tcp", ":50051")
- update the sdk server logic to use the configured socket info. if using 'unix' as network, then creates the unix socket.
- update tests for the new config
- update the examples to use the new config
- adds a make target to build all examples


I names the config field 'socket' since that seemed to make enough sense to me. Maybe not the best name though? Any thoughts/alternative ideas for it or does it seem fine?