### PR TITLE
Updates to the plugin configuration

### DIFF
--- a/sdk/cfg/config.go
+++ b/sdk/cfg/config.go
@@ -43,9 +43,14 @@ func NewConfigContext(source string, config ConfigBase) *ConfigContext {
 	}
 }
 
-// IsDeviceConfig checks whether the config in this context
-// is a DeviceConfig.
+// IsDeviceConfig checks whether the config in this context is a DeviceConfig.
 func (ctx *ConfigContext) IsDeviceConfig() bool {
 	_, ok := ctx.Config.(*DeviceConfig)
+	return ok
+}
+
+// IsPluginConfig checks whether the config in the context is a PluginConfig.
+func (ctx *ConfigContext) IsPluginConfig() bool {
+	_, ok := ctx.Config.(*PluginConfig)
 	return ok
 }

--- a/sdk/cfg/config.go
+++ b/sdk/cfg/config.go
@@ -1,12 +1,16 @@
 package cfg
 
+import (
+	"github.com/vapor-ware/synse-sdk/sdk/errors"
+)
+
 // ConfigComponent is an interface that all structs that define configuration
 // components should implement.
 //
 // This interface implements a Validate function which is used by the
 // SchemeValidator in order to validate each struct that makes up a configuration.
 type ConfigComponent interface {
-	Validate() error
+	Validate(*errors.MultiError)
 }
 
 // ConfigBase is an interface that the base configuration struct should

--- a/sdk/cfg/config_test.go
+++ b/sdk/cfg/config_test.go
@@ -1,0 +1,95 @@
+package cfg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestNewConfigContext tests creating a new ConfigContext.
+func TestNewConfigContext(t *testing.T) {
+	var testTable = []struct {
+		desc   string
+		source string
+		config ConfigBase
+	}{
+		{
+			desc:   "Config is a pointer to a DeviceConfig",
+			source: "test",
+			config: &DeviceConfig{},
+		},
+		{
+			desc:   "Config is a pointer to a PluginConfig",
+			source: "test",
+			config: &PluginConfig{},
+		},
+	}
+
+	for _, testCase := range testTable {
+		ctx := NewConfigContext(testCase.source, testCase.config)
+		assert.NotNil(t, ctx, testCase.desc)
+		assert.IsType(t, &ConfigContext{}, ctx, testCase.desc)
+		assert.Equal(t, testCase.source, ctx.Source, testCase.desc)
+		assert.Equal(t, testCase.config, ctx.Config, testCase.desc)
+	}
+}
+
+// TestConfigContext_IsDeviceConfig tests whether the Config member is a DeviceConfig.
+func TestConfigContext_IsDeviceConfig(t *testing.T) {
+	var testTable = []struct {
+		desc     string
+		isDevCfg bool
+		config   ConfigBase
+	}{
+		{
+			desc:     "Config is a pointer to a DeviceConfig",
+			isDevCfg: true,
+			config:   &DeviceConfig{},
+		},
+		{
+			desc:     "Config is a pointer to a PluginConfig",
+			isDevCfg: false,
+			config:   &PluginConfig{},
+		},
+	}
+
+	for _, testCase := range testTable {
+		ctx := ConfigContext{
+			Source: "test",
+			Config: testCase.config,
+		}
+
+		actual := ctx.IsDeviceConfig()
+		assert.Equal(t, testCase.isDevCfg, actual, testCase.desc)
+	}
+}
+
+// TestConfigContext_IsPluginConfig tests whether the Config member is a PluginConfig.
+func TestConfigContext_IsPluginConfig(t *testing.T) {
+	var testTable = []struct {
+		desc        string
+		isPluginCfg bool
+		config      ConfigBase
+	}{
+		{
+			desc:        "Config is a pointer to a DeviceConfig",
+			isPluginCfg: false,
+			config:      &DeviceConfig{},
+		},
+		{
+			desc:        "Config is a pointer to a PluginConfig",
+			isPluginCfg: true,
+			config:      &PluginConfig{},
+		},
+	}
+
+	for _, testCase := range testTable {
+		ctx := ConfigContext{
+			Source: "test",
+			Config: testCase.config,
+		}
+
+		actual := ctx.IsPluginConfig()
+		assert.Equal(t, testCase.isPluginCfg, actual, testCase.desc)
+	}
+}

--- a/sdk/cfg/device.go
+++ b/sdk/cfg/device.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/vapor-ware/synse-sdk/sdk/logger"
 	"github.com/vapor-ware/synse-sdk/sdk/errors"
+	"github.com/vapor-ware/synse-sdk/sdk/logger"
 )
 
 // DeviceConfig holds the configuration for the kinds of devices and the

--- a/sdk/cfg/plugin.go
+++ b/sdk/cfg/plugin.go
@@ -1,1 +1,264 @@
 package cfg
+
+import (
+	"time"
+
+	"github.com/vapor-ware/synse-sdk/sdk/errors"
+)
+
+const (
+	modeSerial = "serial"
+	modeParallel = "parallel"
+)
+
+// PluginConfig contains the configuration options for the plugin.
+type PluginConfig struct {
+
+	// ConfigVersion is the version of the configuration scheme.
+	ConfigVersion
+
+	// Debug is a flag that determines whether the plugin should run
+	// with debug logging or not.
+	Debug bool `yaml:"debug,omitempty" addedIn:"1.0"`
+
+	// Settings provide specifications for how the plugin should run.
+	Settings *PluginSettings `yaml:"settings,omitempty" addedIn:"1.0"`
+
+	// Network specifies the networking configuration for the plugin.
+	Network *NetworkSettings `yaml:"network,omitempty" addedIn:"1.0"`
+
+	// DynamicRegistration specifies configuration settings and data
+	// for how the plugin should handle dynamic device registration.
+	DynamicRegistration *DynamicRegistrationSettings `yaml:"dynamicRegistration,omitempty" addedIn:"1.0"`
+
+	// Limiter specifies settings for a rate limiter for reads/writes.
+	Limiter *LimiterSettings `yaml:"limiter,omitempty" addedIn:"1.0"`
+
+	// Context is a map that allows the plugin to specify any arbitrary
+	// data it may need.
+	Context map[string]interface{} `yaml:"context,omitempty" addedIn:"1.0"`
+}
+
+// Validate validates that the PluginConfig has no configuration errors.
+func (config *PluginConfig) Validate(multiErr *errors.MultiError) {
+	// A version must be specified and it must be of the correct format.
+	_, err := config.GetSchemeVersion()
+	if err != nil {
+		multiErr.Add(errors.NewValidationError(multiErr.Context["source"], err.Error()))
+	}
+
+	// If network is nil or an empty struct, error. We need to know how
+	// the plugin should communicate with Synse Server.
+	if config.Network == nil || config.Network == (&NetworkSettings{}) {
+		multiErr.Add(errors.NewFieldRequiredError(multiErr.Context["source"], "network"))
+	}
+}
+
+// PluginSettings specifies the configuration options that determine the
+// runtime behavior of the plugin.
+type PluginSettings struct {
+	// Mode is the run mode of the read and write loops. This can either
+	// be "serial" or "parallel".
+	Mode string `yaml:"mode,omitempty" addedIn:"1.0"`
+
+	// Read contains the settings to configure read behavior.
+	Read ReadSettings `yaml:"read,omitempty" addedIn:"1.0"`
+
+	// Write contains the settings to configure write behavior.
+	Write WriteSettings `yaml:"write,omitempty" addedIn:"1.0"`
+
+	// Transaction contains the settings to configure transaction
+	// handling behavior.
+	Transaction TransactionSettings `yaml:"transaction,omitempty" addedIn:"1.0"`
+}
+
+// Validate validates that the PluginSettings has no configuration errors.
+func (settings *PluginSettings) Validate(multiErr *errors.MultiError) {
+	if settings.Mode != modeSerial && settings.Mode != modeParallel {
+		multiErr.Add(errors.NewInvalidValueError(
+			multiErr.Context["source"],
+			"settings.mode",
+			"one of: serial, parallel",
+		))
+	}
+}
+
+// IsSerial checks if the PluginSettings is configured with mode "serial".
+func (settings *PluginSettings) IsSerial() bool {
+	return settings.Mode == modeSerial
+}
+
+// IsParallel checks if the PluginSettings is configured with mode "parallel".
+func (settings *PluginSettings) IsParallel() bool {
+	return settings.Mode == modeParallel
+}
+
+// NetworkSettings specifies the configuration options around the gRPC
+// server's networking behavior.
+type NetworkSettings struct {
+	// Type is the type of networking. Currently, this must be one of
+	// "tcp" (TCP/IP) or "unix" (Unix Socket)
+	Type string `yaml:"type,omitempty" addedIn:"1.0"`
+
+	// Address is the address to communicate over. For "tcp", this would
+	// be the host/port (e.g. 0.0.0.0:50001). For "unix", this would be
+	// the name of the unix socket (e.g. plugin.sock).
+	Address string `yaml:"address,omitempty" addedIn:"1.0"`
+}
+
+// Validate validates that the NetworkSettings has no configuration errors.
+func (settings *NetworkSettings) Validate(multiErr *errors.MultiError) {
+	if settings.Type == "" {
+		multiErr.Add(errors.NewFieldRequiredError(multiErr.Context["source"], "network.type"))
+	}
+	if settings.Address == "" {
+		multiErr.Add(errors.NewFieldRequiredError(multiErr.Context["source"], "network.address"))
+	}
+}
+
+// DynamicRegistrationSettings specifies configuration and data for
+// the dynamic registration of devices.
+type DynamicRegistrationSettings struct {
+}
+
+// Validate validates that the DynamicRegistrationSettings has no configuration errors.
+func (settings *DynamicRegistrationSettings) Validate(multiErr *errors.MultiError) {
+	// todo
+}
+
+// LimiterSettings specifies configurations for a rate limiter on reads
+// and writes.
+type LimiterSettings struct {
+	// Rate is the limit, or maximum frequency of events. A rate of
+	// 0 signifies 'unlimited'.
+	Rate int `yaml:"rate,omitempty" addedIn:"1.0"`
+
+	// Burst defines the bucket size for the limiter, or maximum number
+	// of events that can be fulfilled at once. If this is 0, it will take
+	// the same value as the rate.
+	Burst int `yaml:"burst,omitempty" addedIn:"1.0"`
+}
+
+// Validate validates that the LimiterSettings has no configuration errors.
+func (settings *LimiterSettings) Validate(multiErr *errors.MultiError) {
+	// Nothing to validate.
+}
+
+// ReadSettings provides configuration options for read operations.
+type ReadSettings struct {
+	// Enabled globally enables or disables reading for the plugin.
+	// By default, a plugin will have reading enabled.
+	Enabled bool `yaml:"enabled,omitempty" addedIn:"1.0"`
+
+	// Interval specifies the interval at which devices should be
+	// read from. This is 1s by default.
+	Interval string `yaml:"interval,omitempty" addedIn:"1.0"`
+
+	// Buffer defines the size of the read buffer. This will be
+	// the size of the channel that passes along read responses.
+	Buffer int `yaml:"buffer,omitempty" addedIn:"1.0"`
+}
+
+// Validate validates that the ReadSettings has no configuration errors.
+func (settings *ReadSettings) Validate(multiErr *errors.MultiError) {
+	// Try parsing the interval to validate it is a correctly specified
+	// duration string.
+	_, err := settings.GetInterval()
+	if err != nil {
+		multiErr.Add(errors.NewValidationError(multiErr.Context["source"], err.Error()))
+	}
+
+	// If the buffer size is set to 0, return an error. Previously, this
+	// was allowed, as a size of 0 could indicate "no read", but now we
+	// have the 'enabled' field, so we don't need to support this.
+	if settings.Buffer <= 0 {
+		multiErr.Add(errors.NewInvalidValueError(
+			multiErr.Context["source"],
+			"settings.read.buffer",
+			"a value greater than 0",
+		))
+	}
+}
+
+// GetInterval gets the read interval as a duration. If the config
+// has been validated successfully, this should never return an error.
+func (settings *ReadSettings) GetInterval() (time.Duration, error) {
+	return time.ParseDuration(settings.Interval)
+}
+
+// WriteSettings provides configuration options for write operations.
+type WriteSettings struct {
+	// Enabled globally enables or disables writing for the plugin.
+	// By default, a plugin will have writing enabled.
+	Enabled bool `yaml:"enabled,omitempty" addedIn:"1.0"`
+
+	// Interval specifies the interval at which devices should be
+	// written to. This is 1s by default.
+	Interval string `yaml:"interval,omitempty" addedIn:"1.0"`
+
+	// Buffer defines the size of the write buffer. This will be
+	// the size of the channel that passes along write requests.
+	Buffer int `yaml:"buffer,omitempty" addedIn:"1.0"`
+
+	// Max is the maximum number of write transactions to process
+	// in a single batch. In general, this can tune performance when
+	// running in serial mode.
+	Max int `yaml:"max,omitempty" addedIn:"1.0"`
+}
+
+// Validate validates that the WriteSettings has no configuration errors.
+func (settings *WriteSettings) Validate(multiErr *errors.MultiError) {
+	// Try parsing the interval to validate it is a correctly specified
+	// duration string.
+	_, err := settings.GetInterval()
+	if err != nil {
+		multiErr.Add(errors.NewValidationError(multiErr.Context["source"], err.Error()))
+	}
+
+	// If the buffer size is set to 0, return an error. Previously, this
+	// was allowed, as a size of 0 could indicate "no write", but now we
+	// have the 'enabled' field, so we don't need to support this.
+	if settings.Buffer <= 0 {
+		multiErr.Add(errors.NewInvalidValueError(
+			multiErr.Context["source"],
+			"settings.write.buffer",
+			"a value greater than 0",
+		))
+	}
+
+	if settings.Max <= 0 {
+		multiErr.Add(errors.NewInvalidValueError(
+			multiErr.Context["source"],
+			"settings.write.max",
+			"a value greater than 0",
+		))
+	}
+}
+
+// GetInterval gets the write interval as a duration. If the config
+// has been validated successfully, this should never return an error.
+func (settings *WriteSettings) GetInterval() (time.Duration, error) {
+	return time.ParseDuration(settings.Interval)
+}
+
+// TransactionSettings provides configuration options for transaction operations.
+type TransactionSettings struct {
+	// TTL is the time-to-live for a transaction in the transaction cache.
+	TTL string `yaml:"ttl,omitempty" addedIn:"1.0"`
+}
+
+// Validate validates that the TransactionSettings has no configuration errors.
+func (settings *TransactionSettings) Validate(multiErr *errors.MultiError) {
+	// Try parsing the interval to validate it is a correctly specified
+	// duration string.
+	_, err := settings.GetTTL()
+	if err != nil {
+		multiErr.Add(errors.NewValidationError(multiErr.Context["source"], err.Error()))
+	}
+}
+
+// GetTTL gets the transaction TTL as a duration. If the config has been
+// validated successfully, this should never return an error.
+func (settings *TransactionSettings) GetTTL() (time.Duration, error) {
+	return time.ParseDuration(settings.TTL)
+}

--- a/sdk/cfg/reader.go
+++ b/sdk/cfg/reader.go
@@ -11,10 +11,9 @@ import (
 )
 
 var (
-	// TODO: use this once plugin configs are added/updated
 	// pluginConfigSearchPaths define the search paths, in order of evaluation,
 	// that are used when looking for the plugin configuration file.
-	//pluginConfigSearchPaths = []string{".", "./config", "/etc/synse/plugin/config"}
+	pluginConfigSearchPaths = []string{".", "./config", "/etc/synse/plugin/config"}
 
 	// deviceConfigSearchPaths define the search paths, in order of evaluation,
 	// that are used when looking for device configuration files.

--- a/sdk/errors/errors.go
+++ b/sdk/errors/errors.go
@@ -5,12 +5,6 @@ import (
 	"fmt"
 )
 
-/*
-TODO:
-----------------
-- add error types for validation errors
-*/
-
 // MultiError is a collection of errors that also fulfills the error interface.
 //
 // It can be used to aggregate errors and then return them all at once.
@@ -21,6 +15,11 @@ type MultiError struct {
 	// For is a string that describes the process/function that the MultiError
 	// is used for. This is optional.
 	For string
+
+	// Context is a general purpose mapping that can be used to store context
+	// information about errors, such as their source. This is useful when passing
+	// the MultiError across different scopes where not all info may be present.
+	Context map[string]string
 }
 
 // NewMultiError creates a new instance of a MultiError.
@@ -28,6 +27,7 @@ func NewMultiError(source string) *MultiError {
 	return &MultiError{
 		Errors: []error{},
 		For:    source,
+		Context: map[string]string{},
 	}
 }
 

--- a/sdk/errors/errors.go
+++ b/sdk/errors/errors.go
@@ -25,8 +25,8 @@ type MultiError struct {
 // NewMultiError creates a new instance of a MultiError.
 func NewMultiError(source string) *MultiError {
 	return &MultiError{
-		Errors: []error{},
-		For:    source,
+		Errors:  []error{},
+		For:     source,
 		Context: map[string]string{},
 	}
 }

--- a/sdk/errors/validation.go
+++ b/sdk/errors/validation.go
@@ -23,7 +23,7 @@ func NewValidationError(source, msg string) *ValidationError {
 
 // Error returns the error string and fulfils the error interface.
 func (e *ValidationError) Error() string {
-	return fmt.Sprintf("validating %s: %s", e.source, e.msg)
+	return fmt.Sprintf("validating config %s: %s", e.source, e.msg)
 }
 
 // FieldNotSupported is an error returned when a configuration scheme version is
@@ -55,7 +55,7 @@ func NewFieldNotSupportedError(source, field, fieldVersion, configVersion string
 // Error returns the error string and fulfils the error interface.
 func (e *FieldNotSupported) Error() string {
 	return fmt.Sprintf(
-		"validating %s: field '%s' not supported in v%s (field added in v%s)",
+		"validating config %s: field '%s' not supported in v%s (field added in v%s)",
 		e.source, e.field, e.configVersion, e.fieldVersion,
 	)
 }
@@ -89,7 +89,7 @@ func NewFieldRemovedError(source, field, fieldVersion, configVersion string) *Fi
 // Error returns the error string and fulfils the error interface.
 func (e *FieldRemoved) Error() string {
 	return fmt.Sprintf(
-		"validating %s: field '%s' not supported in v%s (field removed in v%s)",
+		"validating config %s: field '%s' not supported in v%s (field removed in v%s)",
 		e.source, e.field, e.configVersion, e.fieldVersion,
 	)
 }
@@ -108,13 +108,13 @@ type FieldRequired struct {
 func NewFieldRequiredError(source, field string) *FieldRequired {
 	return &FieldRequired{
 		source: source,
-		field: field,
+		field:  field,
 	}
 }
 
 func (e *FieldRequired) Error() string {
 	return fmt.Sprintf(
-		"validating %s: missing required field '%s'",
+		"validating config %s: missing required field '%s'",
 		e.source, e.field,
 	)
 }
@@ -136,14 +136,14 @@ type InvalidValue struct {
 func NewInvalidValueError(source, field, needs string) *InvalidValue {
 	return &InvalidValue{
 		source: source,
-		field: field,
-		needs: needs,
+		field:  field,
+		needs:  needs,
 	}
 }
 
 func (e *InvalidValue) Error() string {
 	return fmt.Sprintf(
-		"validating %s: invalid value for field '%s'. must be %s",
+		"validating config %s: invalid value for field '%s'. must be %s",
 		e.source, e.field, e.needs,
 	)
 }

--- a/sdk/errors/validation.go
+++ b/sdk/errors/validation.go
@@ -93,3 +93,57 @@ func (e *FieldRemoved) Error() string {
 		e.source, e.field, e.configVersion, e.fieldVersion,
 	)
 }
+
+// FieldRequired is an error returned when a configuration is being validated and
+// a field is not filled, but it is required.
+type FieldRequired struct {
+	// source is the source of the configuration which caused the validation error.
+	source string
+
+	// field is the field which is not supported
+	field string
+}
+
+// NewFieldRequiredError returns a new instance of a FieldRequired error.
+func NewFieldRequiredError(source, field string) *FieldRequired {
+	return &FieldRequired{
+		source: source,
+		field: field,
+	}
+}
+
+func (e *FieldRequired) Error() string {
+	return fmt.Sprintf(
+		"validating %s: missing required field '%s'",
+		e.source, e.field,
+	)
+}
+
+// InvalidValue is an error returned when a configuration is being validated and
+// a field does not contain the expected data.
+type InvalidValue struct {
+	// source is the source of the configuration which caused the validation error.
+	source string
+
+	// field is the field which is not supported
+	field string
+
+	// needs is a string that specifies what the field needs
+	needs string
+}
+
+// NewInvalidValueError returns a new instance of an InvalidValue error.
+func NewInvalidValueError(source, field, needs string) *InvalidValue {
+	return &InvalidValue{
+		source: source,
+		field: field,
+		needs: needs,
+	}
+}
+
+func (e *InvalidValue) Error() string {
+	return fmt.Sprintf(
+		"validating %s: invalid value for field '%s'. must be %s",
+		e.source, e.field, e.needs,
+	)
+}


### PR DESCRIPTION
This adds in an updated scheme for the plugin config, updates the ConfigComponent validation method so we can collect all errors and not just the first one (if there are multiple). Adds some tests, and lays down the initial work for reading in the plugin config. 

The dynamic registration piece still needs to be figured out, but I am considering that a separate issue, since there is a bunch of other work that needs to happen for that bit of functionality.

Related to:
- #213 
- #198 
- #194 