### PR TITLE
add step to release job to auto generate changelog.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,6 @@ jobs:
               -draft \
               ${CIRCLE_TAG} /tmp/bin/
 
-
 workflows:
   version: 2
   build:


### PR DESCRIPTION
here goes nothing -- update config to autogen a changelog for new releases. based on the work in ksync. 

will need to push a new tag to see if this works properly. will do that in a bit, as I have some changes in the SDK that will need to be released with a micro version rev bump.

fixes #64