### PR TITLE
Added `go dep` commands to the #development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 [![CircleCI](https://circleci.com/gh/vapor-ware/synse-sdk.svg?style=svg&circle-token=a35e96598e3df84da3dc58a4f0f9dcc8632bfbd3)](https://circleci.com/gh/vapor-ware/synse-sdk)
 
 # Synse Plugin SDK for Go
-An SDK in the Go programming language for creating plugins for Vapor IO's 
+An SDK in the Go programming language for creating plugins for Vapor IO's
 [Synse Server][synse-server].
 
 This SDK handles most of the common functionality needed for Synse Server plugins,
 such as configuration parsing, background reading, asynchronous writing, generation
 and tracking of transaction ids, handling metainfo, etc.
 
-In most cases, a plugin author will only need to write the plugin-specific read and 
+In most cases, a plugin author will only need to write the plugin-specific read and
 write functionality as well as plugin-specific configuration parsing.
 
 
@@ -32,8 +32,21 @@ TODO: link to documentation
 
 ## Development
 
+### Dependencies
+[`go dep`](https://github.com/golang/dep) is used for dependency management. After cloning the repo, you can install `dep` with:
+
+```shell
+go get -u github.com/golang/dep/cmd/dep
+```
+
+To download the dependencies (or update them in the future) you can run:
+
+```shell
+dep ensure -v --vendor-only
+```
+
 ### Testing
-Tests for the Synse Plugin SDK are run in CI, the status of which is shown by the 
+Tests for the Synse Plugin SDK are run in CI, the status of which is shown by the
 badge at the top of this README. Tests can be run locally with:
 
 ```
@@ -48,7 +61,7 @@ make test
 
 ### Linting
 Linting is performed as a step in CI. A failure to lint should cause a CI build failure.
-The SDK source can also be linted locally using `golint`. To get `golint`, 
+The SDK source can also be linted locally using `golint`. To get `golint`,
 ```
 go get -u github.com/golang/lint/golint
 ```
@@ -69,6 +82,6 @@ make lint
 This SDK is licensed under the ____. See LICENSE.txt and NOTICE.txt for more information.
 
 
- 
+
 [synse-server]: https://github.com/vapor-ware/synse-server
 [examples]: https://github.com/vapor-ware/synse-sdk/tree/master/examples


### PR DESCRIPTION
People will need to get dependencies in order to start running tests or compiling. Just adding this so they know.

Automated cleanup of some weird hanging chads, I mean whitespaces.