### PR TITLE
add configuration versioning support

### DIFF
--- a/examples/auto_enumerate/Makefile
+++ b/examples/auto_enumerate/Makefile
@@ -1,6 +1,19 @@
+PLUGIN_VERSION=1.0
+
+PKG_CTX=github.com/vapor-ware/synse-sdk/sdk
+BUILD_DATE := $(shell date -u +%Y-%m-%dT%T 2> /dev/null)
+GIT_COMMIT := $(shell git rev-parse --short HEAD 2> /dev/null || true)
+GIT_TAG := $(shell git describe --tags 2> /dev/null || true)
+GO_VERSION := $(shell go version | awk '{ print $$3 }')
+
+LDFLAGS="-X ${PKG_CTX}.BuildDate=${BUILD_DATE} \
+		 -X ${PKG_CTX}.GitCommit=${GIT_COMMIT} \
+		 -X ${PKG_CTX}.GitTag=${GIT_TAG} \
+		 -X ${PKG_CTX}.GoVersion=${GO_VERSION} \
+         -X ${PKG_CTX}.VersionString=${PLUGIN_VERSION}"
 
 build:
-	go build -o plugin
+	@go build -ldflags ${LDFLAGS} -o plugin
 
 
 .PHONY: build

--- a/examples/auto_enumerate/config.yml
+++ b/examples/auto_enumerate/config.yml
@@ -1,5 +1,5 @@
+version: 1
 name: auto-enum-plugin
-version: 1.0.0
 debug: true
 network:
   type: unix

--- a/examples/auto_enumerate/plugin.go
+++ b/examples/auto_enumerate/plugin.go
@@ -6,10 +6,11 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
+	"os"
 	"strconv"
 	"time"
+
 	"github.com/vapor-ware/synse-sdk/sdk/config"
-	"os"
 )
 
 // ExamplePluginHandler is a plugin-specific handler required by the

--- a/examples/c_plugin/Makefile
+++ b/examples/c_plugin/Makefile
@@ -1,6 +1,19 @@
+PLUGIN_VERSION=1.0
+
+PKG_CTX=github.com/vapor-ware/synse-sdk/sdk
+BUILD_DATE := $(shell date -u +%Y-%m-%dT%T 2> /dev/null)
+GIT_COMMIT := $(shell git rev-parse --short HEAD 2> /dev/null || true)
+GIT_TAG := $(shell git describe --tags 2> /dev/null || true)
+GO_VERSION := $(shell go version | awk '{ print $$3 }')
+
+LDFLAGS="-X ${PKG_CTX}.BuildDate=${BUILD_DATE} \
+		 -X ${PKG_CTX}.GitCommit=${GIT_COMMIT} \
+		 -X ${PKG_CTX}.GitTag=${GIT_TAG} \
+		 -X ${PKG_CTX}.GoVersion=${GO_VERSION} \
+         -X ${PKG_CTX}.VersionString=${PLUGIN_VERSION}"
 
 build:
-	go build -o plugin
+	@go build -ldflags ${LDFLAGS} -o plugin
 
 
 .PHONY: build

--- a/examples/c_plugin/config.yml
+++ b/examples/c_plugin/config.yml
@@ -1,5 +1,5 @@
+version: 1
 name: c-plugin
-version: 1.0.0
 network:
   type: unix
   address: c-plugin.sock

--- a/examples/c_plugin/plugin.go
+++ b/examples/c_plugin/plugin.go
@@ -4,10 +4,11 @@ import (
 	"github.com/vapor-ware/synse-sdk/sdk"
 
 	"log"
+	"os"
 	"strconv"
 	"time"
+
 	"github.com/vapor-ware/synse-sdk/sdk/config"
-	"os"
 )
 
 // ExamplePluginHandler is a plugin-specific handler required by the

--- a/examples/multi_device_plugin/Makefile
+++ b/examples/multi_device_plugin/Makefile
@@ -1,6 +1,19 @@
+PLUGIN_VERSION=1.0
+
+PKG_CTX=github.com/vapor-ware/synse-sdk/sdk
+BUILD_DATE := $(shell date -u +%Y-%m-%dT%T 2> /dev/null)
+GIT_COMMIT := $(shell git rev-parse --short HEAD 2> /dev/null || true)
+GIT_TAG := $(shell git describe --tags 2> /dev/null || true)
+GO_VERSION := $(shell go version | awk '{ print $$3 }')
+
+LDFLAGS="-X ${PKG_CTX}.BuildDate=${BUILD_DATE} \
+		 -X ${PKG_CTX}.GitCommit=${GIT_COMMIT} \
+		 -X ${PKG_CTX}.GitTag=${GIT_TAG} \
+		 -X ${PKG_CTX}.GoVersion=${GO_VERSION} \
+         -X ${PKG_CTX}.VersionString=${PLUGIN_VERSION}"
 
 build:
-	go build -o plugin
+	@go build -ldflags ${LDFLAGS} -o plugin
 
 
 .PHONY: build

--- a/examples/multi_device_plugin/config.yml
+++ b/examples/multi_device_plugin/config.yml
@@ -1,5 +1,5 @@
+version: 1
 name: example-plugin
-version: 1.0.0
 debug: true
 network:
   type: unix

--- a/examples/multi_device_plugin/plugin.go
+++ b/examples/multi_device_plugin/plugin.go
@@ -3,10 +3,11 @@ package main
 import (
 	"log"
 
+	"os"
+
 	"github.com/vapor-ware/synse-sdk/examples/multi_device_plugin/devices"
 	"github.com/vapor-ware/synse-sdk/sdk"
 	"github.com/vapor-ware/synse-sdk/sdk/config"
-	"os"
 )
 
 // lookup is a simple lookup table that maps the known device models

--- a/examples/simple_plugin/Makefile
+++ b/examples/simple_plugin/Makefile
@@ -1,6 +1,19 @@
+PLUGIN_VERSION=1.0
+
+PKG_CTX=github.com/vapor-ware/synse-sdk/sdk
+BUILD_DATE := $(shell date -u +%Y-%m-%dT%T 2> /dev/null)
+GIT_COMMIT := $(shell git rev-parse --short HEAD 2> /dev/null || true)
+GIT_TAG := $(shell git describe --tags 2> /dev/null || true)
+GO_VERSION := $(shell go version | awk '{ print $$3 }')
+
+LDFLAGS="-X ${PKG_CTX}.BuildDate=${BUILD_DATE} \
+		 -X ${PKG_CTX}.GitCommit=${GIT_COMMIT} \
+		 -X ${PKG_CTX}.GitTag=${GIT_TAG} \
+		 -X ${PKG_CTX}.GoVersion=${GO_VERSION} \
+         -X ${PKG_CTX}.VersionString=${PLUGIN_VERSION}"
 
 build:
-	go build -o plugin
+	@go build -ldflags ${LDFLAGS} -o plugin
 
 
 .PHONY: build

--- a/examples/simple_plugin/plugin.go
+++ b/examples/simple_plugin/plugin.go
@@ -15,9 +15,9 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
+	"os"
 	"strconv"
 	"time"
-	"os"
 )
 
 // SimplePluginHandler fulfils the SDK's PluginHandler interface. It requires a

--- a/sdk/config/device.go
+++ b/sdk/config/device.go
@@ -1,13 +1,11 @@
 package config
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 
 	"github.com/vapor-ware/synse-server-grpc/go"
-	"gopkg.in/yaml.v2"
 )
 
 const (
@@ -19,18 +17,6 @@ const (
 	// specify a non-default directory for device configs.
 	EnvDevicePath = "PLUGIN_DEVICE_PATH"
 )
-
-type v1deviceConfig struct {
-	Version   string              `yaml:"version"`
-	Locations map[string]Location `yaml:"locations"`
-	Devices   []v1device          `yaml:"devices"`
-}
-
-type v1device struct {
-	Type      string              `yaml:"type"`
-	Model     string              `yaml:"model"`
-	Instances []map[string]string `yaml:"instances"`
-}
 
 // DeviceConfig represents a single device instance.
 type DeviceConfig struct {
@@ -77,36 +63,33 @@ func ParseDeviceConfig() ([]*DeviceConfig, error) {
 
 	for _, f := range files {
 		if isValidConfig(f) {
-			var scheme v1deviceConfig
-
+			// Get the file contents
 			fpath := filepath.Join(path, f.Name())
 			yml, err := ioutil.ReadFile(fpath)
 			if err != nil {
 				return nil, err
 			}
-			err = yaml.Unmarshal(yml, &scheme)
+
+			// Get the version of the configuration file
+			ver, err := getConfigVersion(yml)
 			if err != nil {
 				return nil, err
 			}
 
-			for _, device := range scheme.Devices {
-				for _, i := range device.Instances {
-					locationTag := i["location"]
-					if locationTag == "" {
-						return nil, fmt.Errorf("no location defined for device: %#v", device)
-					}
-					location := scheme.Locations[locationTag]
-
-					cfg := DeviceConfig{
-						Version:  scheme.Version,
-						Type:     device.Type,
-						Model:    device.Model,
-						Location: location,
-						Data:     i,
-					}
-					cfgs = append(cfgs, &cfg)
-				}
+			// Get the handler for the given configuration version
+			cfgHandler, err := getDeviceConfigVersionHandler(ver)
+			if err != nil {
+				return nil, err
 			}
+
+			// Process the configuration files with the specific handler
+			// for the version of that config file.
+			c, err := cfgHandler.processDeviceConfig(yml)
+			if err != nil {
+				return nil, err
+			}
+
+			cfgs = append(cfgs, c...)
 		}
 	}
 	return cfgs, nil

--- a/sdk/config/plugin.go
+++ b/sdk/config/plugin.go
@@ -87,73 +87,7 @@ func (c *PluginConfig) Validate() error {
 func NewPluginConfig() (*PluginConfig, error) {
 	v := viper.New()
 	setLookupInfo(v)
-	setDefaults(v)
-
-	err := v.ReadInConfig()
-	if err != nil {
-		return nil, err
-	}
-
-	autoEnum, err := toSliceStringMapI(v.Get("auto_enumerate"))
-	if err != nil {
-		return nil, err
-	}
-
-	ctx, err := toStringMapI(v.Get("context"))
-	if err != nil {
-		return nil, err
-	}
-
-	p := &PluginConfig{
-		Name:    v.GetString("name"),
-		Version: v.GetString("version"),
-		Network: NetworkSettings{
-			Type:    v.GetString("network.type"),
-			Address: v.GetString("network.address"),
-		},
-		Settings: Settings{
-			LoopDelay: v.GetInt("settings.loop_delay"),
-			Read: ReadSettings{
-				BufferSize: v.GetInt("settings.read.buffer_size"),
-			},
-			Write: WriteSettings{
-				BufferSize: v.GetInt("settings.write.buffer_size"),
-				PerLoop:    v.GetInt("settings.write.per_loop"),
-			},
-			Transaction: TransactionSettings{
-				TTL: v.GetInt("settings.transaction.ttl"),
-			},
-		},
-		AutoEnumerate: autoEnum,
-		Context:       ctx,
-	}
-
-	err = p.Validate()
-	if err != nil {
-		return nil, err
-	}
-	return p, nil
-}
-
-// setDefaults sets default configuration values for a Viper instance.
-func setDefaults(v *viper.Viper) {
-	// the "name", "version" and "network" fields are required, so they should
-	// not have any default values.
-
-	v.SetDefault("debug", false)
-
-	// settings
-	v.SetDefault("settings.loop_delay", 0)
-	v.SetDefault("settings.read.buffer_size", 100)
-	v.SetDefault("settings.write.buffer_size", 100)
-	v.SetDefault("settings.write.per_loop", 5)
-	v.SetDefault("settings.transaction.ttl", 60*5) // five minutes
-
-	// auto-enumerate
-	v.SetDefault("auto_enumerate", []map[string]interface{}{})
-
-	// context
-	v.SetDefault("context", map[string]interface{}{})
+	return parseVersionedPluginConfig(v)
 }
 
 // setLookupInfo sets the config name, environment prefix, and search

--- a/sdk/config/v1.0-device.go
+++ b/sdk/config/v1.0-device.go
@@ -1,0 +1,81 @@
+package config
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v2"
+)
+
+// V1 Device Prototype
+// -------------------
+
+type v1protoConfig struct {
+	Version    string            `yaml:"version"`
+	Prototypes []PrototypeConfig `yaml:"prototypes"`
+}
+
+// V1 Device Instance
+// ------------------
+
+type v1deviceConfig struct {
+	Version   string              `yaml:"version"`
+	Locations map[string]Location `yaml:"locations"`
+	Devices   []v1device          `yaml:"devices"`
+}
+
+type v1device struct {
+	Type      string              `yaml:"type"`
+	Model     string              `yaml:"model"`
+	Instances []map[string]string `yaml:"instances"`
+}
+
+// V1 Device Config Handler
+// ------------------------
+
+type v1DeviceConfigHandler struct{}
+
+func (h *v1DeviceConfigHandler) processPrototypeConfig(yml []byte) ([]*PrototypeConfig, error) {
+	var cfgs []*PrototypeConfig
+	var scheme v1protoConfig
+
+	err := yaml.Unmarshal(yml, &scheme)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, p := range scheme.Prototypes {
+		p.Version = scheme.Version
+		cfgs = append(cfgs, &p)
+	}
+	return cfgs, nil
+}
+
+func (h *v1DeviceConfigHandler) processDeviceConfig(yml []byte) ([]*DeviceConfig, error) {
+	var cfgs []*DeviceConfig
+	var scheme v1deviceConfig
+
+	err := yaml.Unmarshal(yml, &scheme)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, device := range scheme.Devices {
+		for _, i := range device.Instances {
+			locationTag := i["location"]
+			if locationTag == "" {
+				return nil, fmt.Errorf("no location defined for device: %#v", device)
+			}
+			location := scheme.Locations[locationTag]
+
+			cfg := DeviceConfig{
+				Version:  scheme.Version,
+				Type:     device.Type,
+				Model:    device.Model,
+				Location: location,
+				Data:     i,
+			}
+			cfgs = append(cfgs, &cfg)
+		}
+	}
+	return cfgs, nil
+}

--- a/sdk/config/v1.0-plugin.go
+++ b/sdk/config/v1.0-plugin.go
@@ -1,0 +1,80 @@
+package config
+
+import (
+	"github.com/spf13/viper"
+)
+
+type v1PluginConfigHandler struct{}
+
+func (h *v1PluginConfigHandler) processPluginConfig(v *viper.Viper) (*PluginConfig, error) {
+
+	// Set any default values for the v1 configuration
+	setV1Defaults(v)
+
+	// Cast the "auto_enumerate" field
+	autoEnum, err := toSliceStringMapI(v.Get("auto_enumerate"))
+	if err != nil {
+		return nil, err
+	}
+
+	// Cast the "context" field
+	ctx, err := toStringMapI(v.Get("context"))
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a new PluginConfig instance
+	p := &PluginConfig{
+		Name:    v.GetString("name"),
+		Version: v.GetString("version"),
+		Debug:   v.GetBool("debug"),
+		Network: NetworkSettings{
+			Type:    v.GetString("network.type"),
+			Address: v.GetString("network.address"),
+		},
+		Settings: Settings{
+			LoopDelay: v.GetInt("settings.loop_delay"),
+			Read: ReadSettings{
+				BufferSize: v.GetInt("settings.read.buffer_size"),
+			},
+			Write: WriteSettings{
+				BufferSize: v.GetInt("settings.write.buffer_size"),
+				PerLoop:    v.GetInt("settings.write.per_loop"),
+			},
+			Transaction: TransactionSettings{
+				TTL: v.GetInt("settings.transaction.ttl"),
+			},
+		},
+		AutoEnumerate: autoEnum,
+		Context:       ctx,
+	}
+
+	// Validate that the PluginConfig has all of its required fields
+	// populated.
+	err = p.Validate()
+	if err != nil {
+		return nil, err
+	}
+	return p, nil
+}
+
+// setV1Defaults sets default v1 configuration values for a Viper instance.
+func setV1Defaults(v *viper.Viper) {
+	// the "name", "version" and "network" fields are required, so they should
+	// not have any default values.
+
+	v.SetDefault("debug", false)
+
+	// settings
+	v.SetDefault("settings.loop_delay", 0)
+	v.SetDefault("settings.read.buffer_size", 100)
+	v.SetDefault("settings.write.buffer_size", 100)
+	v.SetDefault("settings.write.per_loop", 5)
+	v.SetDefault("settings.transaction.ttl", 60*5) // five minutes
+
+	// auto-enumerate
+	v.SetDefault("auto_enumerate", []map[string]interface{}{})
+
+	// context
+	v.SetDefault("context", map[string]interface{}{})
+}

--- a/sdk/config/versioning.go
+++ b/sdk/config/versioning.go
@@ -1,0 +1,217 @@
+package config
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/viper"
+	"gopkg.in/yaml.v2"
+)
+
+// TODO - add in support for deprecated versions. this doesn't need to go
+// in immediately, since we have no versions to deprecate initially.
+
+// Versions
+var (
+	// version "1" or "1.0"
+	v1maj0min = configVersion{Major: 1, Minor: 0}
+)
+
+// Common Configuration Versioning
+// -------------------------------
+
+// configVersion represents the version found in a configuration file.
+type configVersion struct {
+	Major int
+	Minor int
+}
+
+// ToString converts the ConfigVersion to a version string.
+func (v *configVersion) ToString() string {
+	return fmt.Sprintf("%d.%d", v.Major, v.Minor)
+}
+
+// getConfigVersion gets the version of the specified configuration file.
+func getConfigVersion(data []byte) (*configVersion, error) {
+	var version cfgVersion
+	err := yaml.Unmarshal(data, &version)
+	if err != nil {
+		return nil, err
+	}
+	v, err := version.toConfigVersion()
+	if err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+// isSupportedVersion checks whether the given ConfigVersion is in the slice
+// of supported versions.
+func isSupportedVersion(cfg *configVersion, supported []configVersion) bool {
+	isSupported := false
+	for _, version := range supported {
+		if *cfg == version {
+			isSupported = true
+			break
+		}
+	}
+	return isSupported
+}
+
+// cfgVersion is an intermediary struct used to pull out the version
+// information from a configuration file.
+type cfgVersion struct {
+	Version string `yaml:"version"`
+}
+
+// toConfigVersion converts the cfgVersion struct into a corresponding
+// configVersion representation.
+func (v *cfgVersion) toConfigVersion() (*configVersion, error) {
+	var min, maj int
+	var err error
+
+	s := strings.Split(v.Version, ".")
+	if len(s) == 0 {
+		return nil, fmt.Errorf("no version info found in config file")
+	}
+
+	if len(s) == 1 {
+		maj, err = strconv.Atoi(s[0])
+		if err != nil {
+			return nil, err
+		}
+		min = 0
+	} else {
+		maj, err = strconv.Atoi(s[0])
+		if err != nil {
+			return nil, err
+		}
+		min, err = strconv.Atoi(s[1])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &configVersion{
+		Major: maj,
+		Minor: min,
+	}, nil
+}
+
+// Device Configuration Versioning
+// -------------------------------
+
+// deviceConfigVersionHandler defines an interface that all versions of the
+// configuration will need to implement, which specifies how to parse the
+// configuration for that given version.
+type deviceConfigVersionHandler interface {
+	processPrototypeConfig([]byte) ([]*PrototypeConfig, error)
+	processDeviceConfig([]byte) ([]*DeviceConfig, error)
+}
+
+// deviceConfigHandler defines which device config versions are supported as
+// well as the config handlers for each of those supported versions.
+var deviceConfigHandlers = map[configVersion]deviceConfigVersionHandler{
+	// versions: "1", "1.0"
+	v1maj0min: &v1DeviceConfigHandler{},
+}
+
+// supportedDeviceConfigVersions defines the collection of versions which the
+// current version of the SDK supports for device instance/prototype configuration
+// files.
+var supportedDeviceConfigVersions = func() []configVersion {
+	s := make([]configVersion, len(deviceConfigHandlers))
+	i := 0
+	for k := range deviceConfigHandlers {
+		s[i] = k
+		i++
+	}
+	return s
+}()
+
+// getDeviceConfigVersionHandler gets the handler for the given device
+// configuration version.
+func getDeviceConfigVersionHandler(cv *configVersion) (deviceConfigVersionHandler, error) {
+	if !isSupportedVersion(cv, supportedDeviceConfigVersions) {
+		return nil, fmt.Errorf("config version '%s' not supported", cv.ToString())
+	}
+	h := deviceConfigHandlers[*cv]
+	if h == nil {
+		return nil, fmt.Errorf("no handler defined for config version '%s'", cv.ToString())
+	}
+	return h, nil
+}
+
+// Plugin Configuration Versioning
+// -------------------------------
+
+// pluginConfigVersionHandler defines an interface that all versions of the
+// configuration will need to implement, which specifies how to parse the
+// configuration for that given version.
+type pluginConfigVersionHandler interface {
+	processPluginConfig(v *viper.Viper) (*PluginConfig, error)
+}
+
+// pluginConfigHandler defines which plugin config versions are supported as
+// well as the config handlers for each of those supported versions.
+var pluginConfigHandlers = map[configVersion]pluginConfigVersionHandler{
+	// versions: "1", "1.0"
+	v1maj0min: &v1PluginConfigHandler{},
+}
+
+// supportedPluginConfigVersions defines the collection of versions which the
+// current version of the SDK supports for plugin configuration files.
+var supportedPluginConfigVersions = func() []configVersion {
+	s := make([]configVersion, len(pluginConfigHandlers))
+	i := 0
+	for k := range pluginConfigHandlers {
+		s[i] = k
+		i++
+	}
+	return s
+}()
+
+// getPluginConfigVersionHandler gets the handler for the given plugin
+// configuration version.
+func getPluginConfigVersionHandler(cv *configVersion) (pluginConfigVersionHandler, error) {
+	if !isSupportedVersion(cv, supportedPluginConfigVersions) {
+		return nil, fmt.Errorf("config version '%s' not supported", cv.ToString())
+	}
+	h := pluginConfigHandlers[*cv]
+	if h == nil {
+		return nil, fmt.Errorf("no handler defined for config version '%s'", cv.ToString())
+	}
+	return h, nil
+}
+
+// parseVersionedPluginConfig takes a Viper instance and reads in the Plugin configuration
+// with it. If successful, it will check the version field in the config and parse the
+// configuration appropriately based on the version number.
+func parseVersionedPluginConfig(v *viper.Viper) (*PluginConfig, error) {
+
+	// Read in the configuration file
+	err := v.ReadInConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the plugin configuration version
+	cv := cfgVersion{v.GetString("version")}
+	version, err := cv.toConfigVersion()
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the handler for the given configuration version.
+	cfgHandler, err := getPluginConfigVersionHandler(version)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse the config with the versioned handler
+	c, err := cfgHandler.processPluginConfig(v)
+	if err != nil {
+		return nil, err
+	}
+	return c, nil
+}

--- a/sdk/plugin.go
+++ b/sdk/plugin.go
@@ -3,6 +3,8 @@ package sdk
 import (
 	"fmt"
 
+	"runtime"
+
 	"github.com/vapor-ware/synse-sdk/sdk/config"
 )
 
@@ -99,15 +101,21 @@ func (p *Plugin) setup() error {
 // logInfo logs out the information about the plugin. This is called just before the
 // plugin begins running all of its components.
 func (p *Plugin) logInfo() {
-	Logger.Info("-- Starting Plugin --")
-	Logger.Infof(" Name:        %v", p.Config.Name)
-	Logger.Infof(" Version:     %v", p.Config.Version)
-	Logger.Infof(" SDK Version: %v", Version)
-	Logger.Info("-- Plugin Config --")
-	Logger.Infof(" %#v", p.Config)
-	Logger.Info("-- Configured Devices --")
+	Logger.Info("Plugin Info:")
+	Logger.Infof(" Name:        %s", p.Config.Name)
+	Logger.Infof(" Version:     %s", VersionString)
+	Logger.Infof(" SDK Version: %s", SDKVersion)
+	Logger.Infof(" Git Commit:  %s", GitCommit)
+	Logger.Infof(" Git Tag:     %s", GitTag)
+	Logger.Infof(" Go Version:  %s", GoVersion)
+	Logger.Infof(" Build Date:  %s", BuildDate)
+	Logger.Infof(" OS:          %s", runtime.GOOS)
+	Logger.Infof(" Arch:        %s", runtime.GOARCH)
+	Logger.Debug("Plugin Config:")
+	Logger.Debugf(" %#v", p.Config)
+	Logger.Info("Registered Devices:")
 	for id, dev := range deviceMap {
 		Logger.Infof(" %v (%v)", id, dev.Model())
 	}
-	Logger.Info("---------------------")
+	Logger.Info("--------------------------------")
 }

--- a/sdk/version.go
+++ b/sdk/version.go
@@ -1,4 +1,14 @@
 package sdk
 
-// Version specifies the version of the Synse Plugin SDK.
-const Version = "0.2.0"
+// SDKVersion specifies the version of the Synse Plugin SDK.
+const SDKVersion = "0.2.0"
+
+// Variables for specifying the plugin version. These should be set
+// at run time.
+var (
+	BuildDate     = "-"
+	GitCommit     = "-"
+	GitTag        = "-"
+	GoVersion     = "-"
+	VersionString = "-"
+)


### PR DESCRIPTION
This PR adds support for configuration versioning for both device configurations (prototype & instance) as well as plugin configurations. it also changes how plugin versions are specified.

**Motivation**
- the SDK is likely to change in the future to add/drop support of things as the plugins evolve. having versioned configs will make it easier to support different versions of the SDK.

**Changes**
- configuration files should have a `version` field in them - this is the version of the config file.
- configuration versions are checked against a set of supported versions. 
- configuration validation/parsing has been moved around to files/structs that are labeled with the appropriate version info
- previously, the plugin config had a "version" field which specified the plugin version (not the config version). now that the version field specifies the config version, the plugin version is specified differently -- it is defined in the Makefile and added to the plugin binary at build time.

**TODO** 
- version deprecation. on the back burner since we only have one version and nothing is deprecated yet.
- tests. these are coming in the next batch of PRs as this PR is the last big change to config that was planned, so things should be stable and tests can be written.