### PR TITLE
add additional test cases

### DIFF
--- a/sdk/data_manager_test.go
+++ b/sdk/data_manager_test.go
@@ -5,7 +5,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"fmt"
+
 	"github.com/vapor-ware/synse-sdk/sdk/config"
+	"golang.org/x/time/rate"
 )
 
 // DeviceID gets the unique identifiers out of the plugin-specific
@@ -122,16 +125,16 @@ func TestDataManager_WritesEnabled(t *testing.T) {
 			Address: "test",
 		},
 		Settings: config.Settings{
-			Read:        config.ReadSettings{Buffer: 200},
-			Write:       config.WriteSettings{
+			Read: config.ReadSettings{Buffer: 200},
+			Write: config.WriteSettings{
 				Enabled: true,
-				Buffer: 200,
+				Buffer:  200,
 			},
 			Transaction: config.TransactionSettings{TTL: "2s"},
 		},
 	}
 	p := Plugin{
-		Config: &c,
+		Config:   &c,
 		handlers: &Handlers{DeviceID, nil},
 	}
 
@@ -141,3 +144,341 @@ func TestDataManager_WritesEnabled(t *testing.T) {
 
 	assert.True(t, d.writesEnabled())
 }
+
+// TestDataManager_readNoLimiter tests reading a device when a limiter is
+// not configured.
+func TestDataManager_readOkNoLimiter(t *testing.T) {
+	// Create the plugin
+	p := Plugin{
+		Config: &config.PluginConfig{
+			Name:    "test",
+			Version: "test",
+			Network: config.NetworkSettings{
+				Type:    "tcp",
+				Address: "test",
+			},
+			Settings: config.Settings{
+				Read:        config.ReadSettings{Buffer: 200},
+				Write:       config.WriteSettings{Buffer: 200},
+				Transaction: config.TransactionSettings{TTL: "2s"},
+			},
+		},
+		handlers: &Handlers{DeviceID, nil},
+	}
+
+	// Create the device to read
+	device := makeTestDevice()
+	device.Handler = &DeviceHandler{
+		Read: func(d *Device) ([]*Reading, error) {
+			return []*Reading{NewReading("test", "ok")}, nil
+		},
+	}
+
+	// Create the dataManager
+	d, err := newDataManager(&p)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 0, len(d.readChannel))
+	d.read(device)
+	assert.Equal(t, 1, len(d.readChannel))
+
+	reading := <-d.readChannel
+	assert.Equal(t, 1, len(reading.Reading))
+	assert.Equal(t, "test", reading.Reading[0].Type)
+	assert.Equal(t, "ok", reading.Reading[0].Value)
+}
+
+// TestDataManager_readOkWithLimiter tests reading a device when a limiter is
+// configured.
+func TestDataManager_readOkWithLimiter(t *testing.T) {
+	// Create the plugin
+	p := Plugin{
+		Config: &config.PluginConfig{
+			Name:    "test",
+			Version: "test",
+			Network: config.NetworkSettings{
+				Type:    "tcp",
+				Address: "test",
+			},
+			Settings: config.Settings{
+				Read:        config.ReadSettings{Buffer: 200},
+				Write:       config.WriteSettings{Buffer: 200},
+				Transaction: config.TransactionSettings{TTL: "2s"},
+			},
+			Limiter: rate.NewLimiter(200, 200),
+		},
+		handlers: &Handlers{DeviceID, nil},
+	}
+
+	// Create the device to read
+	device := makeTestDevice()
+	device.Handler = &DeviceHandler{
+		Read: func(d *Device) ([]*Reading, error) {
+			return []*Reading{NewReading("test", "ok")}, nil
+		},
+	}
+
+	// Create the dataManager
+	d, err := newDataManager(&p)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 0, len(d.readChannel))
+	d.read(device)
+	assert.Equal(t, 1, len(d.readChannel))
+
+	reading := <-d.readChannel
+	assert.Equal(t, 1, len(reading.Reading))
+	assert.Equal(t, "test", reading.Reading[0].Type)
+	assert.Equal(t, "ok", reading.Reading[0].Value)
+}
+
+// TestDataManager_readErr tests reading a device that results in error.
+func TestDataManager_readErr(t *testing.T) {
+	// Create the plugin
+	p := Plugin{
+		Config: &config.PluginConfig{
+			Name:    "test",
+			Version: "test",
+			Network: config.NetworkSettings{
+				Type:    "tcp",
+				Address: "test",
+			},
+			Settings: config.Settings{
+				Read:        config.ReadSettings{Buffer: 200},
+				Write:       config.WriteSettings{Buffer: 200},
+				Transaction: config.TransactionSettings{TTL: "2s"},
+			},
+		},
+		handlers: &Handlers{DeviceID, nil},
+	}
+
+	// Create the device to read
+	device := makeTestDevice()
+	device.Handler = &DeviceHandler{
+		Read: func(d *Device) ([]*Reading, error) {
+			return nil, fmt.Errorf("test read error")
+		},
+	}
+
+	// Create the dataManager
+	d, err := newDataManager(&p)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 0, len(d.readChannel))
+	d.read(device)
+	assert.Equal(t, 0, len(d.readChannel))
+}
+
+// TestDataManager_serialReadSingle tests reading a single device serially.
+func TestDataManager_serialReadSingle(t *testing.T) {
+	// Create the plugin
+	p := Plugin{
+		Config: &config.PluginConfig{
+			Name:    "test",
+			Version: "test",
+			Network: config.NetworkSettings{
+				Type:    "tcp",
+				Address: "test",
+			},
+			Settings: config.Settings{
+				Read:        config.ReadSettings{Buffer: 200},
+				Write:       config.WriteSettings{Buffer: 200},
+				Transaction: config.TransactionSettings{TTL: "2s"},
+			},
+		},
+		handlers: &Handlers{DeviceID, nil},
+	}
+
+	// Create the device to read
+	device := makeTestDevice()
+	device.Handler = &DeviceHandler{
+		Read: func(d *Device) ([]*Reading, error) {
+			return []*Reading{NewReading("test", "ok")}, nil
+		},
+	}
+
+	// Clear the global device map then add the device to it
+	deviceMap = make(map[string]*Device)
+	deviceMap["test-id-1"] = device
+
+	// Create the dataManager
+	d, err := newDataManager(&p)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 0, len(d.readChannel))
+	d.serialRead()
+	assert.Equal(t, 1, len(d.readChannel))
+
+	reading := <-d.readChannel
+	assert.Equal(t, 1, len(reading.Reading))
+	assert.Equal(t, "test", reading.Reading[0].Type)
+	assert.Equal(t, "ok", reading.Reading[0].Value)
+}
+
+// FIXME - race condition, likely because the deviceMap is global and used by other tests..
+//// TestDataManager_serialReadMultiple tests reading multiple devices serially.
+//func TestDataManager_serialReadMultiple(t *testing.T) {
+//	// Create the plugin
+//	p := Plugin{
+//		Config:   &config.PluginConfig{
+//			Name:    "test",
+//			Version: "test",
+//			Network: config.NetworkSettings{
+//				Type:    "tcp",
+//				Address: "test",
+//			},
+//			Settings: config.Settings{
+//				Read: config.ReadSettings{Buffer: 200},
+//				Write: config.WriteSettings{Buffer:  200},
+//				Transaction: config.TransactionSettings{TTL: "2s"},
+//			},
+//		},
+//		handlers: &Handlers{DeviceID, nil},
+//	}
+//
+//	// Create the device to read
+//	device1 := makeTestDevice()
+//	device1.Type = "abc"
+//	device1.Handler = &DeviceHandler{
+//		Read: func(d *Device) ([]*Reading, error) {
+//			return []*Reading{NewReading("test", "ok")}, nil
+//		},
+//	}
+//	fmt.Printf("device1: %v\n", device1.ID())
+//
+//	device2 := makeTestDevice()
+//	device2.Type = "def"
+//	device2.Handler = &DeviceHandler{
+//		Read: func(d *Device) ([]*Reading, error) {
+//			return []*Reading{NewReading("test", "ok")}, nil
+//		},
+//	}
+//	fmt.Printf("device2: %v\n", device2.ID())
+//
+//	device3 := makeTestDevice()
+//	device3.Type = "ghi"
+//	device3.Handler = &DeviceHandler{
+//		Read: func(d *Device) ([]*Reading, error) {
+//			return []*Reading{NewReading("test", "ok")}, nil
+//		},
+//	}
+//	fmt.Printf("device3: %v\n", device3.ID())
+//
+//	// Clear the global device map then add devices to it
+//	deviceMap = make(map[string]*Device)
+//	deviceMap["test-id-1"] = device1
+//	deviceMap["test-id-2"] = device2
+//	deviceMap["test-id-3"] = device3
+//
+//	// Create the dataManager
+//	d, err := newDataManager(&p)
+//	assert.NoError(t, err)
+//
+//	assert.Equal(t, 0, len(d.readChannel))
+//	d.serialRead()
+//	assert.Equal(t, 3, len(d.readChannel))
+//
+//	reading := <-d.readChannel
+//	assert.Equal(t, 3, len(reading.Reading))
+//	for _, r := range reading.Reading {
+//		assert.Equal(t, "test", r.Type)
+//		assert.Equal(t, "ok", r.Value)
+//	}
+//}
+
+// TestDataManager_parallelReadSingle tests reading a single device in parallel.
+func TestDataManager_parallelReadSingle(t *testing.T) {
+	// Create the plugin
+	p := Plugin{
+		Config: &config.PluginConfig{
+			Name:    "test",
+			Version: "test",
+			Network: config.NetworkSettings{
+				Type:    "tcp",
+				Address: "test",
+			},
+			Settings: config.Settings{
+				Read:        config.ReadSettings{Buffer: 200},
+				Write:       config.WriteSettings{Buffer: 200},
+				Transaction: config.TransactionSettings{TTL: "2s"},
+			},
+		},
+		handlers: &Handlers{DeviceID, nil},
+	}
+
+	// Create the device to read
+	device := makeTestDevice()
+	device.Handler = &DeviceHandler{
+		Read: func(d *Device) ([]*Reading, error) {
+			return []*Reading{NewReading("test", "ok")}, nil
+		},
+	}
+
+	// Clear the global device map then add the device to it
+	deviceMap = make(map[string]*Device)
+	deviceMap["test-id-1"] = device
+
+	// Create the dataManager
+	d, err := newDataManager(&p)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 0, len(d.readChannel))
+	d.parallelRead()
+	assert.Equal(t, 1, len(d.readChannel))
+
+	reading := <-d.readChannel
+	assert.Equal(t, 1, len(reading.Reading))
+	assert.Equal(t, "test", reading.Reading[0].Type)
+	assert.Equal(t, "ok", reading.Reading[0].Value)
+}
+
+// FIXME - race condition, likely because the deviceMap is global and used by other tests..
+//// TestDataManager_parallelReadSingle tests reading multiple devices in parallel.
+//func TestDataManager_parallelReadMultiple(t *testing.T) {
+//	// Create the plugin
+//	p := Plugin{
+//		Config:   &config.PluginConfig{
+//			Name:    "test",
+//			Version: "test",
+//			Network: config.NetworkSettings{
+//				Type:    "tcp",
+//				Address: "test",
+//			},
+//			Settings: config.Settings{
+//				Read: config.ReadSettings{Buffer: 200},
+//				Write: config.WriteSettings{Buffer:  200},
+//				Transaction: config.TransactionSettings{TTL: "2s"},
+//			},
+//		},
+//		handlers: &Handlers{DeviceID, nil},
+//	}
+//
+//	// Create the device to read
+//	device := makeTestDevice()
+//	device.Handler = &DeviceHandler{
+//		Read: func(d *Device) ([]*Reading, error) {
+//			return []*Reading{NewReading("test", "ok")}, nil
+//		},
+//	}
+//
+//	// Clear the global device map then add devices to it
+//	deviceMap = make(map[string]*Device)
+//	deviceMap["test-id-1"] = device
+//	deviceMap["test-id-2"] = device
+//	deviceMap["test-id-3"] = device
+//
+//	// Create the dataManager
+//	d, err := newDataManager(&p)
+//	assert.NoError(t, err)
+//
+//	assert.Equal(t, 0, len(d.readChannel))
+//	d.parallelRead()
+//	assert.Equal(t, 3, len(d.readChannel))
+//
+//	reading := <-d.readChannel
+//	assert.Equal(t, 3, len(reading.Reading))
+//	for _, r := range reading.Reading {
+//		assert.Equal(t, "test", r.Type)
+//		assert.Equal(t, "ok", r.Value)
+//	}
+//}

--- a/sdk/data_manager_test.go
+++ b/sdk/data_manager_test.go
@@ -77,3 +77,67 @@ func TestNewDataManager2(t *testing.T) {
 	assert.Equal(t, 500, cap(d.readChannel))
 	assert.Equal(t, h, d.handlers)
 }
+
+// TestNewDataManager_NilPlugin tests creating a new dataManager instance, passing
+// in a nil Plugin to the constructor.
+func TestNewDataManager_NilPlugin(t *testing.T) {
+	d, err := newDataManager(nil)
+	assert.Nil(t, d)
+	assert.Error(t, err)
+}
+
+// TestNewDataManager_NilPluginHandlers tests creating a new dataManager instance,
+// passing in a Plugin with nil handlers to the constructor.
+func TestNewDataManager_NilPluginHandlers(t *testing.T) {
+	p := Plugin{
+		handlers: nil,
+	}
+
+	d, err := newDataManager(&p)
+	assert.Nil(t, d)
+	assert.Error(t, err)
+}
+
+// TestNewDataManager_NilPluginConfig tests creating a new dataManager instance,
+// passing in a Plugin with nil config to the constructor.
+func TestNewDataManager_NilPluginConfig(t *testing.T) {
+	p := Plugin{
+		handlers: &Handlers{DeviceID, nil},
+	}
+
+	d, err := newDataManager(&p)
+	assert.Nil(t, d)
+	assert.Error(t, err)
+}
+
+// TestDataManager_WritesEnabled tests that writes are enabled in the dataManager
+// when they are enabled in the config.
+func TestDataManager_WritesEnabled(t *testing.T) {
+	// Create the plugin
+	c := config.PluginConfig{
+		Name:    "test",
+		Version: "test",
+		Network: config.NetworkSettings{
+			Type:    "tcp",
+			Address: "test",
+		},
+		Settings: config.Settings{
+			Read:        config.ReadSettings{Buffer: 200},
+			Write:       config.WriteSettings{
+				Enabled: true,
+				Buffer: 200,
+			},
+			Transaction: config.TransactionSettings{TTL: "2s"},
+		},
+	}
+	p := Plugin{
+		Config: &c,
+		handlers: &Handlers{DeviceID, nil},
+	}
+
+	// Create the dataManager
+	d, err := newDataManager(&p)
+	assert.NoError(t, err)
+
+	assert.True(t, d.writesEnabled())
+}

--- a/sdk/devices_test.go
+++ b/sdk/devices_test.go
@@ -291,7 +291,7 @@ func TestDevicesFromAutoEnum_noConfig(t *testing.T) {
 
 	// Initialize plugin with handlers.
 	p := Plugin{
-		Config: &config.PluginConfig{},
+		Config:   &config.PluginConfig{},
 		handlers: handlers,
 	}
 

--- a/sdk/logger/logger_test.go
+++ b/sdk/logger/logger_test.go
@@ -1,11 +1,31 @@
 package logger
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
+
+// setupLogger is a test utility function to set up the logger
+// to write out to a bytes buffer for tests.
+func setupLogger(level logrus.Level) *bytes.Buffer {
+	// Set the logger output to a bytes buffer
+	var buffer bytes.Buffer
+	logger.Out = &buffer
+
+	// Set the level
+	logger.Level = level
+
+	// Set a custom formatter for testing - this is to disable the
+	// timestamp in the log to make it easier to test the output value.
+	logger.Formatter = &logrus.TextFormatter{
+		DisableTimestamp: true,
+	}
+
+	return &buffer
+}
 
 // TestSetLogLevel tests setting the logging level for the SDK logger.
 func TestSetLogLevel(t *testing.T) {
@@ -17,4 +37,144 @@ func TestSetLogLevel(t *testing.T) {
 
 	SetLogLevel(false)
 	assert.Equal(t, logrus.InfoLevel, logger.Level)
+}
+
+func TestDebug(t *testing.T) {
+	buffer := setupLogger(logrus.DebugLevel)
+
+	Debug("test")
+	assert.Equal(t, "level=debug msg=test\n", buffer.String())
+}
+
+func TestDebug_BadLevel(t *testing.T) {
+	buffer := setupLogger(logrus.FatalLevel)
+
+	Debug("test")
+	assert.Equal(t, "", buffer.String())
+}
+
+func TestDebugf(t *testing.T) {
+	buffer := setupLogger(logrus.DebugLevel)
+
+	Debugf("test %d", 1)
+	assert.Equal(t, "level=debug msg=\"test 1\"\n", buffer.String())
+}
+
+func TestDebugf_BadLevel(t *testing.T) {
+	buffer := setupLogger(logrus.FatalLevel)
+
+	Debugf("test %d", 1)
+	assert.Equal(t, "", buffer.String())
+}
+
+func TestInfo(t *testing.T) {
+	buffer := setupLogger(logrus.InfoLevel)
+
+	Info("test")
+	assert.Equal(t, "level=info msg=test\n", buffer.String())
+}
+
+func TestInfo_BadLevel(t *testing.T) {
+	buffer := setupLogger(logrus.FatalLevel)
+
+	Info("test")
+	assert.Equal(t, "", buffer.String())
+}
+
+func TestInfof(t *testing.T) {
+	buffer := setupLogger(logrus.InfoLevel)
+
+	Infof("test %d", 1)
+	assert.Equal(t, "level=info msg=\"test 1\"\n", buffer.String())
+}
+
+func TestInfof_BadLevel(t *testing.T) {
+	buffer := setupLogger(logrus.FatalLevel)
+
+	Infof("test %d", 1)
+	assert.Equal(t, "", buffer.String())
+}
+
+func TestInfoMultiline_EmptyLine(t *testing.T) {
+	buffer := setupLogger(logrus.InfoLevel)
+
+	InfoMultiline("")
+	assert.Equal(t, "level=info msg=\"Line 0000: \"\n", buffer.String())
+}
+
+func TestInfoMultiline_SingleLine(t *testing.T) {
+	buffer := setupLogger(logrus.InfoLevel)
+
+	InfoMultiline("test")
+	assert.Equal(t, "level=info msg=\"Line 0000: test\"\n", buffer.String())
+}
+
+func TestInfoMultiline_MultiLine(t *testing.T) {
+	buffer := setupLogger(logrus.InfoLevel)
+
+	InfoMultiline("one\ntwo\nthree")
+	assert.Equal(t, "level=info msg=\"Line 0000: one\"\nlevel=info msg=\"Line 0001: two\"\nlevel=info msg=\"Line 0002: three\"\n", buffer.String())
+}
+
+func TestInfoMultiline_BadLevel(t *testing.T) {
+	buffer := setupLogger(logrus.FatalLevel)
+
+	InfoMultiline("test")
+	assert.Equal(t, "", buffer.String())
+}
+
+func TestWarn(t *testing.T) {
+	buffer := setupLogger(logrus.WarnLevel)
+
+	Warn("test")
+	assert.Equal(t, "level=warning msg=test\n", buffer.String())
+}
+
+func TestWarn_BadLevel(t *testing.T) {
+	buffer := setupLogger(logrus.FatalLevel)
+
+	Warn("test")
+	assert.Equal(t, "", buffer.String())
+}
+
+func TestWarnf(t *testing.T) {
+	buffer := setupLogger(logrus.WarnLevel)
+
+	Warnf("test %d", 1)
+	assert.Equal(t, "level=warning msg=\"test 1\"\n", buffer.String())
+}
+
+func TestWarnf_BadLevel(t *testing.T) {
+	buffer := setupLogger(logrus.FatalLevel)
+
+	Warnf("test %d", 1)
+	assert.Equal(t, "", buffer.String())
+}
+
+func TestError(t *testing.T) {
+	buffer := setupLogger(logrus.ErrorLevel)
+
+	Error("test")
+	assert.Equal(t, "level=error msg=test\n", buffer.String())
+}
+
+func TestError_BadLevel(t *testing.T) {
+	buffer := setupLogger(logrus.FatalLevel)
+
+	Error("test")
+	assert.Equal(t, "", buffer.String())
+}
+
+func TestErrorf(t *testing.T) {
+	buffer := setupLogger(logrus.ErrorLevel)
+
+	Errorf("test %d", 1)
+	assert.Equal(t, "level=error msg=\"test 1\"\n", buffer.String())
+}
+
+func TestErrorf_BadLevel(t *testing.T) {
+	buffer := setupLogger(logrus.FatalLevel)
+
+	Errorf("test %d", 1)
+	assert.Equal(t, "", buffer.String())
 }


### PR DESCRIPTION
This PR adds in additional test cases. 

- device enumeration (dynamic device config)
- data manager reads
  - came across a race condition when writing some tests which I believe are related to the test setup themselves, not the actual code. (those tests are currently commented out)
- logger tests


related: #152