### PR TITLE
bumping version to 0.3.1 since thats the version we're at now. 

### DIFF
--- a/sdk/version.go
+++ b/sdk/version.go
@@ -1,7 +1,7 @@
 package sdk
 
 // SDKVersion specifies the version of the Synse Plugin SDK.
-const SDKVersion = "0.3.0"
+const SDKVersion = "0.3.1"
 
 // VersionInfo contains the versioning information for a Plugin.
 type VersionInfo struct {


### PR DESCRIPTION
will need to re-tag at 0.3.1 after this gets merged in. 

should probably also set up some kind of process that validates the version has been bumped to the correct rev.. will open a separate issue for this.