### PR TITLE
Better logging for config files.

### DIFF
--- a/sdk/config/v1.0-device.go
+++ b/sdk/config/v1.0-device.go
@@ -57,10 +57,9 @@ func (h *v1DeviceConfigHandler) processPrototypeConfig(yml []byte) ([]*Prototype
 
 // This function parses out the devices from the device configuration in the yaml file.
 func (h *v1DeviceConfigHandler) processDeviceConfig(yml []byte) ([]*DeviceConfig, error) {
-	// TODO: Fix these traces. Get something.
-	logger.Debugf("processDeviceConfig start. yml: %+v", yml)
-	logger.Debugf("processDeviceConfig start. yml: %+v", string(yml[:])) // had \n for newlines.
-	logger.Debugf("processDeviceConfig start. yml: %v", string(yml[:]))
+	// Logging the yml so that we can debug this with the log.
+	logger.InfoMultiline(string(yml[:]))
+
 	var cfgs []*DeviceConfig
 	var scheme v1deviceConfig
 

--- a/sdk/logger/logger.go
+++ b/sdk/logger/logger.go
@@ -1,6 +1,8 @@
 package logger
 
 import (
+	"strings"
+
 	"github.com/Sirupsen/logrus"
 )
 
@@ -72,4 +74,16 @@ func Debug(args ...interface{}) {
 // Debugf is a wrapper around logger.Debugf.
 func Debugf(format string, args ...interface{}) {
 	logger.Debugf(format, args...)
+}
+
+// InfoMultiline logs a multi-line string at the debug level.
+// logrus emits a newline as a literal \n which isn't always desirable.
+// This function is useful for logging configuration files so that we can:
+// - Spot a syntax error.
+// - Determine the configuration from a log file.
+func InfoMultiline(toLog string) {
+	lines := strings.Split(toLog, "\n")
+	for line := 0; line < len(lines); line++ {
+		logger.Infof("Line %04d: %v", line, lines[line])
+	}
 }


### PR DESCRIPTION
This commit logs the yaml config files in a better way. It's not perfect, but a step in the right direction.

We want this for the following reasons:
- If we can get the logs for an issue, the config is in the log. The issue may be the config itself.
- I'm pretty convinced there are some error handing issues (bugs) in this area. That's fine. This will help us diagnose and fix them.
- This is cloud, and we can't effectively use a debugger and set breakpoints and such. We need logs. If they're too chatty we can always filter them or remove log statements at a future date.

```
vapor@vec1-c1-austin:~$ kubectl logs synse-65775c7958-ptv2x i2c-plugin
time="2018-02-09T03:28:00Z" level=debug msg="devicesFromConfig start"
time="2018-02-09T03:28:00Z" level=debug msg="ParseDeviceConfig start"
time="2018-02-09T03:28:00Z" level=debug msg="ParseDeviceConfig 2"
time="2018-02-09T03:28:00Z" level=debug msg="ParseDeviceConfig 3. path: /plugin/config/device"
time="2018-02-09T03:28:00Z" level=debug msg="ParseDeviceConfig 4. files: [0xc82012b5f0 0xc82012b520 0xc82012b450]"
time="2018-02-09T03:28:00Z" level=debug msg="ParseDeviceConfig 5"
time="2018-02-09T03:28:00Z" level=debug msg="ParseDeviceConfig 5"
time="2018-02-09T03:28:00Z" level=debug msg="ParseDeviceConfig 5"
time="2018-02-09T03:28:00Z" level=debug msg="ParseDeviceConfig reading file /plugin/config/device/devices.yml"
time="2018-02-09T03:28:00Z" level=debug msg="ParseDeviceConfig 6"
time="2018-02-09T03:28:00Z" level=debug msg="ParseDeviceConfig 7"
time="2018-02-09T03:28:00Z" level=debug msg="ParseDeviceConfig 8"
time="2018-02-09T03:28:00Z" level=info msg="Line 0000: # One entry for each I2C device on the synse instance on a VEC on a chamber wedge."
time="2018-02-09T03:28:00Z" level=info msg="Line 0001: version: 1.0"
time="2018-02-09T03:28:00Z" level=info msg="Line 0002: locations:"
time="2018-02-09T03:28:00Z" level=info msg="Line 0003:   r1vec:"
time="2018-02-09T03:28:00Z" level=info msg="Line 0004:     rack: rack-1"
time="2018-02-09T03:28:00Z" level=info msg="Line 0005:     board: vec"
time="2018-02-09T03:28:00Z" level=info msg="Line 0006: devices:"
time="2018-02-09T03:28:00Z" level=info msg="Line 0007:   - type: led"
time="2018-02-09T03:28:00Z" level=info msg="Line 0008:     model: PCA9632"
time="2018-02-09T03:28:00Z" level=info msg="Line 0009:     instances:"
time="2018-02-09T03:28:00Z" level=info msg="Line 0010:       # LED controller on each wedge."
time="2018-02-09T03:28:00Z" level=info msg="Line 0011:       - channel: \"0014\""
time="2018-02-09T03:28:00Z" level=info msg="Line 0012:         location: r1vec"
time="2018-02-09T03:28:00Z" level=info msg="Line 0013:         info: Chamber LED"
time="2018-02-09T03:28:00Z" level=info msg="Line 0014:   - type: temperature"
time="2018-02-09T03:28:00Z" level=info msg="Line 0015:     model: MAX11610"
time="2018-02-09T03:28:00Z" level=info msg="Line 0016:     instances:"
time="2018-02-09T03:28:00Z" level=info msg="Line 0017:       # Thermistors on each wedge."
time="2018-02-09T03:28:00Z" level=info msg="Line 0018:       - channel: \"0000\""
time="2018-02-09T03:28:00Z" level=info msg="Line 0019:         location: r1vec"
time="2018-02-09T03:28:00Z" level=info msg="Line 0020:         info: Rack Temperature 0 Top Left"
time="2018-02-09T03:28:00Z" level=info msg="Line 0021:       - channel: \"0001\""
time="2018-02-09T03:28:00Z" level=info msg="Line 0022:         location: r1vec"
time="2018-02-09T03:28:00Z" level=info msg="Line 0023:         info: Rack Temperature 1 Middle Left"
time="2018-02-09T03:28:00Z" level=info msg="Line 0024:       - channel: \"0002\""
time="2018-02-09T03:28:00Z" level=info msg="Line 0025:         location: r1vec"
time="2018-02-09T03:28:00Z" level=info msg="Line 0026:         info: Rack Temperature 2 Bottom Left"
time="2018-02-09T03:28:00Z" level=info msg="Line 0027:       # Likely failing startup due to no thermistor plugged in."
time="2018-02-09T03:28:00Z" level=info msg="Line 0028:       - channel: \"0003\""
time="2018-02-09T03:28:00Z" level=info msg="Line 0029:         location: r1vec"
time="2018-02-09T03:28:00Z" level=info msg="Line 0030:         info: Rack Temperature 3 Spare"
time="2018-02-09T03:28:00Z" level=info msg="Line 0031:       - channel: \"0004\""
time="2018-02-09T03:28:00Z" level=info msg="Line 0032:         location: r1vec"
time="2018-02-09T03:28:00Z" level=info msg="Line 0033:         info: Rack Temperature 4 Top Rear"
time="2018-02-09T03:28:00Z" level=info msg="Line 0034:       - channel: \"0005\""
time="2018-02-09T03:28:00Z" level=info msg="Line 0035:         location: r1vec"
time="2018-02-09T03:28:00Z" level=info msg="Line 0036:         info: Rack Temperature 5 Middle Rear"
time="2018-02-09T03:28:00Z" level=info msg="Line 0037:       - channel: \"0006\""
time="2018-02-09T03:28:00Z" level=info msg="Line 0038:         location: r1vec"
time="2018-02-09T03:28:00Z" level=info msg="Line 0039:         info: Rack Temperature 6 Bottom Rear"
time="2018-02-09T03:28:00Z" level=info msg="Line 0040:       - channel: \"0007\""
time="2018-02-09T03:28:00Z" level=info msg="Line 0041:         location: r1vec"
time="2018-02-09T03:28:00Z" level=info msg="Line 0042:         info: Rack Temperature 7 Spare"
time="2018-02-09T03:28:00Z" level=info msg="Line 0043:       - channel: \"0008\""
time="2018-02-09T03:28:00Z" level=info msg="Line 0044:         location: r1vec"
time="2018-02-09T03:28:00Z" level=info msg="Line 0045:         info: Rack Temperature 8 Top Right"
time="2018-02-09T03:28:00Z" level=info msg="Line 0046:       - channel: \"0009\""
time="2018-02-09T03:28:00Z" level=info msg="Line 0047:         location: r1vec"
time="2018-02-09T03:28:00Z" level=info msg="Line 0048:         info: Rack Temperature 9 Middle Right"
time="2018-02-09T03:28:00Z" level=info msg="Line 0049:       - channel: \"000a\""
time="2018-02-09T03:28:00Z" level=info msg="Line 0050:         location: r1vec"
time="2018-02-09T03:28:00Z" level=info msg="Line 0051:         info: Rack Temperature 10 Bottom Right"
time="2018-02-09T03:28:00Z" level=info msg="Line 0052:       - channel: \"000b\""
time="2018-02-09T03:28:00Z" level=info msg="Line 0053:         location: r1vec"
time="2018-02-09T03:28:00Z" level=info msg="Line 0054:         info: Rack Temperature 11 Spare"
time="2018-02-09T03:28:00Z" level=info msg="Line 0055:   #- type: pressure"
time="2018-02-09T03:28:00Z" level=info msg="Line 0056:   - type: differential_pressure"
time="2018-02-09T03:28:00Z" level=info msg="Line 0057:     model: SDP610"
time="2018-02-09T03:28:00Z" level=info msg="Line 0058:     instances:"
time="2018-02-09T03:28:00Z" level=info msg="Line 0059:       # Differential pressure sensors on each wedge."
time="2018-02-09T03:28:00Z" level=info msg="Line 0060:       - channel: \"0001\""
time="2018-02-09T03:28:00Z" level=info msg="Line 0061:         location: r1vec"
time="2018-02-09T03:28:00Z" level=info msg="Line 0062:         info: Rack Differential Pressure Bottom"
time="2018-02-09T03:28:00Z" level=info msg="Line 0063:       - channel: \"0002\""
time="2018-02-09T03:28:00Z" level=info msg="Line 0064:         location: r1vec"
time="2018-02-09T03:28:00Z" level=info msg="Line 0065:         info: Rack Differential Pressure Middle"
time="2018-02-09T03:28:00Z" level=info msg="Line 0066:       - channel: \"0004\""
time="2018-02-09T03:28:00Z" level=info msg="Line 0067:         location: r1vec"
time="2018-02-09T03:28:00Z" level=info msg="Line 0068:         info: Rack Differential Pressure Top"
time="2018-02-09T03:28:00Z" level=info msg="Line 0069: "
```