### PR TITLE
bump to version 0.3.2 for pending tag/release

### DIFF
--- a/sdk/version.go
+++ b/sdk/version.go
@@ -1,7 +1,7 @@
 package sdk
 
 // SDKVersion specifies the version of the Synse Plugin SDK.
-const SDKVersion = "0.3.1"
+const SDKVersion = "0.3.2"
 
 // VersionInfo contains the versioning information for a Plugin.
 type VersionInfo struct {


### PR DESCRIPTION
time to cut a new release since there have been a bunch of changes/bug fixes