### PR TITLE
add and update more tests

### DIFF
--- a/sdk/config/plugin_test.go
+++ b/sdk/config/plugin_test.go
@@ -2,124 +2,224 @@ package config
 
 import (
 	"testing"
+	"time"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
 )
 
-var pluginConfigValidateTestList = []PluginConfig{
-	{
-		Name:    "test",
-		Version: "1",
-		Network: NetworkSettings{
-			Type:    "test",
-			Address: "test",
-		},
-		Settings: Settings{
-			Transaction: TransactionSettings{
-				TTL: "300s",
-			},
-		},
-	},
-	{
-		Name:    "1",
-		Version: "2",
-		Network: NetworkSettings{
-			Type:    "3",
-			Address: "4",
-		},
-		Settings: Settings{
-			Transaction: TransactionSettings{
-				TTL: "20m",
-			},
-		},
-	},
+// TestSettings_IsParallel tests checking whether a Settings instance
+// is configured for parallel mode.
+func TestSettings_IsParallel(t *testing.T) {
+	s := Settings{}
+
+	s.Mode = "serial"
+	assert.False(t, s.IsParallel())
+
+	s.Mode = "parallel"
+	assert.True(t, s.IsParallel())
 }
 
+// TestSettings_IsSerial tests checking whether a Settings instance
+// is configured for serial mode.
+func TestSettings_IsSerial(t *testing.T) {
+	s := Settings{}
+
+	s.Mode = "serial"
+	assert.True(t, s.IsSerial())
+
+	s.Mode = "parallel"
+	assert.False(t, s.IsSerial())
+}
+
+// TestReadSettings_GetInterval tests getting the read interval setting
+// successfully.
+func TestReadSettings_GetInterval(t *testing.T) {
+	s := ReadSettings{}
+	s.Interval = "10s"
+
+	interval, err := s.GetInterval()
+	assert.NoError(t, err)
+	assert.Equal(t, time.Duration(10)*time.Second, interval)
+}
+
+// TestReadSettings_GetIntervalErr tests getting the read interval setting
+// unsuccessfully.
+func TestReadSettings_GetIntervalErr(t *testing.T) {
+	s := ReadSettings{}
+	s.Interval = "abc"
+
+	interval, err := s.GetInterval()
+	assert.Equal(t, time.Duration(0), interval)
+	assert.Error(t, err)
+}
+
+// TestWriteSettings_GetInterval tests getting the write interval setting
+// successfully.
+func TestWriteSettings_GetInterval(t *testing.T) {
+	s := WriteSettings{}
+	s.Interval = "10s"
+
+	interval, err := s.GetInterval()
+	assert.NoError(t, err)
+	assert.Equal(t, time.Duration(10)*time.Second, interval)
+}
+
+// TestWriteSettings_GetIntervalErr tests getting the write interval setting
+// unsuccessfully.
+func TestWriteSettings_GetIntervalErr(t *testing.T) {
+	s := WriteSettings{}
+	s.Interval = "abc"
+
+	interval, err := s.GetInterval()
+	assert.Equal(t, time.Duration(0), interval)
+	assert.Error(t, err)
+}
+
+// TestNewPluginConfigErr tests creating a new plugin config that should result
+// in an error because no plugin configuration file can be found.
+func TestNewPluginConfigErr(t *testing.T) {
+	config, err := NewPluginConfig()
+	assert.Error(t, err)
+	assert.Nil(t, config)
+}
+
+// TestPluginConfig_Validate tests validating the PluginConfig successfully.
 func TestPluginConfig_Validate(t *testing.T) {
-	for _, ti := range pluginConfigValidateTestList {
-		err := ti.Validate()
-		if err != nil {
-			t.Errorf("PluginConfig.Validate() expected no error but got %v", err)
-		}
+	var cases = []PluginConfig{
+		{
+			Name:    "test",
+			Version: "1",
+			Network: NetworkSettings{
+				Type:    "test",
+				Address: "test",
+			},
+			Settings: Settings{
+				Transaction: TransactionSettings{
+					TTL: "300s",
+				},
+			},
+		},
+		{
+			Name:    "1",
+			Version: "2",
+			Network: NetworkSettings{
+				Type:    "3",
+				Address: "4",
+			},
+			Settings: Settings{
+				Transaction: TransactionSettings{
+					TTL: "20m",
+				},
+			},
+		},
+		{
+			Name:    "test",
+			Version: "1",
+			Network: NetworkSettings{
+				Type:    "test",
+				Address: "test",
+			},
+			Settings: Settings{
+				Transaction: TransactionSettings{
+					TTL: "0s",
+				},
+			},
+		},
+	}
+
+	for _, testCase := range cases {
+		err := testCase.Validate()
+		assert.NoError(t, err)
 	}
 }
 
-var pluginConfigValidateErrorsTestList = []PluginConfig{
-	{
-		Version: "1",
-		Network: NetworkSettings{
-			Type:    "test",
-			Address: "test",
-		},
-		Settings: Settings{
-			Transaction: TransactionSettings{
-				TTL: "2s",
+// TestPluginConfig_ValidateErr tests validating the PluginConfig unsuccessfully.
+func TestPluginConfig_ValidateErr(t *testing.T) {
+	var cases = []PluginConfig{
+		{
+			Version: "1",
+			Network: NetworkSettings{
+				Type:    "test",
+				Address: "test",
+			},
+			Settings: Settings{
+				Transaction: TransactionSettings{
+					TTL: "2s",
+				},
 			},
 		},
-	},
-	{
-		Name: "test",
-		Network: NetworkSettings{
-			Type:    "test",
-			Address: "test",
-		},
-		Settings: Settings{
-			Transaction: TransactionSettings{
-				TTL: "2s",
+		{
+			Name: "test",
+			Network: NetworkSettings{
+				Type:    "test",
+				Address: "test",
+			},
+			Settings: Settings{
+				Transaction: TransactionSettings{
+					TTL: "2s",
+				},
 			},
 		},
-	},
-	{
-		Name:    "test",
-		Version: "1",
-		Settings: Settings{
-			Transaction: TransactionSettings{
-				TTL: "2s",
+		{
+			Name:    "test",
+			Version: "1",
+			Settings: Settings{
+				Transaction: TransactionSettings{
+					TTL: "2s",
+				},
 			},
 		},
-	},
-	{
-		Name:    "test",
-		Version: "1",
-		Network: NetworkSettings{
-			Address: "test",
-		},
-		Settings: Settings{
-			Transaction: TransactionSettings{
-				TTL: "2s",
+		{
+			Name:    "test",
+			Version: "1",
+			Network: NetworkSettings{
+				Address: "test",
+			},
+			Settings: Settings{
+				Transaction: TransactionSettings{
+					TTL: "2s",
+				},
 			},
 		},
-	},
-	{
-		Name:    "test",
-		Version: "1",
-		Network: NetworkSettings{
-			Type: "test",
-		},
-		Settings: Settings{
-			Transaction: TransactionSettings{
-				TTL: "2s",
+		{
+			Name:    "test",
+			Version: "1",
+			Network: NetworkSettings{
+				Type: "test",
+			},
+			Settings: Settings{
+				Transaction: TransactionSettings{
+					TTL: "2s",
+				},
 			},
 		},
-	},
-	{
-		Name:    "1",
-		Version: "2",
-		Network: NetworkSettings{
-			Type:    "3",
-			Address: "4",
-		},
-		Settings: Settings{
-			Transaction: TransactionSettings{
-				TTL: "not-a-duration",
+		{
+			Name:    "1",
+			Version: "2",
+			Network: NetworkSettings{
+				Type:    "3",
+				Address: "4",
+			},
+			Settings: Settings{
+				Transaction: TransactionSettings{
+					TTL: "not-a-duration",
+				},
 			},
 		},
-	},
+	}
+
+	for _, testCase := range cases {
+		err := testCase.Validate()
+		assert.Error(t, err)
+	}
 }
 
-func TestPluginConfig_Validate2(t *testing.T) {
-	for _, ti := range pluginConfigValidateErrorsTestList {
-		err := ti.Validate()
-		if err == nil {
-			t.Error("PluginConfig.Validate() expected error but got nil.")
-		}
-	}
+// TestSetupLookupInfo tests setting up the lookup info for a Viper instance
+// for the plugin configuration. setLookupInfo does not return anything, and
+// the values it sets on the Viper instance are not exported, so we just make
+// sure nothing goes wrong here.
+func TestSetLookupInfo(t *testing.T) {
+	v := viper.New()
+	setLookupInfo(v)
 }

--- a/sdk/config/proto_test.go
+++ b/sdk/config/proto_test.go
@@ -6,221 +6,206 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/vapor-ware/synse-server-grpc/go"
 )
 
-var deviceOutputEncodeTestTable = []struct {
-	in  DeviceOutput
-	out synse.MetaOutput
-}{
-	{
-		in: DeviceOutput{},
-		out: synse.MetaOutput{
-			Unit:  &synse.MetaOutputUnit{},
-			Range: &synse.MetaOutputRange{},
-		},
-	},
-	{
-		in: DeviceOutput{
-			Type: "test",
-		},
-		out: synse.MetaOutput{
-			Type:  "test",
-			Unit:  &synse.MetaOutputUnit{},
-			Range: &synse.MetaOutputRange{},
-		},
-	},
-	{
-		in: DeviceOutput{
-			Type:      "test",
-			DataType:  "test",
-			Precision: 10,
-		},
-		out: synse.MetaOutput{
-			Type:      "test",
-			DataType:  "test",
-			Precision: 10,
-			Unit:      &synse.MetaOutputUnit{},
-			Range:     &synse.MetaOutputRange{},
-		},
-	},
-	{
-		in: DeviceOutput{
-			Type:      "test",
-			DataType:  "test",
-			Precision: 10,
-			Unit: &Unit{
-				Name:   "test",
-				Symbol: "t",
-			},
-			Range: &Range{
-				Min: 10,
-				Max: 100,
-			},
-		},
-		out: synse.MetaOutput{
-			Type:      "test",
-			DataType:  "test",
-			Precision: 10,
-			Unit: &synse.MetaOutputUnit{
-				Name:   "test",
-				Symbol: "t",
-			},
-			Range: &synse.MetaOutputRange{
-				Min: 10,
-				Max: 100,
-			},
-		},
-	},
-}
-
+// TestDeviceOutput_Encode tests encoding an SDK DeviceOutput to
+// the gRPC MetaOutput model.
 func TestDeviceOutput_Encode(t *testing.T) {
-	for i, tc := range deviceOutputEncodeTestTable {
+	var cases = []struct {
+		in  DeviceOutput
+		out synse.MetaOutput
+	}{
+		{
+			in: DeviceOutput{},
+			out: synse.MetaOutput{
+				Unit:  &synse.MetaOutputUnit{},
+				Range: &synse.MetaOutputRange{},
+			},
+		},
+		{
+			in: DeviceOutput{
+				Type: "test",
+			},
+			out: synse.MetaOutput{
+				Type:  "test",
+				Unit:  &synse.MetaOutputUnit{},
+				Range: &synse.MetaOutputRange{},
+			},
+		},
+		{
+			in: DeviceOutput{
+				Type:      "test",
+				DataType:  "test",
+				Precision: 10,
+			},
+			out: synse.MetaOutput{
+				Type:      "test",
+				DataType:  "test",
+				Precision: 10,
+				Unit:      &synse.MetaOutputUnit{},
+				Range:     &synse.MetaOutputRange{},
+			},
+		},
+		{
+			in: DeviceOutput{
+				Type:      "test",
+				DataType:  "test",
+				Precision: 10,
+				Unit: &Unit{
+					Name:   "test",
+					Symbol: "t",
+				},
+				Range: &Range{
+					Min: 10,
+					Max: 100,
+				},
+			},
+			out: synse.MetaOutput{
+				Type:      "test",
+				DataType:  "test",
+				Precision: 10,
+				Unit: &synse.MetaOutputUnit{
+					Name:   "test",
+					Symbol: "t",
+				},
+				Range: &synse.MetaOutputRange{
+					Min: 10,
+					Max: 100,
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
 		r := tc.in.Encode()
-		if r.Type != tc.out.Type {
-			t.Errorf("(%d) %v.Encode => %v, want %v", i, tc.in, r, tc.out)
-		}
-		if r.DataType != tc.out.DataType {
-			t.Errorf("(%d) %v.Encode => %v, want %v", i, tc.in, r, tc.out)
-		}
-		if r.Precision != tc.out.Precision {
-			t.Errorf("(%d) %v.Encode => %v, want %v", i, tc.in, r, tc.out)
-		}
-		if *r.Unit != *tc.out.Unit {
-			t.Errorf("(%d) %v.Encode => %v, want %v", i, tc.in, r, tc.out)
-		}
-		if *r.Range != *tc.out.Range {
-			t.Errorf("(%d) %v.Encode => %v, want %v", i, tc.in, r, tc.out)
-		}
+
+		assert.Equal(t, tc.out.Type, r.Type)
+		assert.Equal(t, tc.out.DataType, r.DataType)
+		assert.Equal(t, tc.out.Precision, r.Precision)
+		assert.Equal(t, *tc.out.Unit, *r.Unit)
+		assert.Equal(t, *tc.out.Range, *r.Range)
 	}
 }
 
-var unitEncodeTestTable = []struct {
-	in  Unit
-	out synse.MetaOutputUnit
-}{
-	{
-		in:  Unit{},
-		out: synse.MetaOutputUnit{},
-	},
-	{
-		in: Unit{
-			Name: "test",
-		},
-		out: synse.MetaOutputUnit{
-			Name: "test",
-		},
-	},
-	{
-		in: Unit{
-			Name:   "test",
-			Symbol: "t",
-		},
-		out: synse.MetaOutputUnit{
-			Name:   "test",
-			Symbol: "t",
-		},
-	},
-}
-
+// TestUnit_Encode tests encoding the SDK Unit to the gRPC
+// MetaOutputUnit model.
 func TestUnit_Encode(t *testing.T) {
-	for _, tc := range unitEncodeTestTable {
+	var cases = []struct {
+		in  Unit
+		out synse.MetaOutputUnit
+	}{
+		{
+			in:  Unit{},
+			out: synse.MetaOutputUnit{},
+		},
+		{
+			in: Unit{
+				Name: "test",
+			},
+			out: synse.MetaOutputUnit{
+				Name: "test",
+			},
+		},
+		{
+			in: Unit{
+				Name:   "test",
+				Symbol: "t",
+			},
+			out: synse.MetaOutputUnit{
+				Name:   "test",
+				Symbol: "t",
+			},
+		},
+	}
+
+	for _, tc := range cases {
 		r := tc.in.Encode()
-		if *r != tc.out {
-			t.Errorf("%v.Encode() => %v, want %v", tc.in, r, tc.out)
-		}
+		assert.Equal(t, tc.out, *r)
 	}
 }
 
-var rangeEncodeTestTable = []struct {
-	in  Range
-	out synse.MetaOutputRange
-}{
-	{
-		in:  Range{},
-		out: synse.MetaOutputRange{},
-	},
-	{
-		in: Range{
-			Min: 10,
-		},
-		out: synse.MetaOutputRange{
-			Min: 10,
-		},
-	},
-	{
-		in: Range{
-			Min: 10,
-			Max: 100,
-		},
-		out: synse.MetaOutputRange{
-			Min: 10,
-			Max: 100,
-		},
-	},
-}
-
+// TestRange_Encode tests encoding the SDK Range to the gRPC
+// MetaOutputRange model.
 func TestRange_Encode(t *testing.T) {
-	for _, tc := range rangeEncodeTestTable {
+	var cases = []struct {
+		in  Range
+		out synse.MetaOutputRange
+	}{
+		{
+			in:  Range{},
+			out: synse.MetaOutputRange{},
+		},
+		{
+			in: Range{
+				Min: 10,
+			},
+			out: synse.MetaOutputRange{
+				Min: 10,
+			},
+		},
+		{
+			in: Range{
+				Min: 10,
+				Max: 100,
+			},
+			out: synse.MetaOutputRange{
+				Min: 10,
+				Max: 100,
+			},
+		},
+	}
+
+	for _, tc := range cases {
 		r := tc.in.Encode()
-		if *r != tc.out {
-			t.Errorf("%v.Encode() => %v, want %v", tc.in, r, tc.out)
-		}
+		assert.Equal(t, tc.out, *r)
 	}
 }
 
-// config file doesn't exist
+// TestParseProtoConfig tests parsing prototype config when a prototype config
+// file doesn't exist.
 func TestParseProtoConfig(t *testing.T) {
 	// the default directory path shouldn't exist when running tests
 	_, err := ParsePrototypeConfig()
-	if err == nil {
-		t.Error("expected error: config directory should not exist")
-	}
+	assert.Error(t, err)
 }
 
-// config directory is not a directory
+// TestParseProtoConfig2 tests parsing prototype config when the prototype config
+// directory is not a directory.
 func TestParseProtoConfig2(t *testing.T) {
 	tmpfile, err := ioutil.TempFile("", "test")
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err)
 	defer os.Remove(tmpfile.Name())
 
 	os.Setenv(EnvProtoPath, tmpfile.Name())
 	defer os.Unsetenv(EnvProtoPath)
 
 	_, err = ParsePrototypeConfig()
-	if err == nil {
-		t.Error("expected error: config directory should not be a directory")
-	}
+	assert.Error(t, err)
 }
 
-// no valid configs in directory
+// TestParseProtoConfig3 tests parsing prototype config when no valid configs
+// are in the prototype config directory.
 func TestParseProtoConfig3(t *testing.T) {
 	tmpdir, err := ioutil.TempDir("", "test")
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
 	os.Setenv(EnvProtoPath, tmpdir)
 	defer os.Unsetenv(EnvProtoPath)
 
 	res, err := ParsePrototypeConfig()
-	if err != nil {
-		t.Error(err)
-	}
-	if len(res) > 0 {
-		t.Errorf("expected 0 results, but got %v instead", len(res))
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(res))
 }
 
-// no config version specified
+// TestParseProtoConfig4 tests parsing prototype config when no config version
+// is specified in the prototype config.
 func TestParseProtoConfig4(t *testing.T) {
 	tmpdir, err := ioutil.TempDir("", "test")
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
 	os.Setenv(EnvProtoPath, tmpdir)
@@ -244,22 +229,17 @@ func TestParseProtoConfig4(t *testing.T) {
 
 	tmpf := filepath.Join(tmpdir, "tmpfile.yml")
 	err = ioutil.WriteFile(tmpf, []byte(data), 0666)
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err)
 
 	_, err = ParsePrototypeConfig()
-	if err == nil {
-		t.Error("expected error: configuration version not set")
-	}
+	assert.Error(t, err)
 }
 
-// no handler for the specified config version
+// TestParseProtoConfig5 tests parsing prototype config when no handler for the
+// specified config version is defined.
 func TestParseProtoConfig5(t *testing.T) {
 	tmpdir, err := ioutil.TempDir("", "test")
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
 	os.Setenv(EnvProtoPath, tmpdir)
@@ -284,22 +264,17 @@ prototypes:
 
 	tmpf := filepath.Join(tmpdir, "tmpfile.yml")
 	err = ioutil.WriteFile(tmpf, []byte(data), 0666)
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err)
 
 	_, err = ParsePrototypeConfig()
-	if err == nil {
-		t.Error("expected error: no handler for the given version")
-	}
+	assert.Error(t, err)
 }
 
-// unable to process the config via handler
+// TestParseProtoConfig6 tests parsing prototype config when unable to process
+// the config via handler.
 func TestParseProtoConfig6(t *testing.T) {
 	tmpdir, err := ioutil.TempDir("", "test")
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
 	os.Setenv(EnvProtoPath, tmpdir)
@@ -309,22 +284,16 @@ func TestParseProtoConfig6(t *testing.T) {
 
 	tmpf := filepath.Join(tmpdir, "tmpfile.yml")
 	err = ioutil.WriteFile(tmpf, []byte(data), 0666)
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err)
 
 	_, err = ParsePrototypeConfig()
-	if err == nil {
-		t.Error("expected error: invalid config for given version")
-	}
+	assert.Error(t, err)
 }
 
-// process everything successfully
+// TestParseProtoConfig7 tests parsing the prototype configuration successfully.
 func TestParseProtoConfig7(t *testing.T) {
 	tmpdir, err := ioutil.TempDir("", "test")
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
 	os.Setenv(EnvProtoPath, tmpdir)
@@ -349,25 +318,18 @@ prototypes:
 
 	tmpf := filepath.Join(tmpdir, "tmpfile.yml")
 	err = ioutil.WriteFile(tmpf, []byte(data), 0666)
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err)
 
 	res, err := ParsePrototypeConfig()
-	if err != nil {
-		t.Error(err)
-	}
-	if len(res) != 1 {
-		t.Errorf("expected 1 prototype configuration, but got %v", len(res))
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(res))
 }
 
-// process unsuccessfully using env for root config dir
+// TestParseProtoConfig8 tests parsing prototype configs unsuccessfully using
+// an environment variable to specify the root config directory.
 func TestParseProtoConfig8(t *testing.T) {
 	tmpdir, err := ioutil.TempDir("", "test")
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
 	os.Setenv(EnvDeviceConfig, tmpdir)
@@ -392,9 +354,7 @@ prototypes:
 
 	tmpf := filepath.Join(tmpdir, "tmpfile.yml")
 	err = ioutil.WriteFile(tmpf, []byte(data), 0666)
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err)
 
 	_, err = ParsePrototypeConfig()
 	if err == nil {
@@ -402,12 +362,11 @@ prototypes:
 	}
 }
 
-// process successfully using env for root config dir
+// TestParseProtoConfig9 tests parsing the prototype config successfully using
+// an environment variable to specify the root config directory.
 func TestParseProtoConfig9(t *testing.T) {
 	tmpdir, err := ioutil.TempDir("", "test")
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
 	os.Setenv(EnvDeviceConfig, tmpdir)
@@ -435,15 +394,9 @@ prototypes:
 
 	tmpf := filepath.Join(protoDir, "tmpfile.yml")
 	err = ioutil.WriteFile(tmpf, []byte(data), 0666)
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err)
 
 	res, err := ParsePrototypeConfig()
-	if err != nil {
-		t.Error(err)
-	}
-	if len(res) != 1 {
-		t.Errorf("expected 1 prototype configuration, but got %v", len(res))
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(res))
 }

--- a/sdk/config/utils_test.go
+++ b/sdk/config/utils_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type testFileInfo struct {
@@ -23,67 +25,69 @@ func (f testFileInfo) Name() string       { return f.name }
 func (f testFileInfo) Size() int64        { return f.size }
 func (f testFileInfo) Sys() interface{}   { return f.sys }
 
+// TestToStringMapI tests converting a map[interface{}]interface{} to
+// a string map.
 func TestToStringMapI(t *testing.T) {
 	i := map[interface{}]interface{}{
 		"test": "value",
 	}
 
 	_, err := toStringMapI(i)
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err)
 }
 
+// TestToStringMapI2 tests converting a map[string]interface{} to
+// a string map.
 func TestToStringMapI2(t *testing.T) {
 	i := map[string]interface{}{
 		"test": "value",
 	}
 
 	_, err := toStringMapI(i)
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err)
 }
 
+// TestToStringMapI3 tests converting a string to a string map -
+// this should not be possible so we expect this to fail.
 func TestToStringMapI3(t *testing.T) {
 	i := "test"
 
 	_, err := toStringMapI(i)
-	if err == nil {
-		t.Error("expected error, but got nil instead")
-	}
+	assert.Error(t, err)
 }
 
+// TestToSliceStringMapI tests converting a []map[interface{}]interface{} to
+// a slice string map.
 func TestToSliceStringMapI(t *testing.T) {
 	i := []interface{}{}
 	i = append(i, map[interface{}]interface{}{"test": "value"})
 
 	_, err := toSliceStringMapI(i)
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err)
 }
 
+// TestToSliceStringMapI2 tests converting a []map[string]interface{} to
+// a slice string map.
 func TestToSliceStringMapI2(t *testing.T) {
 	i := []map[string]interface{}{
 		{"test": "value"},
 	}
 
 	_, err := toSliceStringMapI(i)
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err)
 }
 
+// TestToSliceStringMapI3 tests converting a string to a slice string map -
+// this should not be possible so we expect this to fail.
 func TestToSliceStringMapI3(t *testing.T) {
 	i := "test"
 
 	_, err := toSliceStringMapI(i)
-	if err == nil {
-		t.Errorf("expected error, but got nil instead")
-	}
+	assert.Error(t, err)
 }
 
+// TestIsValidConfig tests validating a config file when validation should fail because
+// the file is a directory.
 func TestIsValidConfig(t *testing.T) {
 	fi := testFileInfo{
 		name: "test",
@@ -91,40 +95,36 @@ func TestIsValidConfig(t *testing.T) {
 	}
 
 	isValid := isValidConfig(fi)
-	if isValid {
-		t.Error("expected validation failure: file info is a dir")
-	}
+	assert.False(t, isValid)
 }
 
+// TestIsValidConfig2 tests validating a config file when validation should fail because
+// the given file does not have a supported file extension.
 func TestIsValidConfig2(t *testing.T) {
 	fi := testFileInfo{
 		name: "test.json",
 	}
 
 	isValid := isValidConfig(fi)
-	if isValid {
-		t.Error("expected validation failure: file info is not in supported file exts")
-	}
+	assert.False(t, isValid)
 }
 
+// TestIsValidConfig3 tests validating a config file that should be valid.
 func TestIsValidConfig3(t *testing.T) {
 	fi := testFileInfo{
 		name: "test.yml",
 	}
 
 	isValid := isValidConfig(fi)
-	if !isValid {
-		t.Error("expected config to be valid, but was not")
-	}
+	assert.True(t, isValid)
 }
 
+// TestIsValidConfig4 tests validating a config file that should be valid.
 func TestIsValidConfig4(t *testing.T) {
 	fi := testFileInfo{
 		name: "test.yaml",
 	}
 
 	isValid := isValidConfig(fi)
-	if !isValid {
-		t.Error("expected config to be valid, but was not")
-	}
+	assert.True(t, isValid)
 }

--- a/sdk/config/v1.0-device_test.go
+++ b/sdk/config/v1.0-device_test.go
@@ -2,30 +2,34 @@ package config
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
+// TestV1DeviceConfigHandlerProcessProtoConfig tests unsuccessfully processing
+// v1 prototype config due to invalid YAML.
 func TestV1DeviceConfigHandlerProcessProtoConfig(t *testing.T) {
 	data := `--~+::\n:-`
 
 	handler := v1DeviceConfigHandler{}
 
 	_, err := handler.processPrototypeConfig([]byte(data))
-	if err == nil {
-		t.Error("expected error: invalid YAML provided")
-	}
+	assert.Error(t, err)
 }
 
+// TestV1DeviceConfigHandlerProcessProtoConfig2 tests unsuccessfully processing
+// v1 prototype config due to a missing required field.
 func TestV1DeviceConfigHandlerProcessProtoConfig2(t *testing.T) {
 	data := `version: 1.0`
 
 	handler := v1DeviceConfigHandler{}
 
 	_, err := handler.processPrototypeConfig([]byte(data))
-	if err == nil {
-		t.Error("expected error: no 'prototypes' field present in config")
-	}
+	assert.Error(t, err)
 }
 
+// TestV1DeviceConfigHandlerProcessProtoConfig3 tests successfully processing
+// multiple v1 prototype configs.
 func TestV1DeviceConfigHandlerProcessProtoConfig3(t *testing.T) {
 	data := `version: 1.0
 prototypes:
@@ -61,26 +65,23 @@ prototypes:
 	handler := v1DeviceConfigHandler{}
 
 	c, err := handler.processPrototypeConfig([]byte(data))
-	if err != nil {
-		t.Error(err)
-	}
-
-	if len(c) != 2 {
-		t.Errorf("Expecting 2 prototypes, but got %v", len(c))
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(c))
 }
 
+// TestV1DeviceConfigHandlerProcessDeviceConfig tests unsuccessfully processing
+// v1 device config due to invalid YAML.
 func TestV1DeviceConfigHandlerProcessDeviceConfig(t *testing.T) {
 	data := `--~+::\n:-`
 
 	handler := v1DeviceConfigHandler{}
 
 	_, err := handler.processDeviceConfig([]byte(data))
-	if err == nil {
-		t.Error("expected error: invalid YAML provided")
-	}
+	assert.Error(t, err)
 }
 
+// TestV1DeviceConfigHandlerProcessDeviceConfig2 tests unsuccessfully processing
+// v1 device config due to a missing required field.
 func TestV1DeviceConfigHandlerProcessDeviceConfig2(t *testing.T) {
 	data := `version: 1.0
 locations:
@@ -97,11 +98,11 @@ devices:
 	handler := v1DeviceConfigHandler{}
 
 	_, err := handler.processDeviceConfig([]byte(data))
-	if err == nil {
-		t.Error("expected error: no 'location' field present in config")
-	}
+	assert.Error(t, err)
 }
 
+// TestV1DeviceConfigHandlerProcessDeviceConfig3 tests successfully processing
+// multiple v1 device configs.
 func TestV1DeviceConfigHandlerProcessDeviceConfig3(t *testing.T) {
 	data := `version: 1.0
 locations:
@@ -131,11 +132,6 @@ devices:
 	handler := v1DeviceConfigHandler{}
 
 	c, err := handler.processDeviceConfig([]byte(data))
-	if err != nil {
-		t.Error(err)
-	}
-
-	if len(c) != 3 {
-		t.Errorf("Expecting 3 device configs, but got %v", len(c))
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(c))
 }

--- a/sdk/config/versioning_test.go
+++ b/sdk/config/versioning_test.go
@@ -2,216 +2,236 @@ package config
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
-var configVersionToStringTestTable = []struct {
-	in  configVersion
-	out string
-}{
-	{
-		in:  configVersion{0, 0, "test"},
-		out: "0.0",
-	},
-	{
-		in:  configVersion{1, 0, "test"},
-		out: "1.0",
-	},
-	{
-		in:  configVersion{1, 1, "test"},
-		out: "1.1",
-	},
-	{
-		in:  configVersion{888, 66666, "test"},
-		out: "888.66666",
-	},
-}
-
+// TestConfigVersion_ToString tests converting ConfigVersion to a string.
 func TestConfigVersion_ToString(t *testing.T) {
-	for _, tc := range configVersionToStringTestTable {
+	var cases = []struct {
+		in  configVersion
+		out string
+	}{
+		{
+			in:  configVersion{0, 0, "test"},
+			out: "0.0",
+		},
+		{
+			in:  configVersion{1, 0, "test"},
+			out: "1.0",
+		},
+		{
+			in:  configVersion{1, 1, "test"},
+			out: "1.1",
+		},
+		{
+			in:  configVersion{888, 66666, "test"},
+			out: "888.66666",
+		},
+	}
+
+	for _, tc := range cases {
 		r := tc.in.ToString()
-		if r != tc.out {
-			t.Errorf("%#v.ToString() => %v, want %v", tc.in, r, tc.out)
-		}
+		assert.Equal(t, tc.out, r)
 	}
 }
 
+// TestGetConfigVersion tests getting the version of a config file when
+// the provided YAML is invalid.
 func TestGetConfigVersion(t *testing.T) {
 	cfg := ``
 
 	_, err := getConfigVersion("test", []byte(cfg))
-	if err == nil {
-		t.Error("expected error: given YAML should be invalid")
-	}
+	assert.Error(t, err)
 }
 
+// TestGetConfigVersion2 tests getting the version of a config file when
+// the config version is not supported.
 func TestGetConfigVersion2(t *testing.T) {
 	cfg := `version: "abc123 is not a supported version"`
 
 	_, err := getConfigVersion("test", []byte(cfg))
-	if err == nil {
-		t.Error("expected error: given version configuration is invalid")
-	}
+	assert.Error(t, err)
 }
 
+// TestGetConfigVersion3 tests getting the version of a config file successfully.
 func TestGetConfigVersion3(t *testing.T) {
 	cfg := `version: 1.1`
 
 	cv, err := getConfigVersion("test", []byte(cfg))
-	if err != nil {
-		t.Error(err)
-	}
-	if cv.Major != 1 {
-		t.Errorf("expected parsed major version to be 1, but was %v", cv.Major)
-	}
-	if cv.Minor != 1 {
-		t.Errorf("expected parsed minor version to be 1, but was %v", cv.Minor)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, 1, cv.Major)
+	assert.Equal(t, 1, cv.Minor)
 }
 
+// TestGetConfigVersion4 tests getting the version of a config file unsuccessfully
+// due to invalid YAML.
+func TestGetConfigVersion4(t *testing.T) {
+	cfg := `--~+::\n:-`
+
+	cv, err := getConfigVersion("test", []byte(cfg))
+	assert.Error(t, err)
+	assert.Nil(t, cv)
+}
+
+// TestIsSupportedVersion tests checking if a config version is supported
+// when the config version should not be supported.
 func TestIsSupportedVersion(t *testing.T) {
 	cv := configVersion{2, 0, "test"}
 
 	isSupported := isSupportedVersion(&cv, []string{"1.0", "1.1"})
-	if isSupported {
-		t.Error("expected config version to fail supported check")
-	}
+	assert.False(t, isSupported)
 }
 
+// TestIsSupportedVersion2 tests checking if a config version is supported
+// when the config version should be supported.
 func TestIsSupportedVersion2(t *testing.T) {
 	cv := configVersion{1, 0, "test"}
 
 	isSupported := isSupportedVersion(&cv, []string{"1.0", "1.1"})
-	if !isSupported {
-		t.Error("expected config version to pass supported check")
-	}
+	assert.True(t, isSupported)
 }
 
+// TestCfgVersionToConfigVersion tests converting a cfgVersion to
+// a ConfigVersion when no version string is provided.
 func TestCfgVersionToConfigVersion(t *testing.T) {
 	c := cfgVersion{"", "test"}
 
 	_, err := c.toConfigVersion()
-	if err == nil {
-		t.Error("expected error: no version string provided")
-	}
+	assert.Error(t, err)
 }
 
+// TestCfgVersionToConfigVersion2 tests converting a cfgVersion to
+// a ConfigVersion when an invalid config value is provided.
 func TestCfgVersionToConfigVersion2(t *testing.T) {
 	c := cfgVersion{"abc", "test"}
 
 	_, err := c.toConfigVersion()
-	if err == nil {
-		t.Error("expected error: invalid config value")
-	}
+	assert.Error(t, err)
 }
 
+// TestCfgVersionToConfigVersion3 tests converting a cfgVersion to
+// a ConfigVersion when an invalid config value (major version) is supplied.
 func TestCfgVersionToConfigVersion3(t *testing.T) {
 	c := cfgVersion{"abc.0", "test"}
 
 	_, err := c.toConfigVersion()
-	if err == nil {
-		t.Error("expected error: invalid config value (major version)")
-	}
+	assert.Error(t, err)
 }
 
+// TestCfgVersionToConfigVersion4 tests converting a cfgVersion to
+// a ConfigVersion when an invalid config value (minor version) is supplied.
 func TestCfgVersionToConfigVersion4(t *testing.T) {
 	c := cfgVersion{"0.abc", "test"}
 
 	_, err := c.toConfigVersion()
-	if err == nil {
-		t.Error("expected error: invalid config value (minor version)")
-	}
+	assert.Error(t, err)
 }
 
+// TestCfgVersionToConfigVersion5 tests converting a cfgVersion to
+// a ConfigVersion successfully, specifying only the major version.
 func TestCfgVersionToConfigVersion5(t *testing.T) {
 	c := cfgVersion{"1", "test"}
 
 	cv, err := c.toConfigVersion()
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err)
 
 	expected := configVersion{1, 0, "test"}
-	if *cv != expected {
-		t.Errorf("expected version to match 1.0, but instead is %v", cv)
-	}
+	assert.Equal(t, expected, *cv)
 }
 
+// TestCfgVersionToConfigVersion6 tests converting a cfgVersion to
+// a ConfigVersion successfully, specifying major and minor version.
 func TestCfgVersionToConfigVersion6(t *testing.T) {
 	c := cfgVersion{"1.1", "test"}
 
 	cv, err := c.toConfigVersion()
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err)
 
 	expected := configVersion{1, 1, "test"}
-	if *cv != expected {
-		t.Errorf("expected version to match 1.1, but instead is %v", cv)
-	}
+	assert.Equal(t, expected, *cv)
 }
 
+// TestGetDeviceConfigVersionHandler tests getting the device config
+// version handler for a version that is not supported.
 func TestGetDeviceConfigVersionHandler(t *testing.T) {
 	cv := configVersion{9999, 9999, "test"}
 
 	_, err := getDeviceConfigVersionHandler(&cv)
-	if err == nil {
-		t.Error("expected error: config version should not be supported")
-	}
+	assert.Error(t, err)
 }
 
+// TestGetDeviceConfigVersionHandler2 tests getting the device config
+// version handler for a version that is supported.
 func TestGetDeviceConfigVersionHandler2(t *testing.T) {
 	cv := configVersion{1, 0, "test"}
 
 	h, err := getDeviceConfigVersionHandler(&cv)
-	if err != nil {
-		t.Error(err)
-	}
-	if h == nil {
-		t.Error("no handler returned, but one was expected")
-	}
+	assert.NoError(t, err)
+	assert.NotNil(t, h)
 }
 
+// TestGetDeviceConfigVersionHandler3 tests getting the device config
+// version handler for a defined version (that is supported).
 func TestGetDeviceConfigVersionHandler3(t *testing.T) {
 	cv := v1maj0min
 
 	h, err := getDeviceConfigVersionHandler(&cv)
-	if err != nil {
-		t.Error(err)
-	}
-	if h == nil {
-		t.Error("no handler returned, but one was expected")
-	}
+	assert.NoError(t, err)
+	assert.NotNil(t, h)
 }
 
+// TestGetDeviceConfigVersionHandler4 tests getting the device config
+// version handler for a supported version when the handler does not exist.
+func TestGetDeviceConfigVersionHandler4(t *testing.T) {
+	cv := configVersion{999, 999, "test"}
+
+	// add version 999.999 to the supported versions, but do not add a corresponding handler
+	supportedDeviceConfigVersions = append(supportedDeviceConfigVersions, "999.999")
+
+	h, err := getDeviceConfigVersionHandler(&cv)
+	assert.Error(t, err)
+	assert.Nil(t, h)
+}
+
+// TestGetPluginConfigVersionHandler tests getting the plugin config
+// version handler for a version that is not supported.
 func TestGetPluginConfigVersionHandler(t *testing.T) {
 	cv := configVersion{9999, 9999, "test"}
 
 	_, err := getPluginConfigVersionHandler(&cv)
-	if err == nil {
-		t.Error("expected error: config version should not be supported")
-	}
+	assert.Error(t, err)
 }
 
+// TestGetPluginConfigVersionHandler2 tests getting the plugin config
+// version handler for a version that is supported.
 func TestGetPluginConfigVersionHandler2(t *testing.T) {
 	cv := configVersion{1, 0, "test"}
 
 	h, err := getPluginConfigVersionHandler(&cv)
-	if err != nil {
-		t.Error(err)
-	}
-	if h == nil {
-		t.Error("no handler returned, but one was expected")
-	}
+	assert.NoError(t, err)
+	assert.NotNil(t, h)
 }
 
+// TestGetPluginConfigVersionHandler3 tests getting the plugin config
+// version handler for a defined version (that is supported).
 func TestGetPluginConfigVersionHandler3(t *testing.T) {
 	cv := v1maj0min
 
 	h, err := getPluginConfigVersionHandler(&cv)
-	if err != nil {
-		t.Error(err)
-	}
-	if h == nil {
-		t.Error("no handler returned, but one was expected")
-	}
+	assert.NoError(t, err)
+	assert.NotNil(t, h)
+}
+
+// TestGetPluginConfigVersionHandler4 tests getting the plugin config
+// version handler for a supported version when the handler does not exist.
+func TestGetPluginConfigVersionHandler4(t *testing.T) {
+	cv := configVersion{999, 999, "test"}
+
+	// add version 999.999 to the supported versions, but do not add a corresponding handler
+	supportedPluginConfigVersions = append(supportedPluginConfigVersions, "999.999")
+
+	h, err := getPluginConfigVersionHandler(&cv)
+	assert.Error(t, err)
+	assert.Nil(t, h)
 }


### PR DESCRIPTION
Part 2 of adding and updating tests.

This PR should get test coverage up to ~70%. 

There is still a big testing deficit in the data_manager, server, and plugin source files, but since that is where the goroutines/gRPC stuff lives, it'll require a bit more work/learning to write good tests there, so I'll have those be their own testing-part3 PR later on.