### PR TITLE
add better logging around config file names

### DIFF
--- a/sdk/config/device.go
+++ b/sdk/config/device.go
@@ -127,7 +127,11 @@ func ParseDeviceConfig() ([]*DeviceConfig, error) {
 		return nil, err
 	}
 
-	logger.Debugf("Found configuration files: %v", files)
+	fnames := make([]string, len(files))
+	for i, file := range files {
+		fnames[i] = file.Name()
+	}
+	logger.Debugf("Found device configuration files: %v", fnames)
 	for _, f := range files {
 		if isValidConfig(f) {
 			fpath := filepath.Join(path, f.Name())
@@ -146,7 +150,7 @@ func ParseDeviceConfig() ([]*DeviceConfig, error) {
 				logger.Errorf("Failed to get configuration version for file %s: %v", fpath, err)
 				return nil, err
 			}
-			logger.Debugf("Got device configuration file version: %s", ver)
+			logger.Debugf("Got device configuration file version: %s", ver.ToString())
 
 			// Get the handler for the given configuration version
 			cfgHandler, err := getDeviceConfigVersionHandler(ver)

--- a/sdk/config/proto.go
+++ b/sdk/config/proto.go
@@ -110,7 +110,11 @@ func ParsePrototypeConfig() ([]*PrototypeConfig, error) {
 		return nil, err
 	}
 
-	logger.Debugf("Found configuration files: %v", files)
+	fnames := make([]string, len(files))
+	for i, file := range files {
+		fnames[i] = file.Name()
+	}
+	logger.Debugf("Found prototype configuration files: %v", fnames)
 	for _, f := range files {
 		if isValidConfig(f) {
 			fpath := filepath.Join(path, f.Name())
@@ -129,7 +133,7 @@ func ParsePrototypeConfig() ([]*PrototypeConfig, error) {
 				logger.Errorf("Failed to get configuration version for file %s: %v", fpath, err)
 				return nil, err
 			}
-			logger.Debugf("Got prototype configuration file version: %s", ver)
+			logger.Debugf("Got prototype configuration file version: %s", ver.ToString())
 
 			// Get the handler for the given configuration version
 			cfgHandler, err := getDeviceConfigVersionHandler(ver)


### PR DESCRIPTION
fixes #156

Now, we get a list of the actual file names being parsed:
```
DEBU[0000] Searching ./config/device for device configurations. 
DEBU[0000] Found device configuration files: [airflow.yaml temperature.yaml voltage.yaml] 
DEBU[0000] Reading file: config/device/airflow.yaml     
DEBU[0000] Got device configuration file version: 1.0   
```