### PR TITLE
update how build time version variables are set for plugins

### DIFF
--- a/examples/auto_enumerate/Makefile
+++ b/examples/auto_enumerate/Makefile
@@ -1,6 +1,6 @@
 PLUGIN_VERSION=1.0
 
-PKG_CTX=github.com/vapor-ware/synse-sdk/sdk
+PKG_CTX=main
 BUILD_DATE := $(shell date -u +%Y-%m-%dT%T 2> /dev/null)
 GIT_COMMIT := $(shell git rev-parse --short HEAD 2> /dev/null || true)
 GIT_TAG := $(shell git describe --tags 2> /dev/null || true)

--- a/examples/auto_enumerate/plugin.go
+++ b/examples/auto_enumerate/plugin.go
@@ -13,6 +13,15 @@ import (
 	"github.com/vapor-ware/synse-sdk/sdk/config"
 )
 
+// Build time variables for setting the version info of a Plugin.
+var (
+	BuildDate     string
+	GitCommit     string
+	GitTag        string
+	GoVersion     string
+	VersionString string
+)
+
 // ExamplePluginHandler is a plugin-specific handler required by the
 // SDK. It defines the plugin's read and write functionality.
 type ExamplePluginHandler struct{}
@@ -110,6 +119,15 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	// Set build-time version info
+	plugin.SetVersion(sdk.VersionInfo{
+		BuildDate:     BuildDate,
+		GitCommit:     GitCommit,
+		GitTag:        GitTag,
+		GoVersion:     GoVersion,
+		VersionString: VersionString,
+	})
 
 	// Register the Plugin devices.
 	err = plugin.RegisterDevices()

--- a/examples/c_plugin/Makefile
+++ b/examples/c_plugin/Makefile
@@ -1,6 +1,6 @@
 PLUGIN_VERSION=1.0
 
-PKG_CTX=github.com/vapor-ware/synse-sdk/sdk
+PKG_CTX=main
 BUILD_DATE := $(shell date -u +%Y-%m-%dT%T 2> /dev/null)
 GIT_COMMIT := $(shell git rev-parse --short HEAD 2> /dev/null || true)
 GIT_TAG := $(shell git describe --tags 2> /dev/null || true)

--- a/examples/c_plugin/plugin.go
+++ b/examples/c_plugin/plugin.go
@@ -11,6 +11,15 @@ import (
 	"github.com/vapor-ware/synse-sdk/sdk/config"
 )
 
+// Build time variables for setting the version info of a Plugin.
+var (
+	BuildDate     string
+	GitCommit     string
+	GitTag        string
+	GoVersion     string
+	VersionString string
+)
+
 // ExamplePluginHandler is a plugin-specific handler required by the
 // SDK. It defines the plugin's read and write functionality.
 type ExamplePluginHandler struct{}
@@ -72,6 +81,15 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	// Set build-time version info
+	plugin.SetVersion(sdk.VersionInfo{
+		BuildDate:     BuildDate,
+		GitCommit:     GitCommit,
+		GitTag:        GitTag,
+		GoVersion:     GoVersion,
+		VersionString: VersionString,
+	})
 
 	// Register the Plugin devices.
 	err = plugin.RegisterDevices()

--- a/examples/multi_device_plugin/Makefile
+++ b/examples/multi_device_plugin/Makefile
@@ -1,6 +1,6 @@
 PLUGIN_VERSION=1.0
 
-PKG_CTX=github.com/vapor-ware/synse-sdk/sdk
+PKG_CTX=main
 BUILD_DATE := $(shell date -u +%Y-%m-%dT%T 2> /dev/null)
 GIT_COMMIT := $(shell git rev-parse --short HEAD 2> /dev/null || true)
 GIT_TAG := $(shell git describe --tags 2> /dev/null || true)

--- a/examples/multi_device_plugin/plugin.go
+++ b/examples/multi_device_plugin/plugin.go
@@ -10,6 +10,15 @@ import (
 	"github.com/vapor-ware/synse-sdk/sdk/config"
 )
 
+// Build time variables for setting the version info of a Plugin.
+var (
+	BuildDate     string
+	GitCommit     string
+	GitTag        string
+	GoVersion     string
+	VersionString string
+)
+
 // lookup is a simple lookup table that maps the known device models
 // that are supported by this plugin to the handler for that model.
 //
@@ -81,6 +90,15 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	// Set build-time version info
+	plugin.SetVersion(sdk.VersionInfo{
+		BuildDate:     BuildDate,
+		GitCommit:     GitCommit,
+		GitTag:        GitTag,
+		GoVersion:     GoVersion,
+		VersionString: VersionString,
+	})
 
 	// Register the Plugin devices.
 	err = plugin.RegisterDevices()

--- a/examples/simple_plugin/Makefile
+++ b/examples/simple_plugin/Makefile
@@ -1,6 +1,6 @@
 PLUGIN_VERSION=1.0
 
-PKG_CTX=github.com/vapor-ware/synse-sdk/sdk
+PKG_CTX=main
 BUILD_DATE := $(shell date -u +%Y-%m-%dT%T 2> /dev/null)
 GIT_COMMIT := $(shell git rev-parse --short HEAD 2> /dev/null || true)
 GIT_TAG := $(shell git describe --tags 2> /dev/null || true)

--- a/examples/simple_plugin/plugin.go
+++ b/examples/simple_plugin/plugin.go
@@ -20,6 +20,15 @@ import (
 	"time"
 )
 
+// Build time variables for setting the version info of a Plugin.
+var (
+	BuildDate     string
+	GitCommit     string
+	GitTag        string
+	GoVersion     string
+	VersionString string
+)
+
 // SimplePluginHandler fulfils the SDK's PluginHandler interface. It requires a
 // Read and Write function to be defined, which specify how the plugin will read
 // and write to the configured devices.
@@ -131,6 +140,15 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	// Set build-time version info
+	plugin.SetVersion(sdk.VersionInfo{
+		BuildDate:     BuildDate,
+		GitCommit:     GitCommit,
+		GitTag:        GitTag,
+		GoVersion:     GoVersion,
+		VersionString: VersionString,
+	})
 
 	// Register the Plugin devices - this will read the device
 	// instance and prototype config to determine what it will

--- a/sdk/plugin.go
+++ b/sdk/plugin.go
@@ -16,13 +16,20 @@ type Plugin struct {
 	server   *Server
 	handlers *Handlers
 	dm       *DataManager
+	v        *VersionInfo
 }
 
 // NewPlugin creates a new Plugin instance
 func NewPlugin(handlers *Handlers) *Plugin {
 	p := &Plugin{}
 	p.handlers = handlers
+	p.v = emptyVersionInfo()
 	return p
+}
+
+// SetVersion sets the VersionInfo for the Plugin.
+func (p *Plugin) SetVersion(info VersionInfo) {
+	p.v.Merge(&info)
 }
 
 // SetConfig manually sets the configuration of the Plugin.
@@ -103,12 +110,12 @@ func (p *Plugin) setup() error {
 func (p *Plugin) logInfo() {
 	Logger.Info("Plugin Info:")
 	Logger.Infof(" Name:        %s", p.Config.Name)
-	Logger.Infof(" Version:     %s", VersionString)
+	Logger.Infof(" Version:     %s", p.v.VersionString)
 	Logger.Infof(" SDK Version: %s", SDKVersion)
-	Logger.Infof(" Git Commit:  %s", GitCommit)
-	Logger.Infof(" Git Tag:     %s", GitTag)
-	Logger.Infof(" Go Version:  %s", GoVersion)
-	Logger.Infof(" Build Date:  %s", BuildDate)
+	Logger.Infof(" Git Commit:  %s", p.v.GitCommit)
+	Logger.Infof(" Git Tag:     %s", p.v.GitTag)
+	Logger.Infof(" Go Version:  %s", p.v.GoVersion)
+	Logger.Infof(" Build Date:  %s", p.v.BuildDate)
 	Logger.Infof(" OS:          %s", runtime.GOOS)
 	Logger.Infof(" Arch:        %s", runtime.GOARCH)
 	Logger.Debug("Plugin Config:")

--- a/sdk/version.go
+++ b/sdk/version.go
@@ -3,12 +3,44 @@ package sdk
 // SDKVersion specifies the version of the Synse Plugin SDK.
 const SDKVersion = "0.3.0"
 
-// Variables for specifying the plugin version. These should be set
-// at run time.
-var (
-	BuildDate     = "-"
-	GitCommit     = "-"
-	GitTag        = "-"
-	GoVersion     = "-"
-	VersionString = "-"
-)
+// VersionInfo contains the versioning information for a Plugin.
+type VersionInfo struct {
+	BuildDate     string
+	GitCommit     string
+	GitTag        string
+	GoVersion     string
+	VersionString string
+}
+
+// Merge merges the values in the given VersionInfo into this one.
+// This is useful for merging a VersionConfig with the VersionConfig
+// holding the default "empty" values.
+func (v *VersionInfo) Merge(info *VersionInfo) {
+	if info.BuildDate != "" {
+		v.BuildDate = info.BuildDate
+	}
+	if info.GitCommit != "" {
+		v.GitCommit = info.GitCommit
+	}
+	if info.GitTag != "" {
+		v.GitTag = info.GitTag
+	}
+	if info.GoVersion != "" {
+		v.GoVersion = info.GoVersion
+	}
+	if info.VersionString != "" {
+		v.VersionString = info.VersionString
+	}
+}
+
+// emptyVersionInfo gets a new VersionInfo instance filled with its
+// default empty values.
+func emptyVersionInfo() *VersionInfo {
+	return &VersionInfo{
+		BuildDate:     "-",
+		GitCommit:     "-",
+		GitTag:        "-",
+		GoVersion:     "-",
+		VersionString: "-",
+	}
+}

--- a/sdk/version_test.go
+++ b/sdk/version_test.go
@@ -1,0 +1,91 @@
+package sdk
+
+import (
+	"testing"
+)
+
+func TestEmptyVersionInfo(t *testing.T) {
+	v := emptyVersionInfo()
+	if v.VersionString != "-" {
+		t.Errorf("VersionInfo.VersionString should be '-'")
+	}
+	if v.GoVersion != "-" {
+		t.Errorf("VersionInfo.GoVersion should be '-'")
+	}
+	if v.GitTag != "-" {
+		t.Errorf("VersionInfo.GitTag should be '-'")
+	}
+	if v.GitCommit != "-" {
+		t.Errorf("VersionInfo.GitCommit should be '-'")
+	}
+	if v.BuildDate != "-" {
+		t.Errorf("VersionInfo.BuildDate should be '-'")
+	}
+}
+
+func TestVersionInfo_Merge(t *testing.T) {
+	v1 := VersionInfo{}
+	v2 := VersionInfo{
+		VersionString: "1",
+		GitCommit:     "abc",
+	}
+
+	expected := VersionInfo{
+		VersionString: "1",
+		GitCommit:     "abc",
+	}
+
+	v1.Merge(&v2)
+	if v1 != expected {
+		t.Errorf("VersionInfo.Merge(%#v) => %#v, want %#v", v2, v1, expected)
+	}
+}
+
+func TestVersionInfo_Merge2(t *testing.T) {
+	v1 := emptyVersionInfo()
+	v2 := VersionInfo{
+		VersionString: "1",
+		GitCommit:     "abc",
+	}
+
+	expected := VersionInfo{
+		VersionString: "1",
+		GitCommit:     "abc",
+		GitTag:        "-",
+		BuildDate:     "-",
+		GoVersion:     "-",
+	}
+
+	v1.Merge(&v2)
+	if *v1 != expected {
+		t.Errorf("VersionInfo.Merge(%#v) => %#v, want %#v", v2, *v1, expected)
+	}
+}
+
+func TestVersionInfo_Merge3(t *testing.T) {
+	v1 := VersionInfo{
+		VersionString: "1",
+		GitCommit:     "abc",
+		GitTag:        "1.1",
+		BuildDate:     "1-2-3",
+		GoVersion:     "1.8",
+	}
+	v2 := VersionInfo{
+		VersionString: "2",
+		GitCommit:     "def",
+		GitTag:        "1.2",
+	}
+
+	expected := VersionInfo{
+		VersionString: "2",
+		GitCommit:     "def",
+		GitTag:        "1.2",
+		BuildDate:     "1-2-3",
+		GoVersion:     "1.8",
+	}
+
+	v1.Merge(&v2)
+	if v1 != expected {
+		t.Errorf("VersionInfo.Merge(%#v) => %#v, want %#v", v2, v1, expected)
+	}
+}


### PR DESCRIPTION
update how version info is set so plugins that use the SDK can actually set the build-time version info. now the variables reside at the plugin level instead of the SDK level.


fixes #66