### PR TITLE
fix configuration issue in ci config preventing tag runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,10 @@ jobs:
             cd examples/multi_device_plugin ; go build -v ; cd ../..
             cd examples/c_plugin ; go build -v ; cd ../..
             cd examples/auto_enumerate ; go build -v ; cd ../..
+      - run:
+          name: Build CLI
+          command: |
+            cd client ; go build -o pcli ; cd ..
       - save_cache:
           when: on_success
           key: vendor-{{ checksum "Gopkg.toml" }}-{{ checksum "Gopkg.lock" }}


### PR DESCRIPTION
lets see if this works. 

according to https://discuss.circleci.com/t/builds-for-tags-not-triggering/17681/5 jobs configured for tag pushes need to either have its dependencies also be filtered in the same way, or to not have filters.
