### PR TITLE
Skeleton work for type config, device config, validation, errors

### DIFF
--- a/sdk/cfg/device.go
+++ b/sdk/cfg/device.go
@@ -107,7 +107,7 @@ type LocationData struct {
 
 // Validate validates that the LocationData has no configuration errors.
 func (locData *LocationData) Validate() error {
-	if locData.Name == "" || locData.FromEnv == "" {
+	if locData.Name == "" && locData.FromEnv == "" {
 		return fmt.Errorf("location requires one of 'name' or 'fromEnv' to be specified, but found neither")
 	}
 	value, err := locData.Get()
@@ -185,7 +185,8 @@ type DeviceKind struct {
 // Validate validates that the DeviceKind has no configuration errors.
 func (deviceKind *DeviceKind) Validate() (err error) {
 	if deviceKind.Name == "" {
-		return fmt.Errorf("device kind requires 'name', but is empty")
+		err = fmt.Errorf("device kind requires 'name', but is empty")
+		return
 	}
 
 	// Validate all of the DeviceInstances that the DeviceKind contains.
@@ -200,7 +201,7 @@ func (deviceKind *DeviceKind) Validate() (err error) {
 	for _, output := range deviceKind.Outputs {
 		err = output.Validate()
 		if err != nil {
-			return err
+			return
 		}
 	}
 	return

--- a/sdk/cfg/device.go
+++ b/sdk/cfg/device.go
@@ -31,15 +31,15 @@ TODO:
 type DeviceConfig struct {
 
 	// Version is the version of the configuration scheme.
-	Version ConfigVersion `yaml:"version,omitempty"`
+	Version ConfigVersion `yaml:"version,omitempty" addedIn:"1.0"`
 
 	// Locations are all of the locations that are defined by the configuration
 	// for device instances to reference.
-	Locations []Location `yaml:"locations,omitempty"`
+	Locations []Location `yaml:"locations,omitempty" addedIn:"1.0"`
 
 	// Devices are all of the DeviceKinds (and subsequently, all of the
 	// DeviceInstances) that are defined by the configuration.
-	Devices []DeviceKind `yaml:"devices,omitempty"`
+	Devices []DeviceKind `yaml:"devices,omitempty" addedIn:"1.0"`
 }
 
 // Validate validates that the DeviceConfig has no configuration errors.
@@ -73,9 +73,9 @@ func (deviceConfig *DeviceConfig) Validate() (err error) {
 // DeviceInstances. The locational information defined here is used by Synse
 // Server to route commands to the proper device instance.
 type Location struct {
-	Name  string       `yaml:"name,omitempty"`
-	Rack  LocationData `yaml:"rack,omitempty"`
-	Board LocationData `yaml:"board,omitempty"`
+	Name  string       `yaml:"name,omitempty" addedIn:"1.0"`
+	Rack  LocationData `yaml:"rack,omitempty" addedIn:"1.0"`
+	Board LocationData `yaml:"board,omitempty" addedIn:"1.0"`
 }
 
 // Validate validates that the Location has no configuration errors.
@@ -101,8 +101,8 @@ func (location *Location) Validate() (err error) {
 // The name of a Location component can either be defined directly via the
 // Name field, or from the environment via the FromEnv field.
 type LocationData struct {
-	Name    string `yaml:"name,omitempty"`
-	FromEnv string `yaml:"fromEnv,omitempty"`
+	Name    string `yaml:"name,omitempty" addedIn:"1.0"`
+	FromEnv string `yaml:"fromEnv,omitempty" addedIn:"1.0"`
 }
 
 // Validate validates that the LocationData has no configuration errors.
@@ -161,17 +161,17 @@ type DeviceKind struct {
 	//
 	// There is no limit to the number of namespace elements. The terminating
 	// namespace element should always be the type.
-	Name string `yaml:"name,omitempty"`
+	Name string `yaml:"name,omitempty" addedIn:"1.0"`
 
 	// Metadata contains any metainformation provided for the device. Metadata
 	// does not need to be set for a device, but it is recommended, as it makes
 	// it easier to identify devices to plugin consumers.
 	//
 	// There is no restriction on what data can be supplied as metadata.
-	Metadata map[string]string `yaml:"metadata,omitempty"`
+	Metadata map[string]string `yaml:"metadata,omitempty" addedIn:"1.0"`
 
 	// Instances contains the configuration data for instances of this DeviceKind.
-	Instances []DeviceInstance `yaml:"instances,omitempty"`
+	Instances []DeviceInstance `yaml:"instances,omitempty" addedIn:"1.0"`
 
 	// Outputs describes the reading type outputs provided by instances for this
 	// DeviceKind.
@@ -179,7 +179,7 @@ type DeviceKind struct {
 	// By default, all DeviceInstances for a DeviceKind will inherit these outputs.
 	// This behavior can be changed by setting the DeviceInstance.InheritKindOutputs
 	// flag to false.
-	Outputs []DeviceOutput `yaml:"outputs,omitempty"`
+	Outputs []DeviceOutput `yaml:"outputs,omitempty" addedIn:"1.0"`
 }
 
 // Validate validates that the DeviceKind has no configuration errors.
@@ -210,7 +210,7 @@ func (deviceKind *DeviceKind) Validate() (err error) {
 type DeviceInstance struct {
 	// Info is a string that provides a short human-understandable label, description,
 	// or summary of the device instance.
-	Info string `yaml:"info,omitempty"`
+	Info string `yaml:"info,omitempty" addedIn:"1.0"`
 
 	// Location is a string that references a named location entry from the
 	// "locations" section of the config. It is required, as Synse Server,
@@ -219,16 +219,16 @@ type DeviceInstance struct {
 	//
 	// Note: In future versions of Synse, Location will be deprecated and
 	// replaced with a notion of "tags".
-	Location string `yaml:"location,omitempty"`
+	Location string `yaml:"location,omitempty" addedIn:"1.0"`
 
 	// Data contains any protocol/plugin specific configuration associated
 	// with the device instance.
 	//
 	// It is the responsibility of the plugin to handle these values correctly.
-	Data map[string]interface{} `yaml:"data,omitempty"`
+	Data map[string]interface{} `yaml:"data,omitempty" addedIn:"1.0"`
 
 	// Outputs describes the reading type output provided by this device instance.
-	Outputs []DeviceOutput `yaml:"outputs,omitempty"`
+	Outputs []DeviceOutput `yaml:"outputs,omitempty" addedIn:"1.0"`
 
 	// InheritKindOutputs determines whether the device instance should inherit
 	// the Outputs defined in it's DeviceKind. This should be true by default.
@@ -240,7 +240,7 @@ type DeviceInstance struct {
 	// it simply will not inherit anything.
 	//
 	// If false, this will not inherit any of the DeviceKind's outputs.
-	InheritKindOutputs bool `yaml:"inheritKindOutputs,omitempty"`
+	InheritKindOutputs bool `yaml:"inheritKindOutputs,omitempty" addedIn:"1.0"`
 }
 
 // Validate validates that the DeviceInstance has no configuration errors.
@@ -263,14 +263,14 @@ func (deviceInstance *DeviceInstance) Validate() (err error) {
 type DeviceOutput struct {
 	// Type is the name of the ReadingType that describes the expected output format
 	// for this device output.
-	Type string `yaml:"type,omitempty"`
+	Type string `yaml:"type,omitempty" addedIn:"1.0"`
 
 	// Info is a string that provides a short human-understandable label, description,
 	// or summary of the device output.
 	//
 	// This is optional. If this is not set, the Info from its corresponding
 	// DeviceInstance is used.
-	Info string `yaml:"info,omitempty"`
+	Info string `yaml:"info,omitempty" addedIn:"1.0"`
 
 	// Data contains any protocol/output specific configuration associated with
 	// the device output.
@@ -279,7 +279,7 @@ type DeviceOutput struct {
 	// will remain empty.
 	//
 	// It is the responsibility of the plugin to handle these values correctly.
-	Data map[string]interface{} `yaml:"data,omitempty"`
+	Data map[string]interface{} `yaml:"data,omitempty" addedIn:"1.0"`
 }
 
 // Validate validates that the DeviceOutput has no configuration errors.

--- a/sdk/cfg/device.go
+++ b/sdk/cfg/device.go
@@ -8,7 +8,8 @@ import (
 )
 
 /*
-TODO: some things to do here
+TODO:
+---------------
 - functionality to read in from file
 - functionality for default search paths.. '.', '/synse/etc/config', ...
 
@@ -18,11 +19,19 @@ TODO: some things to do here
 - for validation, consider completely validating before returning an error
   so a user can get a list of all issues at once
 
+- think about having some kind of ConfigContext struct that can be associated
+  with configs.
+	- could describe where the config came from (file, dynamic, env, ...)
+	- could provide info depending on where it came from (which env variable(s), which file, ...)
+
 */
 
 // DeviceConfig holds the configuration for the kinds of devices and the
 // instances of those kinds which a plugin will manage.
 type DeviceConfig struct {
+
+	// Version is the version of the configuration scheme.
+	Version ConfigVersion `yaml:"version,omitempty"`
 
 	// Locations are all of the locations that are defined by the configuration
 	// for device instances to reference.
@@ -37,6 +46,11 @@ type DeviceConfig struct {
 //
 // This is called before Devices are created.
 func (deviceConfig *DeviceConfig) Validate() (err error) {
+	err = deviceConfig.Version.Validate()
+	if err != nil {
+		return
+	}
+
 	// Validate all of the Locations that the DeviceConfig contains.
 	for _, location := range deviceConfig.Locations {
 		err = location.Validate()

--- a/sdk/cfg/device.go
+++ b/sdk/cfg/device.go
@@ -18,6 +18,16 @@ TODO:
 
 - for validation, consider completely validating before returning an error
   so a user can get a list of all issues at once
+	- for this, consider: maybe config components shouldn't recursively validate.
+	  doing so isn't *bad*, but it begs the question of 'where does the multierror
+	  start from'. e.g., here it would be the DeviceConfig, but since these structs
+	  should reallly just be the config scheme and not much else (in terms of fields),
+	  I don't want to add a multierror field there.
+	- what we could do is have Validate only validate that instance (no nesting), e.g.
+	  'is this required field present?'. the Validate function could fulfill an interface.
+	  Then, a separate validator could walk the config and validate. when it comes across
+	  something that fulfills the interface, it validates that too. then the thing doing
+	  the walking can track the multierror.
 
 - think about having some kind of ConfigContext struct that can be associated
   with configs.

--- a/sdk/cfg/device.go
+++ b/sdk/cfg/device.go
@@ -18,8 +18,6 @@ TODO: some things to do here
 - for validation, consider completely validating before returning an error
   so a user can get a list of all issues at once
 
-- for all structs, apply the yaml tag with omitempty? still a bit unclear
-  what omitempty does, but other projects seem to use it a lot.
 */
 
 // DeviceConfig holds the configuration for the kinds of devices and the
@@ -28,11 +26,11 @@ type DeviceConfig struct {
 
 	// Locations are all of the locations that are defined by the configuration
 	// for device instances to reference.
-	Locations []Location
+	Locations []Location `yaml:"locations,omitempty"`
 
 	// Devices are all of the DeviceKinds (and subsequently, all of the
 	// DeviceInstances) that are defined by the configuration.
-	Devices []DeviceKind
+	Devices []DeviceKind `yaml:"devices,omitempty"`
 }
 
 // Validate validates that the DeviceConfig has no configuration errors.
@@ -61,9 +59,9 @@ func (deviceConfig *DeviceConfig) Validate() (err error) {
 // DeviceInstances. The locational information defined here is used by Synse
 // Server to route commands to the proper device instance.
 type Location struct {
-	Name  string
-	Rack  LocationData
-	Board LocationData
+	Name  string       `yaml:"name,omitempty"`
+	Rack  LocationData `yaml:"rack,omitempty"`
+	Board LocationData `yaml:"board,omitempty"`
 }
 
 // Validate validates that the Location has no configuration errors.
@@ -149,17 +147,17 @@ type DeviceKind struct {
 	//
 	// There is no limit to the number of namespace elements. The terminating
 	// namespace element should always be the type.
-	Name string
+	Name string `yaml:"name,omitempty"`
 
 	// Metadata contains any metainformation provided for the device. Metadata
 	// does not need to be set for a device, but it is recommended, as it makes
 	// it easier to identify devices to plugin consumers.
 	//
 	// There is no restriction on what data can be supplied as metadata.
-	Metadata map[string]string
+	Metadata map[string]string `yaml:"metadata,omitempty"`
 
 	// Instances contains the configuration data for instances of this DeviceKind.
-	Instances []DeviceInstance
+	Instances []DeviceInstance `yaml:"instances,omitempty"`
 
 	// Outputs describes the reading type outputs provided by instances for this
 	// DeviceKind.
@@ -167,9 +165,10 @@ type DeviceKind struct {
 	// By default, all DeviceInstances for a DeviceKind will inherit these outputs.
 	// This behavior can be changed by setting the DeviceInstance.InheritKindOutputs
 	// flag to false.
-	Outputs []DeviceOutput
+	Outputs []DeviceOutput `yaml:"outputs,omitempty"`
 }
 
+// Validate validates that the DeviceKind has no configuration errors.
 func (deviceKind *DeviceKind) Validate() (err error) {
 	if deviceKind.Name == "" {
 		return fmt.Errorf("device kind requires 'name', but is empty")
@@ -197,7 +196,7 @@ func (deviceKind *DeviceKind) Validate() (err error) {
 type DeviceInstance struct {
 	// Info is a string that provides a short human-understandable label, description,
 	// or summary of the device instance.
-	Info string
+	Info string `yaml:"info,omitempty"`
 
 	// Location is a string that references a named location entry from the
 	// "locations" section of the config. It is required, as Synse Server,
@@ -206,16 +205,16 @@ type DeviceInstance struct {
 	//
 	// Note: In future versions of Synse, Location will be deprecated and
 	// replaced with a notion of "tags".
-	Location string
+	Location string `yaml:"location,omitempty"`
 
 	// Data contains any protocol/plugin specific configuration associated
 	// with the device instance.
 	//
 	// It is the responsibility of the plugin to handle these values correctly.
-	Data map[string]interface{}
+	Data map[string]interface{} `yaml:"data,omitempty"`
 
 	// Outputs describes the reading type output provided by this device instance.
-	Outputs []DeviceOutput
+	Outputs []DeviceOutput `yaml:"outputs,omitempty"`
 
 	// InheritKindOutputs determines whether the device instance should inherit
 	// the Outputs defined in it's DeviceKind. This should be true by default.
@@ -227,9 +226,10 @@ type DeviceInstance struct {
 	// it simply will not inherit anything.
 	//
 	// If false, this will not inherit any of the DeviceKind's outputs.
-	InheritKindOutputs bool
+	InheritKindOutputs bool `yaml:"inheritKindOutputs,omitempty"`
 }
 
+// Validate validates that the DeviceInstance has no configuration errors.
 func (deviceInstance *DeviceInstance) Validate() (err error) {
 	if deviceInstance.Location == "" {
 		return fmt.Errorf("device kind requires 'location', but is empty")
@@ -249,14 +249,14 @@ func (deviceInstance *DeviceInstance) Validate() (err error) {
 type DeviceOutput struct {
 	// Type is the name of the ReadingType that describes the expected output format
 	// for this device output.
-	Type string
+	Type string `yaml:"type,omitempty"`
 
 	// Info is a string that provides a short human-understandable label, description,
 	// or summary of the device output.
 	//
 	// This is optional. If this is not set, the Info from its corresponding
 	// DeviceInstance is used.
-	Info string
+	Info string `yaml:"info,omitempty"`
 
 	// Data contains any protocol/output specific configuration associated with
 	// the device output.
@@ -265,9 +265,10 @@ type DeviceOutput struct {
 	// will remain empty.
 	//
 	// It is the responsibility of the plugin to handle these values correctly.
-	Data map[string]interface{}
+	Data map[string]interface{} `yaml:"data,omitempty"`
 }
 
+// Validate validates that the DeviceOutput has no configuration errors.
 func (deviceOutput *DeviceOutput) Validate() error {
 	if deviceOutput.Type == "" {
 		return fmt.Errorf("device output requires 'type', but is empty")

--- a/sdk/cfg/device.go
+++ b/sdk/cfg/device.go
@@ -1,0 +1,160 @@
+package cfg
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/vapor-ware/synse-sdk/sdk/logger"
+)
+
+// DeviceConfig holds the configuration for the kinds of devices and the
+// instances of those kinds which a plugin will manage.
+type DeviceConfig struct {
+
+	// Locations are all of the locations that are defined by the configuration
+	// for device instances to reference.
+	Locations []Location
+
+	// Devices are all of the DeviceKinds (and subsequently, all of the
+	// DeviceInstances) that are defined by the configuration.
+	Devices []DeviceKind
+}
+
+// Location defines a location (rack, board) which will be associated with
+// DeviceInstances. The locational information defined here is used by Synse
+// Server to route commands to the proper device instance.
+type Location struct {
+	Name  string
+	Rack  LocationData
+	Board LocationData
+}
+
+// LocationData defines the name of a locational routing component.
+//
+// The name of a Location component can either be defined directly via the
+// Name field, or from the environment via the FromEnv field.
+type LocationData struct {
+	Name    string `yaml:"name,omitempty"`
+	FromEnv string `yaml:"fromEnv,omitempty"`
+}
+
+// Get returns the resolved location data.
+//
+// This is the preferred method of getting the location component value.
+func (locData *LocationData) Get() (string, error) {
+	var location string
+
+	if locData.Name != "" {
+		location = locData.Name
+	}
+
+	if locData.FromEnv != "" {
+		// If we already have the location info from the Name field, we
+		// will not resolve the FromEnv field and will log out a warning.
+		if location != "" {
+			logger.Warnf("location fields 'fromEnv' and 'name' are both specified, ignoring 'fromEnv': %+v", locData)
+		} else {
+			l, ok := os.LookupEnv(locData.FromEnv)
+			if !ok {
+				return "", fmt.Errorf("no value found for location data from env: %s", locData.FromEnv)
+			}
+			location = l
+		}
+	}
+	return location, nil
+}
+
+// DeviceKind is a kind of device that it being defined.
+//
+// DeviceKinds are configured as elements of a list under the  "devices" field
+// of a DeviceConfig.
+type DeviceKind struct {
+	// Name is the fully qualified name of the device.
+	//
+	// The Name of a DeviceKind minimally describes the type of the device, e.g.
+	// "temperature". To avoid collisions with DeviceKinds of potentially similar
+	// or identical types, the name can be namespaced using '.' as the delimiter,
+	// e.g. "foo.temperature".
+	//
+	// There is no limit to the number of namespace elements. The terminating
+	// namespace element should always be the type.
+	Name string
+
+	// Metadata contains any metainformation provided for the device. Metadata
+	// does not need to be set for a device, but it is recommended, as it makes
+	// it easier to identify devices to plugin consumers.
+	//
+	// There is no restriction on what data can be supplied as metadata.
+	Metadata map[string]string
+
+	// Instances contains the configuration data for instances of this DeviceKind.
+	Instances []DeviceInstance
+
+	// Outputs describes the reading type outputs provided by instances for this
+	// DeviceKind.
+	//
+	// By default, all DeviceInstances for a DeviceKind will inherit these outputs.
+	// This behavior can be changed by setting the DeviceInstance.InheritKindOutputs
+	// flag to false.
+	Outputs []DeviceOutput
+}
+
+// DeviceInstance describes an individual instance of a given DeviceKind.
+type DeviceInstance struct {
+	// Info is a string that provides a short human-understandable label, description,
+	// or summary of the device instance.
+	Info string
+
+	// Location is a string that references a named location entry from the
+	// "locations" section of the config. It is required, as Synse Server,
+	// the consumer of the plugins, routes requests based on this locational
+	// information.
+	//
+	// Note: In future versions of Synse, Location will be deprecated and
+	// replaced with a notion of "tags".
+	Location string
+
+	// Data contains any protocol/plugin specific configuration associated
+	// with the device instance.
+	//
+	// It is the responsibility of the plugin to handle these values correctly.
+	Data map[string]interface{}
+
+	// Outputs describes the reading type output provided by this device instance.
+	Outputs []DeviceOutput
+
+	// InheritKindOutputs determines whether the device instance should inherit
+	// the Outputs defined in it's DeviceKind. This should be true by default.
+	//
+	// If this is true, it will inherit all outputs defined by its DeviceKind.
+	// If it specifies an output of the same type, the one defined by the
+	// DeviceInstance will override the one defined by the DeviceKind, for the
+	// DeviceInstance. If the DeviceKind has no outputs defined and this is true,
+	// it simply will not inherit anything.
+	//
+	// If false, this will not inherit any of the DeviceKind's outputs.
+	InheritKindOutputs bool
+}
+
+// DeviceOutput describes a valid output for the DeviceInstance.
+type DeviceOutput struct {
+	// Info is a string that provides a short human-understandable label, description,
+	// or summary of the device output.
+	//
+	// This is optional. If this is not set, the Info from its corresponding
+	// DeviceInstance is used.
+	Info string
+
+	// Type is the name of the ReadingType that describes the expected output format
+	// for this device output.
+	Type string
+
+	// Data contains any protocol/output specific configuration associated with
+	// the device output.
+	//
+	// Not all device outputs will need their own configuration, in which case, this
+	// will remain empty.
+	//
+	// It is the responsibility of the plugin to handle these values correctly.
+	Data map[string]interface{}
+}

--- a/sdk/cfg/device_test.go
+++ b/sdk/cfg/device_test.go
@@ -1,0 +1,441 @@
+package cfg
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestDeviceConfig_Validate_Ok tests validating a DeviceConfig with no errors.
+func TestDeviceConfig_Validate_Ok(t *testing.T) {
+	var testTable = []struct {
+		desc   string
+		config DeviceConfig
+	}{
+		{
+			desc: "DeviceConfig has valid version",
+			config: DeviceConfig{
+				Version: ConfigVersion{Version: "1.0"},
+			},
+		},
+		{
+			desc: "DeviceConfig has valid version and location",
+			config: DeviceConfig{
+				Version:   ConfigVersion{Version: "1.0"},
+				Locations: []Location{{Name: "test", Rack: LocationData{Name: "test"}, Board: LocationData{Name: "test"}}},
+			},
+		},
+		{
+			desc: "DeviceConfig has valid version, location, and DeviceKind",
+			config: DeviceConfig{
+				Version:   ConfigVersion{Version: "1.0"},
+				Locations: []Location{{Name: "test", Rack: LocationData{Name: "test"}, Board: LocationData{Name: "test"}}},
+				Devices:   []DeviceKind{{Name: "test"}},
+			},
+		},
+	}
+
+	for _, testCase := range testTable {
+		err := testCase.config.Validate()
+		assert.NoError(t, err, testCase.desc)
+	}
+}
+
+// TestDeviceConfig_Validate_Error tests validating a DeviceConfig with errors.
+func TestDeviceConfig_Validate_Error(t *testing.T) {
+	var testTable = []struct {
+		desc   string
+		config DeviceConfig
+	}{
+		{
+			desc: "DeviceConfig has invalid version",
+			config: DeviceConfig{
+				Version: ConfigVersion{Version: "abc"},
+			},
+		},
+		{
+			desc: "DeviceConfig has invalid Locations",
+			config: DeviceConfig{
+				Version:   ConfigVersion{Version: "1.0"},
+				Locations: []Location{{Name: ""}},
+			},
+		},
+		{
+			desc: "DeviceConfig has invalid DeviceKinds",
+			config: DeviceConfig{
+				Version:   ConfigVersion{Version: "1.0"},
+				Locations: []Location{{Name: "test", Rack: LocationData{Name: "test"}, Board: LocationData{Name: "test"}}},
+				Devices:   []DeviceKind{{Name: ""}},
+			},
+		},
+	}
+
+	for _, testCase := range testTable {
+		err := testCase.config.Validate()
+		assert.Error(t, err, testCase.desc)
+	}
+}
+
+// TestLocation_Validate_Ok tests validating a Location with no errors.
+func TestLocation_Validate_Ok(t *testing.T) {
+	var testTable = []struct {
+		desc     string
+		location Location
+	}{
+		{
+			desc: "Valid Location instance",
+			location: Location{
+				Name:  "test",
+				Rack:  LocationData{Name: "test"},
+				Board: LocationData{Name: "test"},
+			},
+		},
+	}
+
+	for _, testCase := range testTable {
+		err := testCase.location.Validate()
+		assert.NoError(t, err, testCase.desc)
+	}
+}
+
+// TestLocation_Validate_Error tests validating a Location with errors.
+func TestLocation_Validate_Error(t *testing.T) {
+	var testTable = []struct {
+		desc     string
+		location Location
+	}{
+		{
+			desc: "Location requires a name, but has none",
+			location: Location{
+				Rack:  LocationData{Name: "test"},
+				Board: LocationData{Name: "test"},
+			},
+		},
+		{
+			desc: "Location requires a rack, but has none",
+			location: Location{
+				Name:  "test",
+				Board: LocationData{Name: "test"},
+			},
+		},
+		{
+			desc: "Location requires a board, but has none",
+			location: Location{
+				Name: "test",
+				Rack: LocationData{Name: "test"},
+			},
+		},
+		{
+			desc: "Location both rack and board, has neither",
+			location: Location{
+				Name: "test",
+			},
+		},
+		{
+			desc: "Location has an invalid rack",
+			location: Location{
+				Rack:  LocationData{Name: ""},
+				Board: LocationData{Name: "test"},
+			},
+		},
+		{
+			desc: "Location has an invalid board",
+			location: Location{
+				Rack:  LocationData{Name: "test"},
+				Board: LocationData{Name: ""},
+			},
+		},
+	}
+
+	for _, testCase := range testTable {
+		err := testCase.location.Validate()
+		assert.Error(t, err, testCase.desc)
+	}
+}
+
+// TestLocationData_Validate_Ok tests validating a LocationData with no errors.
+func TestLocationData_Validate_Ok(t *testing.T) {
+	var testTable = []struct {
+		desc         string
+		locationData LocationData
+	}{
+		{
+			desc:         "LocationData has a valid name",
+			locationData: LocationData{Name: "test"},
+		},
+		{
+			desc:         "LocationData has a valid fromEnv",
+			locationData: LocationData{FromEnv: "TEST_ENV"},
+		},
+		{
+			desc:         "LocationData has both name and fromEnv",
+			locationData: LocationData{Name: "foo", FromEnv: "TEST_ENV"},
+		},
+	}
+
+	err := os.Setenv("TEST_ENV", "test")
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		err := os.Unsetenv("TEST_ENV")
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	for _, testCase := range testTable {
+		err := testCase.locationData.Validate()
+		assert.NoError(t, err, testCase.desc)
+	}
+}
+
+// TestLocationData_Validate_Error tests validating a LocationData with errors.
+func TestLocationData_Validate_Error(t *testing.T) {
+	var testTable = []struct {
+		desc         string
+		locationData LocationData
+	}{
+		{
+			desc:         "LocationData has no fromEnv or name",
+			locationData: LocationData{},
+		},
+		{
+			desc:         "LocationData fromEnv does not resolve",
+			locationData: LocationData{FromEnv: "FOO_BAR_BAZ"},
+		},
+	}
+
+	for _, testCase := range testTable {
+		err := testCase.locationData.Validate()
+		assert.Error(t, err, testCase.desc)
+	}
+}
+
+// TestLocationData_Get_Ok tests getting the locational data with no errors.
+func TestLocationData_Get_Ok(t *testing.T) {
+	var testTable = []struct {
+		desc         string
+		locationData LocationData
+		expected     string
+	}{
+		{
+			desc:         "LocationData has a valid name",
+			locationData: LocationData{Name: "test"},
+			expected:     "test",
+		},
+		{
+			desc:         "LocationData has a valid fromEnv",
+			locationData: LocationData{FromEnv: "TEST_ENV"},
+			expected:     "foo",
+		},
+		{
+			desc:         "LocationData has both name and fromEnv (should take name)",
+			locationData: LocationData{Name: "test", FromEnv: "TEST_ENV"},
+			expected:     "test",
+		},
+		{
+			desc:         "LocationData has no fromEnv or name",
+			locationData: LocationData{},
+			expected:     "",
+		},
+	}
+
+	err := os.Setenv("TEST_ENV", "foo")
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		err := os.Unsetenv("TEST_ENV")
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	for _, testCase := range testTable {
+		actual, err := testCase.locationData.Get()
+		assert.NoError(t, err, testCase.desc)
+		assert.Equal(t, testCase.expected, actual, testCase.desc)
+	}
+}
+
+// TestLocationData_Get_Error tests getting the location data with errors.
+func TestLocationData_Get_Error(t *testing.T) {
+	var testTable = []struct {
+		desc         string
+		locationData LocationData
+	}{
+		{
+			desc:         "LocationData fromEnv does not resolve",
+			locationData: LocationData{FromEnv: "FOO_BAR_BAZ"},
+		},
+	}
+
+	for _, testCase := range testTable {
+		actual, err := testCase.locationData.Get()
+		assert.Error(t, err, testCase.desc)
+		assert.Equal(t, "", actual, testCase.desc)
+	}
+}
+
+// TestDeviceKind_Validate_Ok tests validating a DeviceKind with no errors.
+func TestDeviceKind_Validate_Ok(t *testing.T) {
+	var testTable = []struct {
+		desc string
+		kind DeviceKind
+	}{
+		{
+			desc: "DeviceKind has a valid name",
+			kind: DeviceKind{
+				Name: "test",
+			},
+		},
+		{
+			desc: "DeviceKind has a valid name and instances",
+			kind: DeviceKind{
+				Name:      "test",
+				Instances: []DeviceInstance{{Location: "test"}},
+			},
+		},
+		{
+			desc: "DeviceKind has a valid name, instances, and outputs",
+			kind: DeviceKind{
+				Name:      "test",
+				Instances: []DeviceInstance{{Location: "test"}},
+				Outputs:   []DeviceOutput{{Type: "test"}},
+			},
+		},
+	}
+
+	for _, testCase := range testTable {
+		err := testCase.kind.Validate()
+		assert.NoError(t, err, testCase.desc)
+	}
+}
+
+// TestDeviceKind_Validate_Error tests validating a DeviceKind with errors.
+func TestDeviceKind_Validate_Error(t *testing.T) {
+	var testTable = []struct {
+		desc string
+		kind DeviceKind
+	}{
+		{
+			desc: "DeviceKind has no name specified",
+			kind: DeviceKind{},
+		},
+		{
+			desc: "DeviceKind has invalid instances",
+			kind: DeviceKind{
+				Name:      "test",
+				Instances: []DeviceInstance{{Location: ""}},
+			},
+		},
+		{
+			desc: "DeviceKind has invalid outputs",
+			kind: DeviceKind{
+				Name:    "test",
+				Outputs: []DeviceOutput{{Type: ""}},
+			},
+		},
+	}
+
+	for _, testCase := range testTable {
+		err := testCase.kind.Validate()
+		assert.Error(t, err, testCase.desc)
+	}
+}
+
+// TestDeviceInstance_Validate_Ok tests validating a DeviceInstance with no errors.
+func TestDeviceInstance_Validate_Ok(t *testing.T) {
+	var testTable = []struct {
+		desc     string
+		instance DeviceInstance
+	}{
+		{
+			desc: "DeviceInstance has a valid location",
+			instance: DeviceInstance{
+				Location: "test",
+			},
+		},
+		{
+			desc: "DeviceInstance has a valid location and outputs",
+			instance: DeviceInstance{
+				Location: "test",
+				Outputs:  []DeviceOutput{{Type: "test"}},
+			},
+		},
+	}
+
+	for _, testCase := range testTable {
+		err := testCase.instance.Validate()
+		assert.NoError(t, err, testCase.desc)
+	}
+}
+
+// TestDeviceInstance_Validate_Error tests validating a DeviceInstance with errors.
+func TestDeviceInstance_Validate_Error(t *testing.T) {
+	var testTable = []struct {
+		desc     string
+		instance DeviceInstance
+	}{
+		{
+			desc: "DeviceInstance has a no location",
+			instance: DeviceInstance{
+				Location: "",
+			},
+		},
+		{
+			desc: "DeviceInstance has invalid outputs",
+			instance: DeviceInstance{
+				Location: "test",
+				Outputs:  []DeviceOutput{{Type: ""}},
+			},
+		},
+	}
+
+	for _, testCase := range testTable {
+		err := testCase.instance.Validate()
+		assert.Error(t, err, testCase.desc)
+	}
+}
+
+// TestDeviceOutput_Validate_Ok tests validating a DeviceOutput with no errors.
+func TestDeviceOutput_Validate_Ok(t *testing.T) {
+	var testTable = []struct {
+		desc   string
+		output DeviceOutput
+	}{
+		{
+			desc: "DeviceOutput has valid type",
+			output: DeviceOutput{
+				Type: "test",
+			},
+		},
+	}
+
+	for _, testCase := range testTable {
+		err := testCase.output.Validate()
+		assert.NoError(t, err, testCase.desc)
+	}
+}
+
+// TestDeviceOutput_Validate_Error tests validating a DeviceOutput with errors.
+func TestDeviceOutput_Validate_Error(t *testing.T) {
+	var testTable = []struct {
+		desc   string
+		output DeviceOutput
+	}{
+		{
+			desc: "DeviceOutput has no type",
+			output: DeviceOutput{
+				Type: "",
+			},
+		},
+	}
+
+	for _, testCase := range testTable {
+		err := testCase.output.Validate()
+		assert.Error(t, err, testCase.desc)
+	}
+}

--- a/sdk/cfg/plugin.go
+++ b/sdk/cfg/plugin.go
@@ -1,0 +1,1 @@
+package cfg

--- a/sdk/cfg/validation.go
+++ b/sdk/cfg/validation.go
@@ -1,0 +1,128 @@
+package cfg
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/vapor-ware/synse-sdk/sdk/logger"
+)
+
+/*
+TODO:
+---------------
+- implement util for annotating struct fields with version info
+- implement something to walk a struct and:
+	- get the config version.
+		- if no version, use the latest version
+	- validate that the version is supported
+	- go through all fields/sub-fields of the config struct
+		- check if a value is present
+			- if so, get the version tags, we should support: addedIn, deprecatedIn, removedIn
+				- check if the scheme version is out of bounds for any of
+				  those constraints. If so, log/error.
+			- if not, move on
+*/
+
+func ValidateFieldsForVersion(version *SchemeVersion, config interface{}) error {
+	cfg := reflect.ValueOf(config)
+
+	if cfg.Kind() != reflect.Ptr {
+		return fmt.Errorf("field validation: config struct must specified as a pointer")
+	}
+
+	v := cfg.Elem()
+	t := v.Type()
+	return walkStructFields(version, v, t)
+
+}
+
+func walkStructFields(version *SchemeVersion, v reflect.Value, t reflect.Type) error {
+	for i := 0; i < t.NumField(); i++ {
+		field := v.Field(i)
+		typeField := t.Field(i)
+
+		// --- Break this out into its own function -------
+
+		// We should only care about validation if the field is set.
+		if !isEmptyValue(field) {
+			// Check the "addedIn" tag
+			tag := typeField.Tag.Get(tagAddedIn)
+			if tag != "" {
+				addedInScheme, err := NewSchemeVersion(tag)
+				if err != nil {
+					return err
+				}
+				// FIXME - perhaps an IsLessThan() function would be better
+				if version.Compare(addedInScheme) == LessThan {
+					return fmt.Errorf("field not supported: '%v'. added in: %v, config version: %v", typeField.Name, addedInScheme.String(), version.String())
+				}
+			}
+
+			// Check the "deprecatedIn" tag
+			tag = typeField.Tag.Get(tagDeprecatedIn)
+			if tag != "" {
+				deprecatedInScheme, err := NewSchemeVersion(tag)
+				if err != nil {
+					return err
+				}
+				// FIXME - perhaps an IsGreaterOrEqaul() function would be better
+				cmp := version.Compare(deprecatedInScheme)
+				if cmp == GreaterThan || cmp == EqualTo {
+					// FIXME - this should be a warning. need to figure out how best to return
+					// all errors/all warnings for validation methods
+					return fmt.Errorf("field deprecated: '%v'. deprecated in: %v, config version: %v", typeField.Name, deprecatedInScheme.String(), version.String())
+				}
+			}
+
+			// Check the "removedIn" tag
+			tag = typeField.Tag.Get(tagRemovedIn)
+			if tag != "" {
+				removedInScheme, err := NewSchemeVersion(tag)
+				if err != nil {
+					return err
+				}
+				// FIXME - perhaps an IsGreaterOrEqaul() function would be better
+				cmp := version.Compare(removedInScheme)
+				if cmp == GreaterThan || cmp == EqualTo {
+					// FIXME - this should be a warning. need to figure out how best to return
+					// all errors/all warnings for validation methods
+					return fmt.Errorf("field not supported: '%v'. removed in: %v, config version: %v", typeField.Name, removedInScheme.String(), version.String())
+				}
+			}
+		}
+
+		// ------- END break --------
+
+		// For any nested types, go through and validate those as well.
+		switch field.Kind() {
+		case reflect.Struct:
+			// TODO
+		case reflect.Slice:
+			// TODO
+		case reflect.Ptr:
+			// TODO
+		}
+
+	}
+	return nil
+}
+
+func isEmptyValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Ptr:
+		return v.IsNil()
+	default:
+		logger.Warn("No case for empty value check: %v", v.Kind())
+	}
+	return false
+}

--- a/sdk/cfg/validation.go
+++ b/sdk/cfg/validation.go
@@ -109,7 +109,7 @@ func (validator *SchemeValidator) walkStructFields(v reflect.Value) {
 
 // validateField validates that a field of a struct is valid for the config's
 // version scheme.
-func (validator *SchemeValidator) validateField(field reflect.Value, structField reflect.StructField) {
+func (validator *SchemeValidator) validateField(field reflect.Value, structField reflect.StructField) { // nolint: gocyclo
 	version := validator.Version
 
 	// We should only care about validation if the field is set.

--- a/sdk/cfg/validation.go
+++ b/sdk/cfg/validation.go
@@ -7,107 +7,124 @@ import (
 	"github.com/vapor-ware/synse-sdk/sdk/logger"
 )
 
-/*
-TODO:
----------------
-- implement util for annotating struct fields with version info
-- implement something to walk a struct and:
-	- get the config version.
-		- if no version, use the latest version
-	- validate that the version is supported
-	- go through all fields/sub-fields of the config struct
-		- check if a value is present
-			- if so, get the version tags, we should support: addedIn, deprecatedIn, removedIn
-				- check if the scheme version is out of bounds for any of
-				  those constraints. If so, log/error.
-			- if not, move on
-*/
-
-func ValidateFieldsForVersion(version *SchemeVersion, config interface{}) error {
-	cfg := reflect.ValueOf(config)
-
-	if cfg.Kind() != reflect.Ptr {
-		return fmt.Errorf("field validation: config struct must specified as a pointer")
-	}
-
-	v := cfg.Elem()
-	t := v.Type()
-	return walkStructFields(version, v, t)
-
+// SchemeValidator is used to validate the scheme of a config.
+type SchemeValidator struct {
+	Version *SchemeVersion
 }
 
-func walkStructFields(version *SchemeVersion, v reflect.Value, t reflect.Type) error {
-	for i := 0; i < t.NumField(); i++ {
-		field := v.Field(i)
-		typeField := t.Field(i)
+// NewSchemeValidator creates a new instance of a SchemeValidator for the
+// specified SchemeVersion.
+func NewSchemeValidator(version *SchemeVersion) *SchemeValidator {
+	return &SchemeValidator{
+		Version: version,
+	}
+}
 
-		// --- Break this out into its own function -------
+func (validator *SchemeValidator) ValidateConfig(config interface{}) error {
+	cfg := reflect.ValueOf(config)
+	if cfg.Kind() != reflect.Ptr {
+		return fmt.Errorf("field validation: config stcut must be specified as a pointer")
+	}
+	return validator.walk(cfg.Elem())
+}
 
-		// We should only care about validation if the field is set.
-		if !isEmptyValue(field) {
-			// Check the "addedIn" tag
-			tag := typeField.Tag.Get(tagAddedIn)
-			if tag != "" {
-				addedInScheme, err := NewSchemeVersion(tag)
-				if err != nil {
-					return err
-				}
-				// FIXME - perhaps an IsLessThan() function would be better
-				if version.Compare(addedInScheme) == LessThan {
-					return fmt.Errorf("field not supported: '%v'. added in: %v, config version: %v", typeField.Name, addedInScheme.String(), version.String())
-				}
-			}
-
-			// Check the "deprecatedIn" tag
-			tag = typeField.Tag.Get(tagDeprecatedIn)
-			if tag != "" {
-				deprecatedInScheme, err := NewSchemeVersion(tag)
-				if err != nil {
-					return err
-				}
-				// FIXME - perhaps an IsGreaterOrEqaul() function would be better
-				cmp := version.Compare(deprecatedInScheme)
-				if cmp == GreaterThan || cmp == EqualTo {
-					// FIXME - this should be a warning. need to figure out how best to return
-					// all errors/all warnings for validation methods
-					return fmt.Errorf("field deprecated: '%v'. deprecated in: %v, config version: %v", typeField.Name, deprecatedInScheme.String(), version.String())
-				}
-			}
-
-			// Check the "removedIn" tag
-			tag = typeField.Tag.Get(tagRemovedIn)
-			if tag != "" {
-				removedInScheme, err := NewSchemeVersion(tag)
-				if err != nil {
-					return err
-				}
-				// FIXME - perhaps an IsGreaterOrEqaul() function would be better
-				cmp := version.Compare(removedInScheme)
-				if cmp == GreaterThan || cmp == EqualTo {
-					// FIXME - this should be a warning. need to figure out how best to return
-					// all errors/all warnings for validation methods
-					return fmt.Errorf("field not supported: '%v'. removed in: %v, config version: %v", typeField.Name, removedInScheme.String(), version.String())
-				}
-			}
+func (validator *SchemeValidator) walk(v reflect.Value) error {
+	switch v.Kind() {
+	case reflect.Struct:
+		err := validator.walkStructFields(v)
+		if err != nil {
+			return err
 		}
 
-		// ------- END break --------
-
-		// For any nested types, go through and validate those as well.
-		switch field.Kind() {
-		case reflect.Struct:
-			// TODO
-		case reflect.Slice:
-			// TODO
-		case reflect.Ptr:
-			// TODO
+	case reflect.Slice:
+		for i := 0; i < v.Len(); i++ {
+			err := validator.walk(v.Index(i))
+			if err != nil {
+				return err
+			}
 		}
-
 	}
 	return nil
 }
 
-func isEmptyValue(v reflect.Value) bool {
+func (validator *SchemeValidator) walkStructFields(v reflect.Value) error {
+	t := v.Type()
+	for i := 0; i < t.NumField(); i++ {
+		field := v.Field(i)
+		structField := t.Field(i)
+
+		err := validator.validateField(field, structField)
+		if err != nil {
+			return err
+		}
+
+		// Try to walk through this field. If it is any nested type,
+		// it will go through and validate, otherwise it will return
+		// with no error.
+		err = validator.walk(field)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (validator *SchemeValidator) validateField(field reflect.Value, structField reflect.StructField) error {
+
+	version := validator.Version
+
+	// We should only care about validation if the field is set.
+	if !validator.isEmptyValue(field) {
+		// Check the "addedIn" tag
+		tag := structField.Tag.Get(tagAddedIn)
+		if tag != "" {
+			addedInScheme, err := NewSchemeVersion(tag)
+			if err != nil {
+				return err
+			}
+			// FIXME - perhaps an IsLessThan() function would be better
+			if version.Compare(addedInScheme) == LessThan {
+				return fmt.Errorf("field not supported: '%v'. added in: %v, config version: %v", structField.Name, addedInScheme.String(), version.String())
+			}
+		}
+
+		// Check the "deprecatedIn" tag
+		tag = structField.Tag.Get(tagDeprecatedIn)
+		if tag != "" {
+			deprecatedInScheme, err := NewSchemeVersion(tag)
+			if err != nil {
+				return err
+			}
+			// FIXME - perhaps an IsGreaterOrEqaul() function would be better
+			cmp := version.Compare(deprecatedInScheme)
+			if cmp == GreaterThan || cmp == EqualTo {
+				// FIXME - this should be a warning. need to figure out how best to return
+				// all errors/all warnings for validation methods
+				return fmt.Errorf("field deprecated: '%v'. deprecated in: %v, config version: %v", structField.Name, deprecatedInScheme.String(), version.String())
+			}
+		}
+
+		// Check the "removedIn" tag
+		tag = structField.Tag.Get(tagRemovedIn)
+		if tag != "" {
+			removedInScheme, err := NewSchemeVersion(tag)
+			if err != nil {
+				return err
+			}
+			// FIXME - perhaps an IsGreaterOrEqaul() function would be better
+			cmp := version.Compare(removedInScheme)
+			if cmp == GreaterThan || cmp == EqualTo {
+				// FIXME - this should be a warning. need to figure out how best to return
+				// all errors/all warnings for validation methods
+				return fmt.Errorf("field not supported: '%v'. removed in: %v, config version: %v", structField.Name, removedInScheme.String(), version.String())
+			}
+		}
+	}
+	return nil
+}
+
+// isEmptyValue checks if a value is its empty type.
+func (validator *SchemeValidator) isEmptyValue(v reflect.Value) bool {
 	switch v.Kind() {
 	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
 		return v.Len() == 0

--- a/sdk/cfg/versioning.go
+++ b/sdk/cfg/versioning.go
@@ -93,9 +93,6 @@ type ConfigVersion struct {
 	// Version is the config version scheme specified in the config file.
 	Version string
 
-	// file is the path of the file that the version was read from.
-	file string
-
 	// scheme is the SchemeVersion that represents the ConfigVersion's Version.
 	scheme *SchemeVersion
 }

--- a/sdk/cfg/versioning.go
+++ b/sdk/cfg/versioning.go
@@ -1,11 +1,160 @@
 package cfg
 
-// configVersion is a struct that is used to extract the configuration
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Comparison is a type that represents the result of a comparison between
+// two SchemeVersions.
+type Comparison uint8
+
+const (
+	LessThan Comparison = iota
+	EqualTo
+	GreaterThan
+)
+
+const (
+	tagAddedIn      = "addedIn"
+	tagDeprecatedIn = "deprecatedIn"
+	tagRemovedIn    = "removedIn"
+)
+
+// SchemeVersion is a representation of a configuration scheme version
+// that can be compared to other SchemeVersions.
+type SchemeVersion struct {
+	Major int
+	Minor int
+}
+
+// NewSchemeVersion creates a new instance of a SchemeVersion.
+func NewSchemeVersion(versionString string) (*SchemeVersion, error) {
+	var min, maj int
+	var err error
+
+	if versionString == "" {
+		return nil, fmt.Errorf("no version info found")
+	}
+
+	s := strings.Split(versionString, ".")
+	if len(s) == 1 {
+		maj, err = strconv.Atoi(s[0])
+		if err != nil {
+			return nil, err
+		}
+		min = 0
+	} else {
+		maj, err = strconv.Atoi(s[0])
+		if err != nil {
+			return nil, err
+		}
+		min, err = strconv.Atoi(s[1])
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &SchemeVersion{
+		Major: maj,
+		Minor: min,
+	}, nil
+}
+
+// String returns a string representation of the scheme version.
+func (schemeVersion *SchemeVersion) String() string {
+	return fmt.Sprintf("%d.%d", schemeVersion.Major, schemeVersion.Minor)
+}
+
+// Compare compares a SchemeVersion with another SchemeVersion.
+//
+// If this SchemeVersion has a greater version number than the provided
+// one, GreaterThan is returned. If they are equal versions, EqualTo is
+// returned. If it is a lower version, LessThan is returned.
+func (schemeVersion *SchemeVersion) Compare(other *SchemeVersion) Comparison {
+	if schemeVersion.Major > other.Major {
+		return GreaterThan
+	}
+
+	if schemeVersion.Major < other.Major {
+		return LessThan
+	}
+
+	if schemeVersion.Minor > other.Minor {
+		return GreaterThan
+	}
+
+	if schemeVersion.Minor < other.Minor {
+		return LessThan
+	}
+	return EqualTo
+}
+
+// ConfigVersion is a struct that is used to extract the configuration
 // scheme version from any config file.
-type configVersion struct {
+type ConfigVersion struct {
 	// Version is the config version scheme specified in the config file.
 	Version string
 
 	// file is the path of the file that the version was read from.
 	file string
+
+	// scheme is the SchemeVersion that represents the ConfigVersion's Version.
+	scheme *SchemeVersion
+}
+
+// parseScheme parses the Version field into a SchemeVersion.
+func (configVersion *ConfigVersion) parseScheme() (err error) {
+	var min, maj int
+
+	if configVersion.Version == "" {
+		return fmt.Errorf("no version info found")
+	}
+
+	s := strings.Split(configVersion.Version, ".")
+	if len(s) == 1 {
+		maj, err = strconv.Atoi(s[0])
+		if err != nil {
+			return
+		}
+		min = 0
+	} else {
+		maj, err = strconv.Atoi(s[0])
+		if err != nil {
+			return
+		}
+		min, err = strconv.Atoi(s[1])
+		if err != nil {
+			return
+		}
+	}
+
+	configVersion.scheme = &SchemeVersion{
+		Major: maj,
+		Minor: min,
+	}
+	return nil
+}
+
+// Validate validates that the ConfigVersion has no configuration errors.
+func (configVersion *ConfigVersion) Validate() error {
+	v, err := NewSchemeVersion(configVersion.Version)
+	if err != nil {
+		return err
+	}
+	configVersion.scheme = v
+	return nil
+}
+
+// GetSchemeVersion gets the SchemeVersion associated with the version specified
+// in the configuration.
+func (configVersion *ConfigVersion) GetSchemeVersion() (*SchemeVersion, error) {
+	if configVersion.scheme == nil {
+		err := configVersion.parseScheme()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return configVersion.scheme, nil
 }

--- a/sdk/cfg/versioning.go
+++ b/sdk/cfg/versioning.go
@@ -1,0 +1,11 @@
+package cfg
+
+// configVersion is a struct that is used to extract the configuration
+// scheme version from any config file.
+type configVersion struct {
+	// Version is the config version scheme specified in the config file.
+	Version string
+
+	// file is the path of the file that the version was read from.
+	file string
+}

--- a/sdk/cfg/versioning.go
+++ b/sdk/cfg/versioning.go
@@ -6,16 +6,6 @@ import (
 	"strings"
 )
 
-// Comparison is a type that represents the result of a comparison between
-// two SchemeVersions.
-type Comparison uint8
-
-const (
-	LessThan Comparison = iota
-	EqualTo
-	GreaterThan
-)
-
 const (
 	tagAddedIn      = "addedIn"
 	tagDeprecatedIn = "deprecatedIn"
@@ -67,28 +57,34 @@ func (schemeVersion *SchemeVersion) String() string {
 	return fmt.Sprintf("%d.%d", schemeVersion.Major, schemeVersion.Minor)
 }
 
-// Compare compares a SchemeVersion with another SchemeVersion.
-//
-// If this SchemeVersion has a greater version number than the provided
-// one, GreaterThan is returned. If they are equal versions, EqualTo is
-// returned. If it is a lower version, LessThan is returned.
-func (schemeVersion *SchemeVersion) Compare(other *SchemeVersion) Comparison {
-	if schemeVersion.Major > other.Major {
-		return GreaterThan
-	}
-
+// IsLessThan returns true if the SchemeVersion is less than the SchemeVersion
+// provided as a parameter.
+func (schemeVersion *SchemeVersion) IsLessThan(other *SchemeVersion) bool {
 	if schemeVersion.Major < other.Major {
-		return LessThan
+		return true
 	}
+	if schemeVersion.Major == other.Major && schemeVersion.Minor < other.Minor {
+		return true
+	}
+	return false
+}
 
-	if schemeVersion.Minor > other.Minor {
-		return GreaterThan
+// IsGreaterOrEqualTo returns true if the SchemeVersion is greater than or equal to
+// the SchemeVersion provided as a parameter.
+func (schemeVersion *SchemeVersion) IsGreaterOrEqualTo(other *SchemeVersion) bool {
+	if schemeVersion.Major > other.Major {
+		return true
 	}
+	if schemeVersion.Major == other.Major && schemeVersion.Minor >= other.Minor {
+		return true
+	}
+	return false
+}
 
-	if schemeVersion.Minor < other.Minor {
-		return LessThan
-	}
-	return EqualTo
+// IsEqual returns true if the SchemeVersion is equal to the SchemeVersion provided
+// as a parameter.
+func (schemeVersion *SchemeVersion) IsEqual(other *SchemeVersion) bool {
+	return schemeVersion.Major == other.Major && schemeVersion.Minor == other.Minor
 }
 
 // ConfigVersion is a struct that is used to extract the configuration

--- a/sdk/errors/errors.go
+++ b/sdk/errors/errors.go
@@ -1,0 +1,59 @@
+package errors
+
+import (
+	"bytes"
+	"fmt"
+)
+
+/*
+TODO:
+----------------
+- add error types for validation errors
+*/
+
+
+// MultiError is a collection of errors that also fulfills the error interface.
+//
+// It can be used to aggregate errors and then return them all at once.
+type MultiError struct {
+	// Errors is a the collection of errors that the MultiError keeps track of.
+	Errors []error
+
+	// For is a string that describes the process/function that the MultiError
+	// is used for. This is optional.
+	For string
+}
+
+// NewMultiError creates a new instance of a MultiError.
+func NewMultiError(source string) *MultiError {
+	return &MultiError{
+		Errors: []error{},
+		For: source,
+	}
+}
+
+// Add adds an error to the MultiError.
+func (err *MultiError) Add(e error) {
+	err.Errors = append(err.Errors, e)
+}
+
+// Error returns the error string
+func (err MultiError) Error() string {
+	if len(err.Errors) == 0 {
+		return ""
+	}
+
+	src := err.For
+	if src == "" {
+		src = "unspecified"
+	}
+
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "MultiError has %d error(s) for source: %s\n", len(err.Errors), src)
+
+	for _, err := range err.Errors {
+		fmt.Fprintf(&buf, "%s\n", err.Error())
+	}
+
+	return buf.String()
+}

--- a/sdk/errors/errors.go
+++ b/sdk/errors/errors.go
@@ -61,10 +61,10 @@ func (err MultiError) Error() string {
 	}
 
 	var buf bytes.Buffer
-	fmt.Fprintf(&buf, "MultiError has %d error(s) for source: %s\n", len(err.Errors), src)
+	fmt.Fprintf(&buf, "MultiError has %d error(s) for source: %s\n", len(err.Errors), src) // nolint: gas
 
 	for _, err := range err.Errors {
-		fmt.Fprintf(&buf, "%s\n", err.Error())
+		fmt.Fprintf(&buf, "%s\n", err.Error()) // nolint: gas
 	}
 
 	return buf.String()

--- a/sdk/errors/errors.go
+++ b/sdk/errors/errors.go
@@ -11,7 +11,6 @@ TODO:
 - add error types for validation errors
 */
 
-
 // MultiError is a collection of errors that also fulfills the error interface.
 //
 // It can be used to aggregate errors and then return them all at once.
@@ -28,8 +27,21 @@ type MultiError struct {
 func NewMultiError(source string) *MultiError {
 	return &MultiError{
 		Errors: []error{},
-		For: source,
+		For:    source,
 	}
+}
+
+// Err returns the MultiError if any errors exist. Otherwise, it returns nil.
+func (err *MultiError) Err() error {
+	if err.HasErrors() {
+		return err
+	}
+	return nil
+}
+
+// HasErrors checks to see if the MultiError is tracking any errors.
+func (err *MultiError) HasErrors() bool {
+	return len(err.Errors) != 0
 }
 
 // Add adds an error to the MultiError.

--- a/sdk/errors/errors_test.go
+++ b/sdk/errors/errors_test.go
@@ -1,0 +1,140 @@
+package errors
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"fmt"
+)
+
+// TestNewMultiError tests creating a new instance of a MultiError.
+func TestNewMultiError(t *testing.T) {
+	var testTable = []struct{
+		desc string
+		source string
+	}{
+		{
+			desc: "The source is unspecified",
+			source: "",
+		},
+		{
+			desc: "The source is a simple string",
+			source: "test",
+		},
+		{
+			desc: "The source is a long string",
+			source: "a long and complex description of the error source",
+		},
+	}
+
+	for _, testCase := range testTable {
+		merr := NewMultiError(testCase.source)
+		assert.IsType(t, &MultiError{}, merr, testCase.desc)
+		assert.Equal(t, testCase.source, merr.For, testCase.desc)
+		assert.Equal(t, 0, len(merr.Errors), testCase.desc)
+	}
+}
+
+// TestMultiError_Error tests getting the error string from a MultiError.
+func TestMultiError_Error(t *testing.T) {
+	var testTable = []struct{
+		desc string
+		source string
+		errs []error
+		expected string
+	}{
+		{
+			desc: "MultiError has no errors",
+			source: "test",
+			errs: []error{},
+			expected: "",
+		},
+		{
+			desc: "MultiError has 1 error, no source",
+			source: "",
+			errs: []error{
+				fmt.Errorf("error 1"),
+			},
+			expected: "MultiError has 1 error(s) for source: unspecified\nerror 1\n",
+		},
+		{
+			desc: "MultiError has 1 error, with source",
+			source: "test",
+			errs: []error{
+				fmt.Errorf("error 1"),
+			},
+			expected: "MultiError has 1 error(s) for source: test\nerror 1\n",
+		},
+		{
+			desc: "MultiError has multiple errors, no source",
+			source: "",
+			errs: []error{
+				fmt.Errorf("error 1"),
+				fmt.Errorf("error 2"),
+				fmt.Errorf("error 3"),
+			},
+			expected: "MultiError has 3 error(s) for source: unspecified\nerror 1\nerror 2\nerror 3\n",
+		},
+		{
+			desc: "MultiError has multiple errors, with source",
+			source: "test",
+			errs: []error{
+				fmt.Errorf("error 1"),
+				fmt.Errorf("error 2"),
+				fmt.Errorf("error 3"),
+			},
+			expected: "MultiError has 3 error(s) for source: test\nerror 1\nerror 2\nerror 3\n",
+		},
+	}
+
+	for _, testCase := range testTable {
+		merr := MultiError{
+			Errors: testCase.errs,
+			For: testCase.source,
+		}
+
+		errStr := merr.Error()
+		assert.Equal(t, testCase.expected, errStr, testCase.desc)
+	}
+}
+
+// TestMultiError_Add tests adding errors to the MultiError
+func TestMultiError_Add(t *testing.T) {
+	var testTable = []struct{
+		desc string
+		toAdd []error
+		expectedLen int
+	}{
+		{
+			desc: "Add no errors to a MultiError",
+			toAdd: []error{},
+			expectedLen: 0,
+		},
+		{
+			desc: "Add one error to a MultiError",
+			toAdd: []error{
+				fmt.Errorf("error 1"),
+			},
+			expectedLen: 1,
+		},
+		{
+			desc: "Add multiple errors to a MultiError",
+			toAdd: []error{
+				fmt.Errorf("error 1"),
+				fmt.Errorf("error 2"),
+				fmt.Errorf("error 3"),
+			},
+			expectedLen: 3,
+		},
+	}
+
+	for _, testCase := range testTable {
+		merr := NewMultiError("test")
+
+		assert.Equal(t, 0, len(merr.Errors), "MultiError should be initialized with no errors")
+		for _, e := range testCase.toAdd {
+			merr.Add(e)
+		}
+		assert.Equal(t, testCase.expectedLen, len(merr.Errors), testCase.desc)
+	}
+}

--- a/sdk/errors/errors_test.go
+++ b/sdk/errors/errors_test.go
@@ -3,26 +3,27 @@ package errors
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"fmt"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // TestNewMultiError tests creating a new instance of a MultiError.
 func TestNewMultiError(t *testing.T) {
-	var testTable = []struct{
-		desc string
+	var testTable = []struct {
+		desc   string
 		source string
 	}{
 		{
-			desc: "The source is unspecified",
+			desc:   "The source is unspecified",
 			source: "",
 		},
 		{
-			desc: "The source is a simple string",
+			desc:   "The source is a simple string",
 			source: "test",
 		},
 		{
-			desc: "The source is a long string",
+			desc:   "The source is a long string",
 			source: "a long and complex description of the error source",
 		},
 	}
@@ -37,20 +38,20 @@ func TestNewMultiError(t *testing.T) {
 
 // TestMultiError_Error tests getting the error string from a MultiError.
 func TestMultiError_Error(t *testing.T) {
-	var testTable = []struct{
-		desc string
-		source string
-		errs []error
+	var testTable = []struct {
+		desc     string
+		source   string
+		errs     []error
 		expected string
 	}{
 		{
-			desc: "MultiError has no errors",
-			source: "test",
-			errs: []error{},
+			desc:     "MultiError has no errors",
+			source:   "test",
+			errs:     []error{},
 			expected: "",
 		},
 		{
-			desc: "MultiError has 1 error, no source",
+			desc:   "MultiError has 1 error, no source",
 			source: "",
 			errs: []error{
 				fmt.Errorf("error 1"),
@@ -58,7 +59,7 @@ func TestMultiError_Error(t *testing.T) {
 			expected: "MultiError has 1 error(s) for source: unspecified\nerror 1\n",
 		},
 		{
-			desc: "MultiError has 1 error, with source",
+			desc:   "MultiError has 1 error, with source",
 			source: "test",
 			errs: []error{
 				fmt.Errorf("error 1"),
@@ -66,7 +67,7 @@ func TestMultiError_Error(t *testing.T) {
 			expected: "MultiError has 1 error(s) for source: test\nerror 1\n",
 		},
 		{
-			desc: "MultiError has multiple errors, no source",
+			desc:   "MultiError has multiple errors, no source",
 			source: "",
 			errs: []error{
 				fmt.Errorf("error 1"),
@@ -76,7 +77,7 @@ func TestMultiError_Error(t *testing.T) {
 			expected: "MultiError has 3 error(s) for source: unspecified\nerror 1\nerror 2\nerror 3\n",
 		},
 		{
-			desc: "MultiError has multiple errors, with source",
+			desc:   "MultiError has multiple errors, with source",
 			source: "test",
 			errs: []error{
 				fmt.Errorf("error 1"),
@@ -90,7 +91,7 @@ func TestMultiError_Error(t *testing.T) {
 	for _, testCase := range testTable {
 		merr := MultiError{
 			Errors: testCase.errs,
-			For: testCase.source,
+			For:    testCase.source,
 		}
 
 		errStr := merr.Error()
@@ -100,14 +101,14 @@ func TestMultiError_Error(t *testing.T) {
 
 // TestMultiError_Add tests adding errors to the MultiError
 func TestMultiError_Add(t *testing.T) {
-	var testTable = []struct{
-		desc string
-		toAdd []error
+	var testTable = []struct {
+		desc        string
+		toAdd       []error
 		expectedLen int
 	}{
 		{
-			desc: "Add no errors to a MultiError",
-			toAdd: []error{},
+			desc:        "Add no errors to a MultiError",
+			toAdd:       []error{},
 			expectedLen: 0,
 		},
 		{
@@ -136,5 +137,89 @@ func TestMultiError_Add(t *testing.T) {
 			merr.Add(e)
 		}
 		assert.Equal(t, testCase.expectedLen, len(merr.Errors), testCase.desc)
+	}
+}
+
+// TestMultiError_HasErrors tests checking whether or not a MultiError has errors specified.
+func TestMultiError_HasErrors(t *testing.T) {
+	var testTable = []struct {
+		desc     string
+		expected bool
+		errors   []error
+	}{
+		{
+			desc:     "No errors",
+			expected: false,
+			errors:   []error{},
+		},
+		{
+			desc:     "Has one error",
+			expected: true,
+			errors: []error{
+				fmt.Errorf("error 1"),
+			},
+		},
+		{
+			desc:     "Has multiple errors",
+			expected: true,
+			errors: []error{
+				fmt.Errorf("error 1"),
+				fmt.Errorf("error 2"),
+				fmt.Errorf("error 3"),
+			},
+		},
+	}
+
+	for _, testCase := range testTable {
+		merr := MultiError{
+			Errors: testCase.errors,
+		}
+		actual := merr.HasErrors()
+		assert.Equal(t, testCase.expected, actual, testCase.desc)
+	}
+}
+
+// TestMultiError_Err tests getting an error return from the MultiError.
+func TestMultiError_Err(t *testing.T) {
+	var testTable = []struct {
+		desc    string
+		isError bool
+		errors  []error
+	}{
+		{
+			desc:    "No errors, should return nil",
+			isError: false,
+			errors:  []error{},
+		},
+		{
+			desc:    "Has one error, should return MultiError",
+			isError: true,
+			errors: []error{
+				fmt.Errorf("error 1"),
+			},
+		},
+		{
+			desc:    "Has multiple errors, should return MultiError",
+			isError: true,
+			errors: []error{
+				fmt.Errorf("error 1"),
+				fmt.Errorf("error 2"),
+				fmt.Errorf("error 3"),
+			},
+		},
+	}
+
+	for _, testCase := range testTable {
+		merr := MultiError{
+			Errors: testCase.errors,
+		}
+		err := merr.Err()
+
+		if testCase.isError {
+			assert.Error(t, err, testCase.desc)
+			assert.IsType(t, &MultiError{}, err, testCase.desc)
+		} else {
+			assert.NoError(t, err, testCase.desc)
+		}
 	}
 }

--- a/sdk/types/type.go
+++ b/sdk/types/type.go
@@ -1,5 +1,7 @@
 package types
 
+import "strings"
+
 // ReadingType provides information about the type of a device reading.
 type ReadingType struct {
 	// Name is the name of the reading type. Each reading type
@@ -28,6 +30,17 @@ type ReadingType struct {
 	// supported. This can be the value itself, e.g. "0.01", or
 	// a mathematical representation of the value, e.g. "1e-2".
 	ScalingFactor string
+}
+
+// Type gets the type of the reading. This is encoded in the ReadingType
+// name. If the ReadingType is namespaced, this will be the last element
+// of the namespace. If it is not namespaced, it will be the name itself.
+func (readingType *ReadingType) Type() string {
+	if strings.Contains(readingType.Name, ".") {
+		nameSpace := strings.Split(readingType.Name, ".")
+		return nameSpace[len(nameSpace)-1]
+	}
+	return readingType.Name
 }
 
 // ReadingUnit is the unit of measure for a device reading.

--- a/sdk/types/type.go
+++ b/sdk/types/type.go
@@ -1,0 +1,40 @@
+package types
+
+// ReadingType provides information about the type of a device reading.
+type ReadingType struct {
+	// Name is the name of the reading type. Each reading type
+	// should have a unique name. Names can be namespaced with
+	// '.' as the delimiter.
+	Name string
+
+	// DataType is the type of the reading data. This should be one of:
+	// float64, float32, float (alias for float64),
+	// int64, int32, int, uint64, uint32, bool, string, bytes
+	DataType string
+
+	// Precision is the number of decimal places to round to.
+	// This is only used when the type is a float-type.
+	Precision int
+
+	// Unit is the unit of measure for the reading.
+	Unit ReadingUnit
+
+	// ScalingFactor is an optional value by which to scale the
+	// reading. This is useful when a device returns reading data
+	// that must be scaled.
+	//
+	// This value should resolve to a numeric. By default, it will
+	// have a value of 1. Negative values and fractional values are
+	// supported. This can be the value itself, e.g. "0.01", or
+	// a mathematical representation of the value, e.g. "1e-2".
+	ScalingFactor string
+}
+
+// ReadingUnit is the unit of measure for a device reading.
+type ReadingUnit struct {
+	// Name is the full name of the unit.
+	Name string
+
+	// Symbol is the symbolic representation of the unit.
+	Symbol string
+}

--- a/sdk/types/type.go
+++ b/sdk/types/type.go
@@ -1,6 +1,18 @@
 package types
 
-import "strings"
+import (
+	"strings"
+)
+
+/*
+TODO:
+- function(s) for proper type casting
+- function(s) for applying scaling factor
+- function for parsing scaling factor
+- function for applying precision
+- functionality for reading in from YAML
+ */
+
 
 // ReadingType provides information about the type of a device reading.
 type ReadingType struct {

--- a/sdk/types/type.go
+++ b/sdk/types/type.go
@@ -11,8 +11,7 @@ TODO:
 - function for parsing scaling factor
 - function for applying precision
 - functionality for reading in from YAML
- */
-
+*/
 
 // ReadingType provides information about the type of a device reading.
 type ReadingType struct {

--- a/sdk/types/type_test.go
+++ b/sdk/types/type_test.go
@@ -9,20 +9,20 @@ import (
 // TestReadingType_Type tests getting the type of the reading
 // from the namespaced ReadingType name.
 func TestReadingType_Type(t *testing.T) {
-	var testTable = []struct{
-		name string
+	var testTable = []struct {
+		name     string
 		expected string
 	}{
 		{
-			name: "foo",
+			name:     "foo",
 			expected: "foo",
 		},
 		{
-			name: "foo.bar",
+			name:     "foo.bar",
 			expected: "bar",
 		},
 		{
-			name: "test.device.sample.temperature",
+			name:     "test.device.sample.temperature",
 			expected: "temperature",
 		},
 	}

--- a/sdk/types/type_test.go
+++ b/sdk/types/type_test.go
@@ -1,0 +1,34 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestReadingType_Type tests getting the type of the reading
+// from the namespaced ReadingType name.
+func TestReadingType_Type(t *testing.T) {
+	var testTable = []struct{
+		name string
+		expected string
+	}{
+		{
+			name: "foo",
+			expected: "foo",
+		},
+		{
+			name: "foo.bar",
+			expected: "bar",
+		},
+		{
+			name: "test.device.sample.temperature",
+			expected: "temperature",
+		},
+	}
+
+	for _, tc := range testTable {
+		readingType := ReadingType{Name: tc.name}
+		assert.Equal(t, tc.expected, readingType.Type())
+	}
+}


### PR DESCRIPTION
This PR adds in some skeleton work for a bunch of different components. There is quite a bit of scope creep in this PR, but its difficult to develop all components independently, so its just a fact of life here. 

This is still not complete and needs quite a bit of work, but it lays down a solid foundation. In doing this work, a bunch of other issues/work items came up -- GH issues will be opened for them as appropriate.

Note that all the config stuff here was added into a new `cfg` package. This will ultimately be moved back into the `config` package when this stuff is stable and ready.