### PR TITLE
allow 'from_env' as a field for rack location configuration

### DIFF
--- a/examples/auto_enumerate/plugin.go
+++ b/examples/auto_enumerate/plugin.go
@@ -61,6 +61,16 @@ func EnumerateDevices(cfg map[string]interface{}) ([]*config.DeviceConfig, error
 	for i := 0; i < 3; i++ {
 		devAddr := fmt.Sprintf("%v-%v", baseAddr, i)
 
+		// validate the location
+		location := config.Location{
+			Rack:  "rack-1",
+			Board: "board-1",
+		}
+		err := location.Validate()
+		if err != nil {
+			return nil, err
+		}
+
 		// create a new device - here, we are using the base address and appending
 		// index of the loop to create the id of the device. we are hardcoding in
 		// the type and model as temperature and temp2010, respectively, because
@@ -69,13 +79,10 @@ func EnumerateDevices(cfg map[string]interface{}) ([]*config.DeviceConfig, error
 		// should be gathered from whatever the real source of auto-enumeration is,
 		// e.g. for IPMI - the SDR records.
 		d := config.DeviceConfig{
-			Version: "1.0",
-			Type:    "temperature",
-			Model:   "temp2010",
-			Location: config.Location{
-				Rack:  "rack-1",
-				Board: "board-1",
-			},
+			Version:  "1.0",
+			Type:     "temperature",
+			Model:    "temp2010",
+			Location: location,
 			// we want to have "id" in the map because our `GetProtocolIdentifiers"
 			// uses the "id" field here to create the internal device uid.
 			Data: map[string]string{

--- a/sdk/config/v1.0-device.go
+++ b/sdk/config/v1.0-device.go
@@ -76,6 +76,10 @@ func (h *v1DeviceConfigHandler) processDeviceConfig(yml []byte) ([]*DeviceConfig
 				return nil, fmt.Errorf("no location defined for device: %#v", device)
 			}
 			location := scheme.Locations[locationTag]
+			err := location.Validate()
+			if err != nil {
+				return nil, err
+			}
 
 			cfg := DeviceConfig{
 				Version:  scheme.Version,

--- a/sdk/devices.go
+++ b/sdk/devices.go
@@ -88,10 +88,15 @@ func (d *Device) Read() (*ReadContext, error) {
 		if err != nil {
 			return nil, err
 		}
+
+		rack, err := d.Location.GetRack()
+		if err != nil {
+			return nil, err
+		}
 		return &ReadContext{
 			Device:  d.ID(),
 			Board:   d.Location.Board,
-			Rack:    d.Location.Rack,
+			Rack:    rack,
 			Reading: readings,
 		}, nil
 
@@ -133,7 +138,8 @@ func (d *Device) ID() string {
 // GUID generates a globally unique ID string by creating a composite
 // string from the rack, board, and device UID.
 func (d *Device) GUID() string {
-	return makeIDString(d.Location.Rack, d.Location.Board, d.ID())
+	rack, _ := d.Location.GetRack()
+	return makeIDString(rack, d.Location.Board, d.ID())
 }
 
 // encode translates the Device to a corresponding gRPC MetainfoResponse.

--- a/sdk/sdktest.go
+++ b/sdk/sdktest.go
@@ -38,15 +38,17 @@ var testDeviceHandler = DeviceHandler{
 // == Utility Functions ==
 
 func makeDeviceConfig() *config.DeviceConfig {
+	location := config.Location{
+		Rack:  "TestRack",
+		Board: "TestBoard",
+	}
+	location.Validate()
 	return &config.DeviceConfig{
-		Version: "1.0",
-		Type:    "TestDevice",
-		Model:   "TestModel",
-		Location: config.Location{
-			Rack:  "TestRack",
-			Board: "TestBoard",
-		},
-		Data: map[string]string{"testKey": "testValue"},
+		Version:  "1.0",
+		Type:     "TestDevice",
+		Model:    "TestModel",
+		Location: location,
+		Data:     map[string]string{"testKey": "testValue"},
 	}
 }
 


### PR DESCRIPTION
fixes #139 

This adds support so that `from_env` can be specified under rack configuration, e.g.
```
locations:
  here:
    board: vec
    rack:
      from_env: HOSTNAME
```

I don't think this addition is particularly great, especially how the error handling/validation stuff works.. just feels kinda messy. The config wasn't really designed for interface field values, so I guess that kinda makes sense. May need to rethink/rework config stuff to work better w/ interfaces. I don't think it changes much on the core configuration stuff, just how/when its validated.

relates to the work for https://github.com/vapor-ware/vec-testbed/pull/176