### PR TITLE
add static plugin metainfo, move metainfo out of config

### DIFF
--- a/examples/auto_enumerate/plugin.go
+++ b/examples/auto_enumerate/plugin.go
@@ -11,6 +11,12 @@ import (
 	"github.com/vapor-ware/synse-sdk/sdk/config"
 )
 
+var (
+	pluginName       = "Dynamic Registration Plugin"
+	pluginMaintainer = "Vapor IO"
+	pluginDesc       = "An example plugin that demonstrates dynamically registering devices"
+)
+
 // temperatureHandler defines the read/write behavior for the "temp2010"
 // temperature device.
 var temperatureHandler = sdk.DeviceHandler{
@@ -95,6 +101,14 @@ func checkErr(err error) {
 }
 
 func main() {
+	// Set the metainfo for the plugin.
+	sdk.SetPluginMeta(
+		pluginName,
+		pluginMaintainer,
+		pluginDesc,
+		"",
+	)
+
 	// Set the prototype and device instance config paths to be relative to the
 	// current working directory instead of using the default location. This way
 	// the plugin can be run from within this directory.

--- a/examples/c_plugin/plugin.go
+++ b/examples/c_plugin/plugin.go
@@ -8,6 +8,12 @@ import (
 	"github.com/vapor-ware/synse-sdk/sdk"
 )
 
+var (
+	pluginName       = "C Plugin"
+	pluginMaintainer = "Vapor IO"
+	pluginDesc       = "An example plugin that demonstrates C code integration"
+)
+
 // temperatureHandler defines the read/write behavior for the "temp2010"
 // temperature device.
 var temperatureHandler = sdk.DeviceHandler{
@@ -46,6 +52,14 @@ func checkErr(err error) {
 // The main function - this is where we will configure, create, and run
 // the plugin.
 func main() {
+	// Set the metainfo for the plugin.
+	sdk.SetPluginMeta(
+		pluginName,
+		pluginMaintainer,
+		pluginDesc,
+		"",
+	)
+
 	// Set the prototype and device instance config paths to be relative to the
 	// current working directory instead of using the default location. This way
 	// the plugin can be run from within this directory.

--- a/examples/multi_device_plugin/plugin.go
+++ b/examples/multi_device_plugin/plugin.go
@@ -8,6 +8,12 @@ import (
 	"github.com/vapor-ware/synse-sdk/sdk"
 )
 
+var (
+	pluginName       = "Multi-Device Plugin"
+	pluginMaintainer = "Vapor IO"
+	pluginDesc       = "An example plugin that demonstrates registering multiple devices"
+)
+
 // ProtocolIdentifier gets the unique identifiers out of the plugin-specific
 // configuration to be used in UID generation.
 func ProtocolIdentifier(data map[string]string) string {
@@ -25,6 +31,14 @@ func checkErr(err error) {
 // The main function - this is where we will configure, create, and run
 // the plugin.
 func main() {
+	// Set the metainfo for the plugin.
+	sdk.SetPluginMeta(
+		pluginName,
+		pluginMaintainer,
+		pluginDesc,
+		"",
+	)
+
 	// Set the prototype and device instance config paths to be relative to the
 	// current working directory instead of using the default location. This way
 	// the plugin can be run from within this directory.

--- a/examples/pre_run_actions/plugin.go
+++ b/examples/pre_run_actions/plugin.go
@@ -9,6 +9,12 @@ import (
 	"github.com/vapor-ware/synse-sdk/sdk/logger"
 )
 
+var (
+	pluginName       = "Pre-Run Action Plugin"
+	pluginMaintainer = "Vapor IO"
+	pluginDesc       = "An example plugin that demonstrates pre-run action capabilities"
+)
+
 // ProtocolIdentifier gets the unique identifiers out of the plugin-specific
 // configuration to be used in UID generation.
 func ProtocolIdentifier(data map[string]string) string {
@@ -51,6 +57,14 @@ func checkErr(err error) {
 // The main function - this is where we will configure, create, and run
 // the plugin.
 func main() {
+	// Set the metainfo for the plugin.
+	sdk.SetPluginMeta(
+		pluginName,
+		pluginMaintainer,
+		pluginDesc,
+		"",
+	)
+
 	// Set the prototype and device instance config paths to be relative to the
 	// current working directory instead of using the default location. This way
 	// the plugin can be run from within this directory.

--- a/examples/simple_plugin/plugin.go
+++ b/examples/simple_plugin/plugin.go
@@ -19,6 +19,12 @@ import (
 	"github.com/vapor-ware/synse-sdk/sdk/config"
 )
 
+var (
+	pluginName       = "Simple Plugin"
+	pluginMaintainer = "Vapor IO"
+	pluginDesc       = "A simple example plugin"
+)
+
 // Read defines the behavior for device reads in this example plugin.
 func Read(device *sdk.Device) ([]*sdk.Reading, error) {
 	return []*sdk.Reading{
@@ -112,6 +118,14 @@ func checkErr(err error) {
 //   the devices from config, start the read-write loop, and start the GRPC
 //   server.
 func main() {
+	// Set the metainfo for the plugin.
+	sdk.SetPluginMeta(
+		pluginName,
+		pluginMaintainer,
+		pluginDesc,
+		"",
+	)
+
 	// Set the prototype and device instance config paths to be relative to the
 	// current working directory instead of using the default location. This way
 	// the plugin can be run from within this directory.
@@ -124,7 +138,6 @@ func main() {
 
 	// Configuration for the Simple Plugin.
 	cfg := config.PluginConfig{
-		Name:    "simple-plugin",
 		Version: "1.0",
 		Debug:   true,
 		Network: config.NetworkSettings{

--- a/sdk/config/plugin.go
+++ b/sdk/config/plugin.go
@@ -19,7 +19,6 @@ var homeConfigPath = os.Getenv("HOME") + "/.synse/plugin"
 
 // PluginConfig specifies the configuration options for the plugin.
 type PluginConfig struct {
-	Name          string
 	Version       string
 	Debug         bool
 	Settings      Settings
@@ -94,10 +93,6 @@ func (setting *TransactionSettings) GetTTL() (time.Duration, error) {
 // the required fields populated.
 func (c *PluginConfig) Validate() error {
 	// Config errors
-	if c.Name == "" {
-		return fmt.Errorf("config validation failed: missing required field 'name'")
-	}
-
 	if c.Version == "" {
 		return fmt.Errorf("config validation failed: missing required field 'version'")
 	}

--- a/sdk/config/plugin_test.go
+++ b/sdk/config/plugin_test.go
@@ -88,7 +88,6 @@ func TestNewPluginConfigErr(t *testing.T) {
 func TestPluginConfig_Validate(t *testing.T) {
 	var cases = []PluginConfig{
 		{
-			Name:    "test",
 			Version: "1",
 			Network: NetworkSettings{
 				Type:    "test",
@@ -101,7 +100,6 @@ func TestPluginConfig_Validate(t *testing.T) {
 			},
 		},
 		{
-			Name:    "1",
 			Version: "2",
 			Network: NetworkSettings{
 				Type:    "3",
@@ -114,7 +112,6 @@ func TestPluginConfig_Validate(t *testing.T) {
 			},
 		},
 		{
-			Name:    "test",
 			Version: "1",
 			Network: NetworkSettings{
 				Type:    "test",
@@ -138,7 +135,6 @@ func TestPluginConfig_Validate(t *testing.T) {
 func TestPluginConfig_ValidateErr(t *testing.T) {
 	var cases = []PluginConfig{
 		{
-			Version: "1",
 			Network: NetworkSettings{
 				Type:    "test",
 				Address: "test",
@@ -150,19 +146,6 @@ func TestPluginConfig_ValidateErr(t *testing.T) {
 			},
 		},
 		{
-			Name: "test",
-			Network: NetworkSettings{
-				Type:    "test",
-				Address: "test",
-			},
-			Settings: Settings{
-				Transaction: TransactionSettings{
-					TTL: "2s",
-				},
-			},
-		},
-		{
-			Name:    "test",
 			Version: "1",
 			Settings: Settings{
 				Transaction: TransactionSettings{
@@ -171,7 +154,6 @@ func TestPluginConfig_ValidateErr(t *testing.T) {
 			},
 		},
 		{
-			Name:    "test",
 			Version: "1",
 			Network: NetworkSettings{
 				Address: "test",
@@ -183,7 +165,6 @@ func TestPluginConfig_ValidateErr(t *testing.T) {
 			},
 		},
 		{
-			Name:    "test",
 			Version: "1",
 			Network: NetworkSettings{
 				Type: "test",
@@ -195,7 +176,6 @@ func TestPluginConfig_ValidateErr(t *testing.T) {
 			},
 		},
 		{
-			Name:    "1",
 			Version: "2",
 			Network: NetworkSettings{
 				Type:    "3",

--- a/sdk/config/v1.0-plugin.go
+++ b/sdk/config/v1.0-plugin.go
@@ -62,7 +62,6 @@ func (h *v1PluginConfigHandler) processPluginConfig(v *viper.Viper) (*PluginConf
 
 	// Create a new PluginConfig instance
 	p := &PluginConfig{
-		Name:    v.GetString("name"),
 		Version: v.GetString("version"),
 		Debug:   v.GetBool("debug"),
 		Network: NetworkSettings{
@@ -104,7 +103,7 @@ func (h *v1PluginConfigHandler) processPluginConfig(v *viper.Viper) (*PluginConf
 // setV1Defaults sets default v1 configuration values for a Viper instance.
 func setV1Defaults(v *viper.Viper) {
 	logger.Debugf("Setting v1 Plugin config defaults.")
-	// the "name", "version" and "network" fields are required, so they should
+	// the "version" and "network" fields are required, so they should
 	// not have any default values.
 
 	v.SetDefault("debug", false)

--- a/sdk/config/v1.0-plugin_test.go
+++ b/sdk/config/v1.0-plugin_test.go
@@ -13,8 +13,8 @@ import (
 // TestV1PluginConfigHandlerProcessPluginConfig tests successfully processing
 // a v1 plugin config.
 func TestV1PluginConfigHandlerProcessPluginConfig(t *testing.T) {
-	config := []byte(`version: 1
-name: example
+	config := []byte(`
+version: 1
 debug: true
 network:
   type: unix
@@ -40,7 +40,6 @@ settings:
 	assert.NoError(t, err)
 
 	assert.True(t, cfg.Debug)
-	assert.Equal(t, "example", cfg.Name)
 	assert.Equal(t, "unix", cfg.Network.Type)
 	assert.Equal(t, "example.sock", cfg.Network.Address)
 	assert.Equal(t, "serial", cfg.Settings.Mode)
@@ -58,8 +57,8 @@ settings:
 // TestV1PluginConfigHandlerProcessPluginConfig2 tests unsuccessfully processing
 // a v1 plugin config because the auto-enumerate field is incorrectly specified.
 func TestV1PluginConfigHandlerProcessPluginConfig2(t *testing.T) {
-	config := []byte(`version: 1
-name: example
+	config := []byte(`
+version: 1
 debug: true
 network:
   type: unix
@@ -90,8 +89,8 @@ auto_enumerate: invalid-value`)
 // TestV1PluginConfigHandlerProcessPluginConfig3 tests unsuccessfully processing
 // a v1 plugin config because the context field is incorrectly specified.
 func TestV1PluginConfigHandlerProcessPluginConfig3(t *testing.T) {
-	config := []byte(`version: 1
-name: example
+	config := []byte(`
+version: 1
 debug: true
 network:
   type: unix
@@ -122,8 +121,8 @@ context: invalid-value`)
 // TestV1PluginConfigHandlerProcessPluginConfig4 tests successfully processing
 // a v1 plugin config, when there is a limiter defined.
 func TestV1PluginConfigHandlerProcessPluginConfig4(t *testing.T) {
-	config := []byte(`version: 1
-name: example
+	config := []byte(`
+version: 1
 network:
   type: unix
   address: example.sock
@@ -142,7 +141,6 @@ limiter:
 	assert.NoError(t, err)
 
 	assert.False(t, cfg.Debug)
-	assert.Equal(t, "example", cfg.Name)
 	assert.Equal(t, "unix", cfg.Network.Type)
 	assert.Equal(t, "example.sock", cfg.Network.Address)
 	assert.Equal(t, 10, cfg.Limiter.Burst())
@@ -152,8 +150,8 @@ limiter:
 // TestV1PluginConfigHandlerProcessPluginConfig5 tests successfully processing
 // a v1 plugin config, when there is a limiter defined with a 0-valued rate.
 func TestV1PluginConfigHandlerProcessPluginConfig5(t *testing.T) {
-	config := []byte(`version: 1
-name: example
+	config := []byte(`
+version: 1
 network:
   type: unix
   address: example.sock
@@ -172,7 +170,6 @@ limiter:
 	assert.NoError(t, err)
 
 	assert.False(t, cfg.Debug)
-	assert.Equal(t, "example", cfg.Name)
 	assert.Equal(t, "unix", cfg.Network.Type)
 	assert.Equal(t, "example.sock", cfg.Network.Address)
 	assert.Equal(t, 10, cfg.Limiter.Burst())
@@ -182,8 +179,8 @@ limiter:
 // TestV1PluginConfigHandlerProcessPluginConfig6 tests successfully processing
 // a v1 plugin config, when there is a limiter defined with a 0-valued burst.
 func TestV1PluginConfigHandlerProcessPluginConfig6(t *testing.T) {
-	config := []byte(`version: 1
-name: example
+	config := []byte(`
+version: 1
 network:
   type: unix
   address: example.sock
@@ -202,7 +199,6 @@ limiter:
 	assert.NoError(t, err)
 
 	assert.False(t, cfg.Debug)
-	assert.Equal(t, "example", cfg.Name)
 	assert.Equal(t, "unix", cfg.Network.Type)
 	assert.Equal(t, "example.sock", cfg.Network.Address)
 	assert.Equal(t, 10, cfg.Limiter.Burst()) // this should take the value of the limit
@@ -210,9 +206,9 @@ limiter:
 }
 
 // TestV1PluginConfigHandlerProcessPluginConfig7 tests unsuccessfully processing
-// a v1 plugin config because of validation error on required fields (missing "name" field).
+// a v1 plugin config because of validation error on required fields (missing "version" field).
 func TestV1PluginConfigHandlerProcessPluginConfig7(t *testing.T) {
-	config := []byte(`version: 1
+	config := []byte(`
 network:
   type: unix
   address: example.sock`)

--- a/sdk/data_manager_test.go
+++ b/sdk/data_manager_test.go
@@ -24,7 +24,6 @@ func TestNewDataManager(t *testing.T) {
 	assert.NoError(t, err)
 
 	c := config.PluginConfig{
-		Name:    "test",
 		Version: "test",
 		Network: config.NetworkSettings{
 			Type:    "tcp",
@@ -56,7 +55,6 @@ func TestNewDataManager2(t *testing.T) {
 	assert.NoError(t, err)
 
 	c := &config.PluginConfig{
-		Name:    "test",
 		Version: "test",
 		Network: config.NetworkSettings{
 			Type:    "tcp",
@@ -118,7 +116,6 @@ func TestNewDataManager_NilPluginConfig(t *testing.T) {
 func TestDataManager_WritesEnabled(t *testing.T) {
 	// Create the plugin
 	c := config.PluginConfig{
-		Name:    "test",
 		Version: "test",
 		Network: config.NetworkSettings{
 			Type:    "tcp",
@@ -151,7 +148,6 @@ func TestDataManager_readOneOkNoLimiter(t *testing.T) {
 	// Create the plugin
 	p := Plugin{
 		Config: &config.PluginConfig{
-			Name:    "test",
 			Version: "test",
 			Network: config.NetworkSettings{
 				Type:    "tcp",
@@ -194,7 +190,6 @@ func TestDataManager_readOneOkWithLimiter(t *testing.T) {
 	// Create the plugin
 	p := Plugin{
 		Config: &config.PluginConfig{
-			Name:    "test",
 			Version: "test",
 			Network: config.NetworkSettings{
 				Type:    "tcp",
@@ -237,7 +232,6 @@ func TestDataManager_readOneErr(t *testing.T) {
 	// Create the plugin
 	p := Plugin{
 		Config: &config.PluginConfig{
-			Name:    "test",
 			Version: "test",
 			Network: config.NetworkSettings{
 				Type:    "tcp",
@@ -274,7 +268,6 @@ func TestDataManager_serialReadSingle(t *testing.T) {
 	// Create the plugin
 	p := Plugin{
 		Config: &config.PluginConfig{
-			Name:    "test",
 			Version: "test",
 			Network: config.NetworkSettings{
 				Type:    "tcp",
@@ -321,7 +314,6 @@ func TestDataManager_serialReadSingle(t *testing.T) {
 //	// Create the plugin
 //	p := Plugin{
 //		Config:   &config.PluginConfig{
-//			Name:    "test",
 //			Version: "test",
 //			Network: config.NetworkSettings{
 //				Type:    "tcp",
@@ -391,7 +383,6 @@ func TestDataManager_parallelReadSingle(t *testing.T) {
 	// Create the plugin
 	p := Plugin{
 		Config: &config.PluginConfig{
-			Name:    "test",
 			Version: "test",
 			Network: config.NetworkSettings{
 				Type:    "tcp",
@@ -438,7 +429,6 @@ func TestDataManager_parallelReadSingle(t *testing.T) {
 //	// Create the plugin
 //	p := Plugin{
 //		Config:   &config.PluginConfig{
-//			Name:    "test",
 //			Version: "test",
 //			Network: config.NetworkSettings{
 //				Type:    "tcp",

--- a/sdk/meta.go
+++ b/sdk/meta.go
@@ -1,0 +1,35 @@
+package sdk
+
+import (
+	"github.com/vapor-ware/synse-sdk/sdk/logger"
+)
+
+// metainfo is the global variable that tracks plugin meta-information.
+var metainfo meta
+
+// meta is a struct that holds the meta-information for a plugin.
+type meta struct {
+	Name        string
+	Maintainer  string
+	Description string
+	VCS         string
+}
+
+// log logs out the plugin meta-info at INFO level.
+func (m *meta) log() {
+	logger.Info("Plugin Info:")
+	logger.Infof("  Name:        %s", m.Name)
+	logger.Infof("  Maintainer:  %s", m.Maintainer)
+	logger.Infof("  Description: %s", m.Description)
+	logger.Infof("  VCS:         %s", m.VCS)
+}
+
+// SetPluginMeta sets the meta-information for a plugin.
+func SetPluginMeta(name, maintainer, desc, vcs string) {
+	metainfo = meta{
+		Name:        name,
+		Maintainer:  maintainer,
+		Description: desc,
+		VCS:         vcs,
+	}
+}

--- a/sdk/meta_test.go
+++ b/sdk/meta_test.go
@@ -1,0 +1,27 @@
+package sdk
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSetPluginMeta tests setting the global plugin meta-information.
+func TestSetPluginMeta(t *testing.T) {
+	// Make sure it is empty to begin with
+	assert.IsType(t, meta{}, metainfo)
+	assert.Equal(t, "", metainfo.Name)
+	assert.Equal(t, "", metainfo.Maintainer)
+	assert.Equal(t, "", metainfo.Description)
+	assert.Equal(t, "", metainfo.VCS)
+
+	// Set the metainfo
+	SetPluginMeta("name", "maintainer", "desc", "vcs")
+
+	// Check that it has changed
+	assert.IsType(t, meta{}, metainfo)
+	assert.Equal(t, "name", metainfo.Name)
+	assert.Equal(t, "maintainer", metainfo.Maintainer)
+	assert.Equal(t, "desc", metainfo.Description)
+	assert.Equal(t, "vcs", metainfo.VCS)
+}

--- a/sdk/plugin.go
+++ b/sdk/plugin.go
@@ -298,6 +298,9 @@ func (p *Plugin) setup() error {
 // plugin begins running all of its components.
 func (p *Plugin) logInfo() {
 
+	// Log out the plugin metainfo
+	metainfo.log()
+
 	// Log out the version info
 	versionInfo := GetVersion()
 	versionInfo.Log()

--- a/sdk/plugin_test.go
+++ b/sdk/plugin_test.go
@@ -12,7 +12,6 @@ import (
 
 // File level global test configuration.
 var testConfig = config.PluginConfig{
-	Name:    "test config",
 	Version: "test config v1",
 	Network: config.NetworkSettings{
 		Type:    "tcp",
@@ -58,7 +57,6 @@ func TestNewPluginWithConfig(t *testing.T) {
 
 	// Create a configuration for the Plugin.
 	c := config.PluginConfig{
-		Name:    "test-plugin",
 		Version: "1.0",
 		Network: config.NetworkSettings{
 			Type:    "tcp",
@@ -82,7 +80,6 @@ func TestNewPluginWithIncompleteConfig(t *testing.T) {
 
 	// network spec missing but required
 	c := config.PluginConfig{
-		Name:    "test-plugin",
 		Version: "1.0",
 	}
 
@@ -192,7 +189,7 @@ func TestPlugin_SetConfig2(t *testing.T) {
 	assert.Nil(t, plugin.Config)
 
 	// use an incomplete config
-	err := plugin.SetConfig(&config.PluginConfig{Name: "test", Version: "1"})
+	err := plugin.SetConfig(&config.PluginConfig{Version: "1"})
 	assert.Error(t, err)
 
 	assert.Nil(t, plugin.Config)
@@ -328,7 +325,7 @@ func TestPlugin_logInfo(t *testing.T) {
 // specified via environment variable.
 func TestPlugin_Configure(t *testing.T) {
 	cfgFilePath := "tmp/config.yml"
-	cfg := `name: test-plugin
+	cfg := `
 version: 1.0.0
 debug: true
 network:
@@ -363,7 +360,6 @@ settings:
 	assert.NoError(t, err)
 
 	assert.NotNil(t, p.Config, "plugin is not configured, but should be")
-	assert.Equal(t, "test-plugin", p.Config.Name)
 	assert.Equal(t, "1.0.0", p.Config.Version)
 }
 


### PR DESCRIPTION
fixes #190

This PR takes out the `name` from the config and moves it and other plugin metainfo to a dedicated metainfo struct. This info gets logged out on startup right now. Later, it can be surfaced to synse server via gRPC.