### PR TITLE
Support for bulk reading

### DIFF
--- a/sdk/data_manager_test.go
+++ b/sdk/data_manager_test.go
@@ -147,7 +147,7 @@ func TestDataManager_WritesEnabled(t *testing.T) {
 
 // TestDataManager_readNoLimiter tests reading a device when a limiter is
 // not configured.
-func TestDataManager_readOkNoLimiter(t *testing.T) {
+func TestDataManager_readOneOkNoLimiter(t *testing.T) {
 	// Create the plugin
 	p := Plugin{
 		Config: &config.PluginConfig{
@@ -179,7 +179,7 @@ func TestDataManager_readOkNoLimiter(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, 0, len(d.readChannel))
-	d.read(device)
+	d.readOne(device)
 	assert.Equal(t, 1, len(d.readChannel))
 
 	reading := <-d.readChannel
@@ -190,7 +190,7 @@ func TestDataManager_readOkNoLimiter(t *testing.T) {
 
 // TestDataManager_readOkWithLimiter tests reading a device when a limiter is
 // configured.
-func TestDataManager_readOkWithLimiter(t *testing.T) {
+func TestDataManager_readOneOkWithLimiter(t *testing.T) {
 	// Create the plugin
 	p := Plugin{
 		Config: &config.PluginConfig{
@@ -223,7 +223,7 @@ func TestDataManager_readOkWithLimiter(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, 0, len(d.readChannel))
-	d.read(device)
+	d.readOne(device)
 	assert.Equal(t, 1, len(d.readChannel))
 
 	reading := <-d.readChannel
@@ -233,7 +233,7 @@ func TestDataManager_readOkWithLimiter(t *testing.T) {
 }
 
 // TestDataManager_readErr tests reading a device that results in error.
-func TestDataManager_readErr(t *testing.T) {
+func TestDataManager_readOneErr(t *testing.T) {
 	// Create the plugin
 	p := Plugin{
 		Config: &config.PluginConfig{
@@ -265,7 +265,7 @@ func TestDataManager_readErr(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, 0, len(d.readChannel))
-	d.read(device)
+	d.readOne(device)
 	assert.Equal(t, 0, len(d.readChannel))
 }
 

--- a/sdk/models.go
+++ b/sdk/models.go
@@ -39,6 +39,21 @@ type ReadContext struct {
 	Reading []*Reading
 }
 
+// NewReadContext creates a new instance of a ReadContext from the given
+// device and corresponding readings.
+func NewReadContext(device *Device, readings []*Reading) (*ReadContext, error) {
+	rack, err := device.Location.GetRack()
+	if err != nil {
+		return nil, err
+	}
+	return &ReadContext{
+		Device:  device.ID(),
+		Board:   device.Location.Board,
+		Rack:    rack,
+		Reading: readings,
+	}, nil
+}
+
 // ID returns a compound string that can identify the resource by its
 // rack, board, and device. This ID should be globally unique. It simply follows
 // the pattern {rack}-{board}-{device}.

--- a/sdk/version.go
+++ b/sdk/version.go
@@ -1,7 +1,7 @@
 package sdk
 
 // SDKVersion specifies the version of the Synse Plugin SDK.
-const SDKVersion = "0.5.0"
+const SDKVersion = "0.6.0"
 
 // VersionInfo contains the versioning information for a Plugin.
 type VersionInfo struct {


### PR DESCRIPTION
This PR implements bulk read functionality (described in Section 4.3.3 of the SDK 1.0 design doc). This work was done now as opposed to with the 1.0 rev because it is needed in the short term.

There will be a corresponding PR for the I2C plugin changes with this.

Once this is merged, I'll cut a new release for 0.6.0