### PR TITLE
add environment variable for root config dir

### DIFF
--- a/sdk/config/device.go
+++ b/sdk/config/device.go
@@ -12,12 +12,6 @@ const (
 	defaultDeviceConfig = "/etc/synse/plugin/config/device"
 )
 
-const (
-	// EnvDevicePath is the environment variable that can be used to
-	// specify a non-default directory for device configs.
-	EnvDevicePath = "PLUGIN_DEVICE_PATH"
-)
-
 // DeviceConfig represents a single device instance.
 type DeviceConfig struct {
 	Version  string
@@ -46,9 +40,14 @@ func (l *Location) Encode() *synse.MetaLocation {
 func ParseDeviceConfig() ([]*DeviceConfig, error) {
 	var cfgs []*DeviceConfig
 
-	path := os.Getenv(EnvDevicePath)
-	if path == "" {
-		path = defaultDeviceConfig
+	path := os.Getenv(EnvDeviceConfig)
+	if path != "" {
+		path = filepath.Join(path, "device")
+	} else {
+		path = os.Getenv(EnvDevicePath)
+		if path == "" {
+			path = defaultDeviceConfig
+		}
 	}
 
 	_, err := os.Stat(path)

--- a/sdk/config/device_test.go
+++ b/sdk/config/device_test.go
@@ -240,3 +240,81 @@ devices:
 		t.Errorf("expected 1 device configuration, but got %v", len(res))
 	}
 }
+
+// process unsuccessfully using env for root config dir
+func TestParseDeviceConfig8(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "test")
+	if err != nil {
+		t.Error(err)
+	}
+	defer os.RemoveAll(tmpdir)
+
+	os.Setenv(EnvDeviceConfig, tmpdir)
+	defer os.Unsetenv(EnvDeviceConfig)
+
+	data := `version: 1.0
+locations:
+  r1b1:
+    rack: rack-1
+    board: board-1
+devices:
+  - type: airflow
+    model: air8884
+    instances:
+      - id: 1
+        location: r1b1
+        comment: first emulated airflow device`
+
+	tmpf := filepath.Join(tmpdir, "tmpfile.yml")
+	err = ioutil.WriteFile(tmpf, []byte(data), 0666)
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, err = ParseDeviceConfig()
+	if err == nil {
+		t.Error("expected error: PLUGIN_DEVICE_CONFIG path does not contain 'device' subdir")
+	}
+}
+
+// process successfully using env for root config dir
+func TestParseDeviceConfig9(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "test")
+	if err != nil {
+		t.Error(err)
+	}
+	defer os.RemoveAll(tmpdir)
+
+	os.Setenv(EnvDeviceConfig, tmpdir)
+	defer os.Unsetenv(EnvDeviceConfig)
+
+	deviceDir := filepath.Join(tmpdir, "device")
+	os.Mkdir(deviceDir, 0700)
+
+	data := `version: 1.0
+locations:
+  r1b1:
+    rack: rack-1
+    board: board-1
+devices:
+  - type: airflow
+    model: air8884
+    instances:
+      - id: 1
+        location: r1b1
+        comment: first emulated airflow device`
+
+	tmpf := filepath.Join(deviceDir, "tmpfile.yml")
+	err = ioutil.WriteFile(tmpf, []byte(data), 0666)
+	if err != nil {
+		t.Error(err)
+	}
+
+	res, err := ParseDeviceConfig()
+	if err != nil {
+		t.Error(err)
+	}
+	if len(res) != 1 {
+		t.Errorf("expected 1 device configuration, but got %v", len(res))
+	}
+}

--- a/sdk/config/env.go
+++ b/sdk/config/env.go
@@ -1,0 +1,27 @@
+package config
+
+const (
+	// EnvDevicePath is the environment variable that can be used to
+	// specify a non-default directory for device configs. If the
+	// prototype config and device config directories are contained
+	// within the same base directory, you can use the
+	// PLUGIN_DEVICE_CONFIG environment variable instead.
+	EnvDevicePath = "PLUGIN_DEVICE_PATH"
+
+	// EnvProtoPath is the environment variable that can be used to
+	// specify a non-default directory for protocol configs. If the
+	// prototype config and device config directories are contained
+	// within the same base directory, you can use the
+	// PLUGIN_DEVICE_CONFIG environment variable instead.
+	EnvProtoPath = "PLUGIN_PROTO_PATH"
+
+	// EnvDeviceConfig is the environment variable that can be used to
+	// specify the directory which holds both a "proto" and "device"
+	// subdirectory (corresponding to the PLUGIN_PROTO_PATH and
+	// PLUGIN_DEVICE_PATH, respectively).
+	EnvDeviceConfig = "PLUGIN_DEVICE_CONFIG"
+
+	// EnvPluginConfig is the environment variable that can be used to
+	// specify the config directory for any non-default location.
+	EnvPluginConfig = "PLUGIN_CONFIG"
+)

--- a/sdk/config/plugin.go
+++ b/sdk/config/plugin.go
@@ -12,12 +12,6 @@ const (
 	homeConfigPath    = "$HOME/.synse/plugin"
 )
 
-const (
-	// EnvPluginConfig is the environment variable that can be used to
-	// specify the config directory for any non-default location.
-	EnvPluginConfig = "PLUGIN_CONFIG"
-)
-
 // PluginConfig specifies the configuration options for the plugin.
 type PluginConfig struct {
 	Name          string

--- a/sdk/config/proto.go
+++ b/sdk/config/proto.go
@@ -12,12 +12,6 @@ const (
 	defaultProtoConfig = "/etc/synse/plugin/config/proto"
 )
 
-const (
-	// EnvProtoPath is the environment variable that can be used to
-	// specify a non-default directory for protocol configs.
-	EnvProtoPath = "PLUGIN_PROTO_PATH"
-)
-
 // PrototypeConfig represents the configuration for a device prototype.
 type PrototypeConfig struct {
 	Version      string
@@ -91,9 +85,14 @@ func (r *Range) Encode() *synse.MetaOutputRange {
 func ParsePrototypeConfig() ([]*PrototypeConfig, error) {
 	var cfgs []*PrototypeConfig
 
-	path := os.Getenv(EnvProtoPath)
-	if path == "" {
-		path = defaultProtoConfig
+	path := os.Getenv(EnvDeviceConfig)
+	if path != "" {
+		path = filepath.Join(path, "proto")
+	} else {
+		path = os.Getenv(EnvProtoPath)
+		if path == "" {
+			path = defaultProtoConfig
+		}
 	}
 
 	_, err := os.Stat(path)

--- a/sdk/config/proto_test.go
+++ b/sdk/config/proto_test.go
@@ -361,3 +361,89 @@ prototypes:
 		t.Errorf("expected 1 prototype configuration, but got %v", len(res))
 	}
 }
+
+// process unsuccessfully using env for root config dir
+func TestParseProtoConfig8(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "test")
+	if err != nil {
+		t.Error(err)
+	}
+	defer os.RemoveAll(tmpdir)
+
+	os.Setenv(EnvDeviceConfig, tmpdir)
+	defer os.Unsetenv(EnvDeviceConfig)
+
+	data := `version: 1.0
+prototypes:
+  - type: airflow
+    model: air8884
+    manufacturer: vaporio
+    protocol: emulator
+    output:
+      - type: airflow
+        data_type: float
+        unit:
+          name: cubic feet per minute
+          symbol: CFM
+        precision: 2
+        range:
+          min: 0
+          max: 1000`
+
+	tmpf := filepath.Join(tmpdir, "tmpfile.yml")
+	err = ioutil.WriteFile(tmpf, []byte(data), 0666)
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, err = ParsePrototypeConfig()
+	if err == nil {
+		t.Error("expected error: PLUGIN_DEVICE_CONFIG path does not contain 'proto' subdir")
+	}
+}
+
+// process successfully using env for root config dir
+func TestParseProtoConfig9(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "test")
+	if err != nil {
+		t.Error(err)
+	}
+	defer os.RemoveAll(tmpdir)
+
+	os.Setenv(EnvDeviceConfig, tmpdir)
+	defer os.Unsetenv(EnvDeviceConfig)
+
+	protoDir := filepath.Join(tmpdir, "proto")
+	os.Mkdir(protoDir, 0700)
+
+	data := `version: 1.0
+prototypes:
+  - type: airflow
+    model: air8884
+    manufacturer: vaporio
+    protocol: emulator
+    output:
+      - type: airflow
+        data_type: float
+        unit:
+          name: cubic feet per minute
+          symbol: CFM
+        precision: 2
+        range:
+          min: 0
+          max: 1000`
+
+	tmpf := filepath.Join(protoDir, "tmpfile.yml")
+	err = ioutil.WriteFile(tmpf, []byte(data), 0666)
+	if err != nil {
+		t.Error(err)
+	}
+
+	res, err := ParsePrototypeConfig()
+	if err != nil {
+		t.Error(err)
+	}
+	if len(res) != 1 {
+		t.Errorf("expected 1 prototype configuration, but got %v", len(res))
+	}
+}


### PR DESCRIPTION
adds an environment variable that allows you to set a directory that is the root for the `device` and `proto` configuration directories. 

moves ENV constants to their own file

adds tests.

fixes #65 