### PR TITLE
Updating client to specify board/rack in gRPC requests.

### DIFF
--- a/client/cli.go
+++ b/client/cli.go
@@ -55,7 +55,7 @@ func check(err error) {
 var readCmd = &cobra.Command{
 	Use:   "read",
 	Short: "Issue a gRPC Read request",
-    Long:  "Issue a gRPC Read request, example: ./pcli --sock PLUGIN read DEVICE_ID BOARD RACK",
+	Long:  "Issue a gRPC Read request, example: ./pcli --sock PLUGIN read DEVICE_ID BOARD RACK",
 	Args:  cobra.ExactArgs(3),
 	Run: func(cmd *cobra.Command, args []string) {
 		read(cmd, args)


### PR DESCRIPTION
A couple of months ago the `ReadRequest` and `WriteRequest` RPC messages were updated to require the board/rack to read/write to/from, in [this](https://github.com/vapor-ware/synse-server-grpc/commit/86792b8bb22fbed31596652f6a06d8007f81785d) commit.

This updates to client to work with the current RPC spec.