### PR TITLE
Add tests for updated SDK configuration package

### DIFF
--- a/internal/test/env.go
+++ b/internal/test/env.go
@@ -1,0 +1,24 @@
+package test
+
+import (
+	"os"
+	"testing"
+)
+
+// SetEnv is a wrapper around os.Setenv that handles error handling with the
+// testing.T isntance.
+func SetEnv(t *testing.T, key, value string) {
+	err := os.Setenv(key, value)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// RemoveEnv is a wrapper around os.Unsetenv that handles error handling with the
+// testing.T instance so this can be deferred easily.
+func RemoveEnv(t *testing.T, key string) {
+	err := os.Unsetenv(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/test/file.go
+++ b/internal/test/file.go
@@ -1,0 +1,87 @@
+package test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// FileInfo is a struct that fulfils the FileInfo interface that
+// can be used for testing.
+type FileInfo struct {
+	name    string
+	size    int64
+	mode    os.FileMode
+	modTime time.Time
+	sys     interface{}
+}
+
+// NewFileInfo creates a new instance of the test FileInfo for tests to use.
+func NewFileInfo(name string, mode os.FileMode) *FileInfo {
+	return &FileInfo{
+		name: name,
+		mode: mode,
+	}
+}
+
+// NOTE: this is not the correct way to check the isDir bit, but since
+// we will only set it this way for tests, this is fine here.
+
+func (f FileInfo) IsDir() bool        { return f.mode == os.ModeDir } // nolint
+func (f FileInfo) ModTime() time.Time { return f.modTime }            // nolint
+func (f FileInfo) Mode() os.FileMode  { return f.mode }               // nolint
+func (f FileInfo) Name() string       { return f.name }               // nolint
+func (f FileInfo) Size() int64        { return f.size }               // nolint
+func (f FileInfo) Sys() interface{}   { return f.sys }                // nolint
+
+// TempDir holds the current directory being used as the test directory.
+// This is generated via ioutil.TempDir.
+var TempDir = ""
+
+// SetupTestDir creates a test directory if one does not already exist.
+func SetupTestDir(t *testing.T) {
+	info, err := os.Stat(TempDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			dir, e := ioutil.TempDir("", "test")
+			if e != nil {
+				t.Fatal(e)
+			}
+			TempDir = dir
+		} else {
+			t.Fatal(err)
+		}
+	} else {
+		if !info.IsDir() {
+			t.Error("testDir is set, but is not a directory")
+		}
+	}
+}
+
+// ClearTestDir removes the test directory, if it exists.
+func ClearTestDir(t *testing.T) {
+	if TempDir != "" {
+		err := os.RemoveAll(TempDir)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// WriteTempFile is a test helper that will write the specified file to
+// a test directory. This is essentially a wrapper around ioutil.WriteFile
+// that ensures the test directory is in place.
+func WriteTempFile(t *testing.T, filename, data string, perm os.FileMode) string {
+	if TempDir == "" {
+		SetupTestDir(t)
+	}
+
+	fullPath := filepath.Join(TempDir, filename)
+	err := ioutil.WriteFile(filepath.Join(TempDir, filename), []byte(data), perm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fullPath
+}

--- a/sdk/cfg/device.go
+++ b/sdk/cfg/device.go
@@ -13,7 +13,7 @@ import (
 type DeviceConfig struct {
 
 	// ConfigVersion is the version of the configuration scheme.
-	ConfigVersion
+	ConfigVersion `yaml:",inline"`
 
 	// Locations are all of the locations that are defined by the configuration
 	// for device instances to reference.

--- a/sdk/cfg/device.go
+++ b/sdk/cfg/device.go
@@ -27,9 +27,9 @@ type DeviceConfig struct {
 // Validate validates that the DeviceConfig has no configuration errors.
 //
 // This is called before Devices are created.
-func (deviceConfig DeviceConfig) Validate(multiErr *errors.MultiError) {
+func (config DeviceConfig) Validate(multiErr *errors.MultiError) {
 	// A version must be specified and it must be of the correct format.
-	_, err := deviceConfig.GetSchemeVersion()
+	_, err := config.GetSchemeVersion()
 	if err != nil {
 		multiErr.Add(errors.NewValidationError(multiErr.Context["source"], err.Error()))
 	}

--- a/sdk/cfg/plugin.go
+++ b/sdk/cfg/plugin.go
@@ -18,7 +18,7 @@ const (
 type PluginConfig struct {
 
 	// ConfigVersion is the version of the configuration scheme.
-	ConfigVersion
+	ConfigVersion `yaml:",inline" mapstructure:",squash"`
 
 	// Debug is a flag that determines whether the plugin should run
 	// with debug logging or not.

--- a/sdk/cfg/plugin.go
+++ b/sdk/cfg/plugin.go
@@ -59,6 +59,8 @@ func NewPluginConfig() (*PluginConfig, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// FIXME: we should probably return a ConfigContext from this.
 	return config, nil
 }
 

--- a/sdk/cfg/plugin_test.go
+++ b/sdk/cfg/plugin_test.go
@@ -1,0 +1,544 @@
+package cfg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vapor-ware/synse-sdk/sdk/errors"
+)
+
+// TestPluginConfig_Validate_Ok tests validating a PluginConfig with no errors.
+func TestPluginConfig_Validate_Ok(t *testing.T) {
+	var testTable = []struct {
+		desc   string
+		config PluginConfig
+	}{
+		{
+			desc: "PluginConfig has valid version and network",
+			config: PluginConfig{
+				ConfigVersion: ConfigVersion{Version: "1.0"},
+				Network: &NetworkSettings{
+					Type:    "tcp",
+					Address: "10.10.10.10",
+				},
+			},
+		},
+		{
+			desc: "PluginConfig has valid version and network, invalid settings (not validated here)",
+			config: PluginConfig{
+				ConfigVersion: ConfigVersion{Version: "1.0"},
+				Network: &NetworkSettings{
+					Type:    "tcp",
+					Address: "10.10.10.10",
+				},
+				Settings: &PluginSettings{
+					Mode: "bad mode",
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testTable {
+		merr := errors.NewMultiError("test")
+
+		testCase.config.Validate(merr)
+		assert.NoError(t, merr.Err(), testCase.desc)
+	}
+}
+
+// TestPluginConfig_Validate_Error tests validating a PluginConfig with errors.
+func TestPluginConfig_Validate_Error(t *testing.T) {
+	var testTable = []struct {
+		desc     string
+		errCount int
+		config   PluginConfig
+	}{
+		{
+			desc:     "PluginConfig has invalid version",
+			errCount: 1,
+			config: PluginConfig{
+				ConfigVersion: ConfigVersion{Version: "abc"},
+				Network: &NetworkSettings{
+					Type:    "tcp",
+					Address: "10.10.10.10",
+				},
+			},
+		},
+		{
+			desc:     "PluginConfig has no network",
+			errCount: 1,
+			config: PluginConfig{
+				ConfigVersion: ConfigVersion{Version: "1.0"},
+			},
+		},
+		{
+			desc:     "PluginConfig is empty",
+			errCount: 2,
+			config:   PluginConfig{},
+		},
+	}
+
+	for _, testCase := range testTable {
+		merr := errors.NewMultiError("test")
+
+		testCase.config.Validate(merr)
+		assert.Error(t, merr.Err(), testCase.desc)
+		assert.Equal(t, testCase.errCount, len(merr.Errors), merr.Error())
+	}
+}
+
+// TestPluginSettings_Validate_Ok tests validating a PluginSettings with no errors.
+func TestPluginSettings_Validate_Ok(t *testing.T) {
+	var testTable = []struct {
+		desc   string
+		config PluginSettings
+	}{
+		{
+			desc: "PluginSettings has valid mode (serial)",
+			config: PluginSettings{
+				Mode:        "serial",
+				Read:        ReadSettings{},
+				Write:       WriteSettings{},
+				Transaction: TransactionSettings{},
+			},
+		},
+		{
+			desc: "PluginSettings has valid mode (parallel)",
+			config: PluginSettings{
+				Mode:        "parallel",
+				Read:        ReadSettings{},
+				Write:       WriteSettings{},
+				Transaction: TransactionSettings{},
+			},
+		},
+	}
+
+	for _, testCase := range testTable {
+		merr := errors.NewMultiError("test")
+
+		testCase.config.Validate(merr)
+		assert.NoError(t, merr.Err(), testCase.desc)
+	}
+}
+
+// TestPluginSettings_Validate_Error tests validating a PluginSettings with errors.
+func TestPluginSettings_Validate_Error(t *testing.T) {
+	var testTable = []struct {
+		desc     string
+		errCount int
+		config   PluginSettings
+	}{
+		{
+			desc:     "PluginSettings is empty",
+			errCount: 1,
+			config:   PluginSettings{},
+		},
+		{
+			desc:     "PluginSettings has invalid mode",
+			errCount: 1,
+			config: PluginSettings{
+				Mode:        "bad mode",
+				Read:        ReadSettings{},
+				Write:       WriteSettings{},
+				Transaction: TransactionSettings{},
+			},
+		},
+	}
+
+	for _, testCase := range testTable {
+		merr := errors.NewMultiError("test")
+
+		testCase.config.Validate(merr)
+		assert.Error(t, merr.Err(), testCase.desc)
+		assert.Equal(t, testCase.errCount, len(merr.Errors), merr.Error())
+	}
+}
+
+// TestPluginSettings_IsParallel tests if the plugin is in parallel mode.
+func TestPluginSettings_IsParallel(t *testing.T) {
+	parallel := PluginSettings{Mode: "parallel"}
+	assert.True(t, parallel.IsParallel())
+
+	serial := PluginSettings{Mode: "serial"}
+	assert.False(t, serial.IsParallel())
+}
+
+// TestPluginSettings_IsSerial tests if the plugin is in serial mode.
+func TestPluginSettings_IsSerial(t *testing.T) {
+	parallel := PluginSettings{Mode: "parallel"}
+	assert.False(t, parallel.IsSerial())
+
+	serial := PluginSettings{Mode: "serial"}
+	assert.True(t, serial.IsSerial())
+}
+
+// TestNetworkSettings_Validate_Ok tests validating a NetworkSettings with no errors.
+func TestNetworkSettings_Validate_Ok(t *testing.T) {
+	var testTable = []struct {
+		desc   string
+		config NetworkSettings
+	}{
+		{
+			desc: "NetworkSettings has valid type (tcp) and address",
+			config: NetworkSettings{
+				Type:    "tcp",
+				Address: "1.2.3.4",
+			},
+		},
+		{
+			desc: "NetworkSettings has valid type (unix) and address",
+			config: NetworkSettings{
+				Type:    "unix",
+				Address: "foo.sock",
+			},
+		},
+	}
+
+	for _, testCase := range testTable {
+		merr := errors.NewMultiError("test")
+
+		testCase.config.Validate(merr)
+		assert.NoError(t, merr.Err(), testCase.desc)
+	}
+}
+
+// TestNetworkSettings_Validate_Error tests validating a NetworkSettings with errors.
+func TestNetworkSettings_Validate_Error(t *testing.T) {
+	var testTable = []struct {
+		desc     string
+		errCount int
+		config   NetworkSettings
+	}{
+		{
+			desc:     "NetworkSettings is empty",
+			errCount: 2,
+			config:   NetworkSettings{},
+		},
+		{
+			desc:     "NetworkSettings has no type",
+			errCount: 1,
+			config: NetworkSettings{
+				Address: "1.2.3.4",
+			},
+		},
+		{
+			desc:     "NetworkSettings has no address",
+			errCount: 1,
+			config: NetworkSettings{
+				Type: "tcp",
+			},
+		},
+		{
+			desc:     "NetworkSettings has invalid type",
+			errCount: 1,
+			config: NetworkSettings{
+				Type:    "other",
+				Address: "foo",
+			},
+		},
+	}
+
+	for _, testCase := range testTable {
+		merr := errors.NewMultiError("test")
+
+		testCase.config.Validate(merr)
+		assert.Error(t, merr.Err(), testCase.desc)
+		assert.Equal(t, testCase.errCount, len(merr.Errors), merr.Error())
+	}
+}
+
+// TestLimiterSettings_Validate_Ok tests validating a LimiterSettings with no errors.
+func TestLimiterSettings_Validate_Ok(t *testing.T) {
+	var testTable = []struct {
+		desc   string
+		config LimiterSettings
+	}{
+		{
+			desc:   "LimiterSettings is empty",
+			config: LimiterSettings{},
+		},
+		{
+			desc: "LimiterSettings has valid rate (0)",
+			config: LimiterSettings{
+				Rate: 0,
+			},
+		},
+		{
+			desc: "LimiterSettings has valid burst (0)",
+			config: LimiterSettings{
+				Burst: 0,
+			},
+		},
+		{
+			desc: "LimiterSettings has valid rate (>0)",
+			config: LimiterSettings{
+				Rate: 100,
+			},
+		},
+		{
+			desc: "LimiterSettings has valid burst (>0)",
+			config: LimiterSettings{
+				Burst: 100,
+			},
+		},
+		{
+			desc: "LimiterSettings has valid rate and burst",
+			config: LimiterSettings{
+				Rate:  100,
+				Burst: 100,
+			},
+		},
+	}
+
+	for _, testCase := range testTable {
+		merr := errors.NewMultiError("test")
+
+		testCase.config.Validate(merr)
+		assert.NoError(t, merr.Err(), testCase.desc)
+	}
+}
+
+// TestLimiterSettings_Validate_Error tests validating a LimiterSettings with errors.
+func TestLimiterSettings_Validate_Error(t *testing.T) {
+	var testTable = []struct {
+		desc     string
+		errCount int
+		config   LimiterSettings
+	}{
+		{
+			desc:     "LimiterSettings has rate below 0",
+			errCount: 1,
+			config: LimiterSettings{
+				Rate: -1,
+			},
+		},
+		{
+			desc:     "LimiterSettings has burst below 0",
+			errCount: 1,
+			config: LimiterSettings{
+				Burst: -1,
+			},
+		},
+		{
+			desc:     "LimiterSettings has rate and burst below 0",
+			errCount: 2,
+			config: LimiterSettings{
+				Rate:  -1,
+				Burst: -1,
+			},
+		},
+	}
+
+	for _, testCase := range testTable {
+		merr := errors.NewMultiError("test")
+
+		testCase.config.Validate(merr)
+		assert.Error(t, merr.Err(), testCase.desc)
+		assert.Equal(t, testCase.errCount, len(merr.Errors), merr.Error())
+	}
+}
+
+// TestReadSettings_Validate_Ok tests validating a ReadSettings with no errors.
+func TestReadSettings_Validate_Ok(t *testing.T) {
+	var testTable = []struct {
+		desc   string
+		config ReadSettings
+	}{
+		{
+			desc: "ReadSettings has valid interval and buffer size",
+			config: ReadSettings{
+				Interval: "5s",
+				Buffer:   100,
+			},
+		},
+	}
+
+	for _, testCase := range testTable {
+		merr := errors.NewMultiError("test")
+
+		testCase.config.Validate(merr)
+		assert.NoError(t, merr.Err(), testCase.desc)
+	}
+}
+
+// TestReadSettings_Validate_Error tests validating a ReadSettings with errors.
+func TestReadSettings_Validate_Error(t *testing.T) {
+	var testTable = []struct {
+		desc     string
+		errCount int
+		config   ReadSettings
+	}{
+		{
+			desc:     "ReadSettings has invalid interval",
+			errCount: 1,
+			config: ReadSettings{
+				Interval: "foobar",
+				Buffer:   100,
+			},
+		},
+		{
+			desc:     "ReadSettings has invalid buffer size",
+			errCount: 1,
+			config: ReadSettings{
+				Interval: "1s",
+				Buffer:   0,
+			},
+		},
+		{
+			desc:     "ReadSettings has invalid interval and invalid buffer size",
+			errCount: 2,
+			config: ReadSettings{
+				Interval: "xyz",
+				Buffer:   -1,
+			},
+		},
+		{
+			desc:     "ReadSettings is empty",
+			errCount: 2,
+			config:   ReadSettings{},
+		},
+	}
+
+	for _, testCase := range testTable {
+		merr := errors.NewMultiError("test")
+
+		testCase.config.Validate(merr)
+		assert.Error(t, merr.Err(), testCase.desc)
+		assert.Equal(t, testCase.errCount, len(merr.Errors), merr.Error())
+	}
+}
+
+// TestWriteSettings_Validate_Ok tests validating a WriteSettings with no errors.
+func TestWriteSettings_Validate_Ok(t *testing.T) {
+	var testTable = []struct {
+		desc   string
+		config WriteSettings
+	}{
+		{
+			desc: "WriteSettings has valid interval, buffer, and max",
+			config: WriteSettings{
+				Interval: "5s",
+				Buffer:   100,
+				Max:      100,
+			},
+		},
+	}
+
+	for _, testCase := range testTable {
+		merr := errors.NewMultiError("test")
+
+		testCase.config.Validate(merr)
+		assert.NoError(t, merr.Err(), testCase.desc)
+	}
+}
+
+// TestWriteSettings_Validate_Error tests validating a WriteSettings with errors.
+func TestWriteSettings_Validate_Error(t *testing.T) {
+	var testTable = []struct {
+		desc     string
+		errCount int
+		config   WriteSettings
+	}{
+		{
+			desc:     "WriteSettings has invalid interval",
+			errCount: 1,
+			config: WriteSettings{
+				Interval: "foobar",
+				Buffer:   100,
+				Max:      100,
+			},
+		},
+		{
+			desc:     "WriteSettings has invalid buffer",
+			errCount: 1,
+			config: WriteSettings{
+				Interval: "5s",
+				Buffer:   0,
+				Max:      100,
+			},
+		},
+		{
+			desc:     "WriteSettings has invalid max",
+			errCount: 1,
+			config: WriteSettings{
+				Interval: "5s",
+				Buffer:   100,
+				Max:      0,
+			},
+		},
+		{
+			desc:     "WriteSettings has invalid interval, buffer, and max",
+			errCount: 3,
+			config: WriteSettings{
+				Interval: "xyz",
+				Buffer:   -1,
+				Max:      -100,
+			},
+		},
+		{
+			desc:     "WriteSettings is empty",
+			errCount: 3,
+			config:   WriteSettings{},
+		},
+	}
+
+	for _, testCase := range testTable {
+		merr := errors.NewMultiError("test")
+
+		testCase.config.Validate(merr)
+		assert.Error(t, merr.Err(), testCase.desc)
+		assert.Equal(t, testCase.errCount, len(merr.Errors), merr.Error())
+	}
+}
+
+// TestTransactionSettings_Validate_Ok tests validating a TransactionSettings with no errors.
+func TestTransactionSettings_Validate_Ok(t *testing.T) {
+	var testTable = []struct {
+		desc   string
+		config TransactionSettings
+	}{
+		{
+			desc: "TransactionSettings has valid TTL",
+			config: TransactionSettings{
+				TTL: "5s",
+			},
+		},
+	}
+
+	for _, testCase := range testTable {
+		merr := errors.NewMultiError("test")
+
+		testCase.config.Validate(merr)
+		assert.NoError(t, merr.Err(), testCase.desc)
+	}
+}
+
+// TestTransactionSettings_Validate_Error tests validating a TransactionSettings with errors.
+func TestTransactionSettings_Validate_Error(t *testing.T) {
+	var testTable = []struct {
+		desc     string
+		errCount int
+		config   TransactionSettings
+	}{
+		{
+			desc:     "TransactionSettings is empty",
+			errCount: 1,
+			config:   TransactionSettings{},
+		},
+		{
+			desc:     "TransactionSettings has invalid TTL",
+			errCount: 1,
+			config: TransactionSettings{
+				TTL: "xyz",
+			},
+		},
+	}
+
+	for _, testCase := range testTable {
+		merr := errors.NewMultiError("test")
+
+		testCase.config.Validate(merr)
+		assert.Error(t, merr.Err(), testCase.desc)
+		assert.Equal(t, testCase.errCount, len(merr.Errors), merr.Error())
+	}
+}

--- a/sdk/cfg/reader.go
+++ b/sdk/cfg/reader.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/mitchellh/mapstructure"
+	"github.com/spf13/viper"
 	"github.com/vapor-ware/synse-sdk/sdk/logger"
 	"gopkg.in/yaml.v2"
 )
@@ -22,6 +24,69 @@ var (
 	// supportedExts are the extensions supported for configuration files.
 	supportedExts = []string{".yml", ".yaml"}
 )
+
+// NewPluginConfig creates a new instance of PluginConfig, populated from
+// the configuration read in by Viper. This will include config options from
+// the command line and from file.
+func NewPluginConfig() (*PluginConfig, error) {
+	// First, we setup all the lookup info for the viper instance.
+	viper.SetConfigName("config")
+
+	// Set the environment variable lookup
+	viper.SetEnvPrefix("plugin")
+	viper.AutomaticEnv()
+
+	// If the PLUGIN_CONFIG environment variable is set, we will only search for
+	// the config in that specified path, as we should expect the user-specified
+	// value to be there. Otherwise, we will look through a set of pre-defined
+	// configuration locations (in order of search):
+	//  - current working directory
+	//  - local config directory
+	//  - the default config location in /etc
+	configPath := os.Getenv(EnvPluginConfig)
+	if configPath != "" {
+		viper.AddConfigPath(configPath)
+	} else {
+		for _, path := range pluginConfigSearchPaths {
+			viper.AddConfigPath(path)
+		}
+	}
+
+	// Set default values for the PluginConfig
+	SetDefaults()
+
+	// will be used for the ConfigContext
+	//configFile := viper.ConfigFileUsed()
+
+	// Read in the configuration
+	err := viper.ReadInConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	config := &PluginConfig{}
+	err = mapstructure.Decode(viper.AllSettings(), config)
+	if err != nil {
+		return nil, err
+	}
+
+	// FIXME: we should probably return a ConfigContext from this.
+	return config, nil
+}
+
+// SetDefaults sets the default values for the PluginConfig via Viper.
+func SetDefaults() {
+	viper.SetDefault("debug", false)
+	viper.SetDefault("settings.mode", modeSerial)
+	viper.SetDefault("settings.read.interval", "1s")
+	viper.SetDefault("settings.read.buffer", 100)
+	viper.SetDefault("settings.read.enabled", true)
+	viper.SetDefault("settings.write.interval", "1s")
+	viper.SetDefault("settings.write.buffer", 100)
+	viper.SetDefault("settings.write.max", 100)
+	viper.SetDefault("settings.write.enabled", true)
+	viper.SetDefault("settings.transaction.ttl", "5m")
+}
 
 // getDeviceConfigFilePaths gets the file paths for device configuration files
 // by searching various config search paths.

--- a/sdk/cfg/reader.go
+++ b/sdk/cfg/reader.go
@@ -189,6 +189,9 @@ func getConfigPathsFromDir(dirpath string) ([]string, error) {
 	return files, nil
 }
 
+// isValidConfig checks if the given FileInfo corresponds to a file that could be
+// a valid configuration file. It checks that it is actually a file (not a Dir)
+// and checks that its extension matches the supported extensions.
 func isValidConfig(f os.FileInfo) bool {
 	if !f.IsDir() {
 		fileExt := filepath.Ext(f.Name())

--- a/sdk/cfg/reader_test.go
+++ b/sdk/cfg/reader_test.go
@@ -1,0 +1,169 @@
+package cfg
+
+import (
+	"testing"
+
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testFileInfo struct {
+	name    string
+	size    int64
+	mode    os.FileMode
+	modTime time.Time
+	sys     interface{}
+}
+
+// NOTE: this is not the correct way to check the isDir bit, but since
+// we will only set it this way for tests, this is fine here.
+func (f testFileInfo) IsDir() bool        { return f.mode == os.ModeDir }
+func (f testFileInfo) ModTime() time.Time { return f.modTime }
+func (f testFileInfo) Mode() os.FileMode  { return f.mode }
+func (f testFileInfo) Name() string       { return f.name }
+func (f testFileInfo) Size() int64        { return f.size }
+func (f testFileInfo) Sys() interface{}   { return f.sys }
+
+// TestIsValidConfig tests validating that a file is a potential config file.
+func TestIsValidConfig(t *testing.T) {
+	var testTable = []struct {
+		desc    string
+		isValid bool
+		file    testFileInfo
+	}{
+		{
+			desc:    "file is not valid -- is a directory",
+			isValid: false,
+			file: testFileInfo{
+				name: "test",
+				mode: os.ModeDir,
+			},
+		},
+		{
+			desc:    "file is not valid -- is a json file",
+			isValid: false,
+			file: testFileInfo{
+				name: "test.json",
+			},
+		},
+		{
+			desc:    "file is valid -- has .yml extension",
+			isValid: true,
+			file: testFileInfo{
+				name: "test.yml",
+			},
+		},
+		{
+			desc:    "file is valid -- has .yaml extension",
+			isValid: true,
+			file: testFileInfo{
+				name: "test.yaml",
+			},
+		},
+	}
+
+	for _, testCase := range testTable {
+		result := isValidConfig(testCase.file)
+		assert.Equal(t, testCase.isValid, result, testCase.desc)
+	}
+}
+
+// Test_getConfigPathsFromDir_NoValidFiles tests getting the paths of the files that are
+// valid config files from a directory. In this case, there are no valid configs.
+func Test_getConfigPathsFromDir_NoValidFiles(t *testing.T) {
+	// Set up a temp directory for testing.
+	dir, err := ioutil.TempDir("", "test")
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		err = os.RemoveAll(dir)
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	// Test
+	configs, err := getConfigPathsFromDir(dir)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(configs))
+}
+
+// Test_getConfigPathsFromDir_NoDir tests getting the paths of the files that are
+// valid config files from a directory when the directory doesn't exist.
+func Test_getConfigPathsFromDir_NoDir(t *testing.T) {
+
+	configs, err := getConfigPathsFromDir("a/b/c/d/e")
+	assert.Error(t, err)
+	assert.Nil(t, configs)
+}
+
+// Test_getConfigPathsFromDir_OneFile tests getting the paths of the files that are
+// valid config files from a directory. In this case, there is only one valid config
+// file, and some invalid.
+func Test_getConfigPathsFromDir_OneFile(t *testing.T) {
+	// Set up a temp directory for testing.
+	dir, err := ioutil.TempDir("", "test")
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		err = os.RemoveAll(dir)
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	// Add a valid config and an invalid config file to the dir
+	if err = ioutil.WriteFile(filepath.Join(dir, "foo.yml"), []byte{}, 0666); err != nil {
+		t.Error(err)
+	}
+	if err = ioutil.WriteFile(filepath.Join(dir, "bar.json"), []byte{}, 0666); err != nil {
+		t.Error(err)
+	}
+
+	// Test
+	configs, err := getConfigPathsFromDir(dir)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(configs))
+	assert.Equal(t, filepath.Join(dir, "foo.yml"), configs[0])
+}
+
+// Test_getConfigPathsFromDir_MultipleFiles tests getting the paths of the files that are
+// valid config files from a directory. In this case, is multiple valid config files.
+func Test_getConfigPathsFromDir_MultipleFiles(t *testing.T) {
+	// Set up a temp directory for testing.
+	dir, err := ioutil.TempDir("", "test")
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		err = os.RemoveAll(dir)
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	// Add a valid config and an invalid config file to the dir
+	if err = ioutil.WriteFile(filepath.Join(dir, "foo.yml"), []byte{}, 0666); err != nil {
+		t.Error(err)
+	}
+	if err = ioutil.WriteFile(filepath.Join(dir, "bar.yaml"), []byte{}, 0666); err != nil {
+		t.Error(err)
+	}
+	if err = ioutil.WriteFile(filepath.Join(dir, "baz.yaml"), []byte{}, 0666); err != nil {
+		t.Error(err)
+	}
+
+	// Test
+	configs, err := getConfigPathsFromDir(dir)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(configs))
+	assert.Equal(t, filepath.Join(dir, "bar.yaml"), configs[0])
+	assert.Equal(t, filepath.Join(dir, "baz.yaml"), configs[1])
+	assert.Equal(t, filepath.Join(dir, "foo.yml"), configs[2])
+}

--- a/sdk/cfg/reader_test.go
+++ b/sdk/cfg/reader_test.go
@@ -1,68 +1,40 @@
 package cfg
 
 import (
+	"os"
 	"testing"
 
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"time"
-
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/vapor-ware/synse-sdk/internal/test"
 )
-
-type testFileInfo struct {
-	name    string
-	size    int64
-	mode    os.FileMode
-	modTime time.Time
-	sys     interface{}
-}
-
-// NOTE: this is not the correct way to check the isDir bit, but since
-// we will only set it this way for tests, this is fine here.
-func (f testFileInfo) IsDir() bool        { return f.mode == os.ModeDir }
-func (f testFileInfo) ModTime() time.Time { return f.modTime }
-func (f testFileInfo) Mode() os.FileMode  { return f.mode }
-func (f testFileInfo) Name() string       { return f.name }
-func (f testFileInfo) Size() int64        { return f.size }
-func (f testFileInfo) Sys() interface{}   { return f.sys }
 
 // TestIsValidConfig tests validating that a file is a potential config file.
 func TestIsValidConfig(t *testing.T) {
 	var testTable = []struct {
 		desc    string
 		isValid bool
-		file    testFileInfo
+		file    *test.FileInfo
 	}{
 		{
 			desc:    "file is not valid -- is a directory",
 			isValid: false,
-			file: testFileInfo{
-				name: "test",
-				mode: os.ModeDir,
-			},
+			file:    test.NewFileInfo("test", os.ModeDir),
 		},
 		{
 			desc:    "file is not valid -- is a json file",
 			isValid: false,
-			file: testFileInfo{
-				name: "test.json",
-			},
+			file:    test.NewFileInfo("test,json", os.ModePerm),
 		},
 		{
 			desc:    "file is valid -- has .yml extension",
 			isValid: true,
-			file: testFileInfo{
-				name: "test.yml",
-			},
+			file:    test.NewFileInfo("test.yml", os.ModePerm),
 		},
 		{
 			desc:    "file is valid -- has .yaml extension",
 			isValid: true,
-			file: testFileInfo{
-				name: "test.yaml",
-			},
+			file:    test.NewFileInfo("test.yaml", os.ModePerm),
 		},
 	}
 
@@ -75,20 +47,12 @@ func TestIsValidConfig(t *testing.T) {
 // Test_getConfigPathsFromDir_NoValidFiles tests getting the paths of the files that are
 // valid config files from a directory. In this case, there are no valid configs.
 func Test_getConfigPathsFromDir_NoValidFiles(t *testing.T) {
-	// Set up a temp directory for testing.
-	dir, err := ioutil.TempDir("", "test")
-	if err != nil {
-		t.Error(err)
-	}
-	defer func() {
-		err = os.RemoveAll(dir)
-		if err != nil {
-			t.Error(err)
-		}
-	}()
+	// Set up a temporary directory for test data.
+	test.SetupTestDir(t)
+	defer test.ClearTestDir(t)
 
 	// Test
-	configs, err := getConfigPathsFromDir(dir)
+	configs, err := getConfigPathsFromDir(test.TempDir)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(configs))
 }
@@ -96,7 +60,6 @@ func Test_getConfigPathsFromDir_NoValidFiles(t *testing.T) {
 // Test_getConfigPathsFromDir_NoDir tests getting the paths of the files that are
 // valid config files from a directory when the directory doesn't exist.
 func Test_getConfigPathsFromDir_NoDir(t *testing.T) {
-
 	configs, err := getConfigPathsFromDir("a/b/c/d/e")
 	assert.Error(t, err)
 	assert.Nil(t, configs)
@@ -106,64 +69,679 @@ func Test_getConfigPathsFromDir_NoDir(t *testing.T) {
 // valid config files from a directory. In this case, there is only one valid config
 // file, and some invalid.
 func Test_getConfigPathsFromDir_OneFile(t *testing.T) {
-	// Set up a temp directory for testing.
-	dir, err := ioutil.TempDir("", "test")
-	if err != nil {
-		t.Error(err)
-	}
-	defer func() {
-		err = os.RemoveAll(dir)
-		if err != nil {
-			t.Error(err)
-		}
-	}()
+	// Set up a temporary directory for test data.
+	test.SetupTestDir(t)
+	defer test.ClearTestDir(t)
 
-	// Add a valid config and an invalid config file to the dir
-	if err = ioutil.WriteFile(filepath.Join(dir, "foo.yml"), []byte{}, 0666); err != nil {
-		t.Error(err)
-	}
-	if err = ioutil.WriteFile(filepath.Join(dir, "bar.json"), []byte{}, 0666); err != nil {
-		t.Error(err)
-	}
+	// Add data to the temporary test directory
+	foo := test.WriteTempFile(t, "foo.yml", "", 0666)
+	_ = test.WriteTempFile(t, "bar.json", "", 0666)
 
 	// Test
-	configs, err := getConfigPathsFromDir(dir)
+	configs, err := getConfigPathsFromDir(test.TempDir)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(configs))
-	assert.Equal(t, filepath.Join(dir, "foo.yml"), configs[0])
+	assert.Equal(t, foo, configs[0])
 }
 
 // Test_getConfigPathsFromDir_MultipleFiles tests getting the paths of the files that are
 // valid config files from a directory. In this case, is multiple valid config files.
 func Test_getConfigPathsFromDir_MultipleFiles(t *testing.T) {
-	// Set up a temp directory for testing.
-	dir, err := ioutil.TempDir("", "test")
-	if err != nil {
-		t.Error(err)
-	}
-	defer func() {
-		err = os.RemoveAll(dir)
-		if err != nil {
-			t.Error(err)
-		}
-	}()
+	// Set up a temporary directory for test data.
+	test.SetupTestDir(t)
+	defer test.ClearTestDir(t)
 
-	// Add a valid config and an invalid config file to the dir
-	if err = ioutil.WriteFile(filepath.Join(dir, "foo.yml"), []byte{}, 0666); err != nil {
-		t.Error(err)
-	}
-	if err = ioutil.WriteFile(filepath.Join(dir, "bar.yaml"), []byte{}, 0666); err != nil {
-		t.Error(err)
-	}
-	if err = ioutil.WriteFile(filepath.Join(dir, "baz.yaml"), []byte{}, 0666); err != nil {
-		t.Error(err)
-	}
+	// Add data to the temporary test directory
+	foo := test.WriteTempFile(t, "foo.yml", "", 0666)
+	bar := test.WriteTempFile(t, "bar.yaml", "", 0666)
+	baz := test.WriteTempFile(t, "baz.yaml", "", 0666)
 
 	// Test
-	configs, err := getConfigPathsFromDir(dir)
+	configs, err := getConfigPathsFromDir(test.TempDir)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, len(configs))
-	assert.Equal(t, filepath.Join(dir, "bar.yaml"), configs[0])
-	assert.Equal(t, filepath.Join(dir, "baz.yaml"), configs[1])
-	assert.Equal(t, filepath.Join(dir, "foo.yml"), configs[2])
+	assert.Equal(t, bar, configs[0])
+	assert.Equal(t, baz, configs[1])
+	assert.Equal(t, foo, configs[2])
+}
+
+// TestUnmarshalConfigFile tests unmarshalling data from a file into a struct successfully.
+func TestUnmarshalConfigFile(t *testing.T) {
+	// Set up a temporary directory for test data.
+	test.SetupTestDir(t)
+	defer test.ClearTestDir(t)
+
+	// Data to write to file
+	data := `
+version: 1.0
+`
+
+	// Add data to the temporary test directory
+	filename := test.WriteTempFile(t, "foo.yml", data, 0666)
+
+	config := &DeviceConfig{}
+	err := UnmarshalConfigFile(filename, config)
+	assert.NoError(t, err)
+
+	// Check that the config now has the correct fields.
+	assert.Equal(t, "1.0", config.Version)
+}
+
+// TestUnmarshalConfigFile2 tests unmarshalling data from a file into a struct successfully.
+func TestUnmarshalConfigFile2(t *testing.T) {
+	// Set up a temporary directory for test data.
+	test.SetupTestDir(t)
+	defer test.ClearTestDir(t)
+
+	// Data to write to file
+	data := `
+name: foobar
+rack:
+  name: r1
+board:
+  fromEnv: HOME
+`
+
+	// Add data to the temporary test directory
+	filename := test.WriteTempFile(t, "foo.yml", data, 0666)
+
+	config := &Location{}
+	err := UnmarshalConfigFile(filename, config)
+	assert.NoError(t, err)
+
+	// Check that the config now has the correct fields.
+	assert.Equal(t, "foobar", config.Name)
+	assert.Equal(t, "r1", config.Rack.Name)
+	assert.Equal(t, "", config.Rack.FromEnv)
+	assert.Equal(t, "", config.Board.Name)
+	assert.Equal(t, "HOME", config.Board.FromEnv)
+}
+
+// TestUnmarshalConfigFile3 tests unmarshalling data from a file into a struct when
+// there is no data to unmarshal.
+func TestUnmarshalConfigFile3(t *testing.T) {
+	// Set up a temporary directory for test data.
+	test.SetupTestDir(t)
+	defer test.ClearTestDir(t)
+
+	// Add data to the temporary test directory
+	filename := test.WriteTempFile(t, "foo.yml", "", 0666)
+
+	config := &Location{}
+	err := UnmarshalConfigFile(filename, config)
+	assert.NoError(t, err)
+
+	// Check that the config now has the correct fields.
+	assert.Equal(t, "", config.Name)
+	assert.Nil(t, config.Rack)
+	assert.Nil(t, config.Board)
+}
+
+// TestUnmarshalConfigFile4 tests unmarshalling data from a file into a struct
+// when none of the data in the file matches up with the struct.
+func TestUnmarshalConfigFile4(t *testing.T) {
+	// Set up a temporary directory for test data.
+	test.SetupTestDir(t)
+	defer test.ClearTestDir(t)
+
+	// Data to write to file
+	data := `
+foo: bar
+version: "1.0"
+`
+
+	// Add data to the temporary test directory
+	filename := test.WriteTempFile(t, "foo.yml", data, 0666)
+
+	config := &Location{}
+	err := UnmarshalConfigFile(filename, config)
+	assert.NoError(t, err)
+
+	// Check that the config now has the correct fields.
+	assert.Equal(t, "", config.Name)
+	assert.Nil(t, config.Rack)
+	assert.Nil(t, config.Board)
+}
+
+// TestUnmarshalConfigFile5 tests unmarshalling data from a file into a struct
+// when the file data is invalid yaml. This should result in an error.
+func TestUnmarshalConfigFile5(t *testing.T) {
+	// Set up a temporary directory for test data.
+	test.SetupTestDir(t)
+	defer test.ClearTestDir(t)
+
+	// Data to write to file
+	data := `
+name:: foo
+rack
+  name: bar
+board:
+  name: baz
+`
+
+	// Add data to the temporary test directory
+	filename := test.WriteTempFile(t, "foo.yml", data, 0666)
+
+	config := &Location{}
+	err := UnmarshalConfigFile(filename, config)
+	assert.Error(t, err)
+
+	// Check that the config now has the correct fields.
+	assert.Equal(t, "", config.Name)
+	assert.Nil(t, config.Rack)
+	assert.Nil(t, config.Board)
+}
+
+// TestUnmarshalConfigFile6 tests unmarshalling data from a file that doesn't exist.
+func TestUnmarshalConfigFile6(t *testing.T) {
+	config := &Location{}
+	err := UnmarshalConfigFile("/foo/bar/baz.yaml", config)
+	assert.Error(t, err)
+
+	// Check that the config now has the correct fields.
+	assert.Equal(t, "", config.Name)
+	assert.Nil(t, config.Rack)
+	assert.Nil(t, config.Board)
+}
+
+// Test_getDeviceConfigFilePaths_Env1 tests getting the filepaths for config files
+// when the override environment variable is specified, but no configs are found
+// in that path.
+func Test_getDeviceConfigFilePaths_Env1(t *testing.T) {
+	// Set up the test dir
+	test.SetupTestDir(t)
+	defer test.ClearTestDir(t)
+
+	// Set up the test env
+	test.SetEnv(t, EnvDevicePath, test.TempDir)
+	defer test.RemoveEnv(t, EnvDevicePath)
+
+	paths, err := getDeviceConfigFilePaths()
+	assert.Error(t, err)
+	assert.Equal(t, 0, len(paths))
+}
+
+// Test_getDeviceConfigFilePaths_Env2 tests getting the filepaths for config files
+// when the override environment variable is specified, and references a directory
+// that doesn't exist.
+func Test_getDeviceConfigFilePaths_Env2(t *testing.T) {
+	// Set up the test env
+	test.SetEnv(t, EnvDevicePath, "/a/b/c/d/")
+	defer test.RemoveEnv(t, EnvDevicePath)
+
+	paths, err := getDeviceConfigFilePaths()
+	assert.Error(t, err)
+	assert.Equal(t, 0, len(paths))
+}
+
+// Test_getDeviceConfigFilePaths_Env3 tests getting the filepaths for config files
+// when the override environment variable is specified, and references a file
+// that doesn't exist.
+func Test_getDeviceConfigFilePaths_Env3(t *testing.T) {
+	// Set up the test env
+	test.SetEnv(t, EnvDevicePath, "/a/b/c/foo.yaml")
+	defer test.RemoveEnv(t, EnvDevicePath)
+
+	paths, err := getDeviceConfigFilePaths()
+	assert.Error(t, err)
+	assert.Equal(t, 0, len(paths))
+}
+
+// Test_getDeviceConfigFilePaths_Env4 tests getting the filepaths for config files
+// when the override environment variable is specified, and references a file
+// that exists and is a valid config type.
+func Test_getDeviceConfigFilePaths_Env4(t *testing.T) {
+	// Set up the test dir
+	test.SetupTestDir(t)
+	defer test.ClearTestDir(t)
+
+	// Add a file to the dir
+	foo := test.WriteTempFile(t, "foo.yaml", "", os.ModePerm)
+
+	// Set up the test env
+	test.SetEnv(t, EnvDevicePath, foo)
+	defer test.RemoveEnv(t, EnvDevicePath)
+
+	paths, err := getDeviceConfigFilePaths()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(paths))
+	assert.Equal(t, foo, paths[0])
+}
+
+// Test_getDeviceConfigFilePaths_Env5 tests getting the filepaths for config files
+// when the override environment variable is specified, and references a file
+// that exists but is not a valid config type.
+func Test_getDeviceConfigFilePaths_Env5(t *testing.T) {
+	// Set up the test dir
+	test.SetupTestDir(t)
+	defer test.ClearTestDir(t)
+
+	// Add a file to the dir
+	foo := test.WriteTempFile(t, "foo.json", "", os.ModePerm)
+
+	// Set up the test env
+	test.SetEnv(t, EnvDevicePath, foo)
+	defer test.RemoveEnv(t, EnvDevicePath)
+
+	paths, err := getDeviceConfigFilePaths()
+	assert.Error(t, err)
+	assert.Nil(t, paths)
+}
+
+// Test_getDeviceConfigFilePaths_Env6 tests getting the filepaths for config files
+// when the override environment variable is specified, and references a directory
+// that exists with a single valid file.
+func Test_getDeviceConfigFilePaths_Env6(t *testing.T) {
+	// Set up the test dir
+	test.SetupTestDir(t)
+	defer test.ClearTestDir(t)
+
+	// Add a file to the dir
+	foo := test.WriteTempFile(t, "foo.yaml", "", os.ModePerm)
+
+	// Set up the test env
+	test.SetEnv(t, EnvDevicePath, test.TempDir)
+	defer test.RemoveEnv(t, EnvDevicePath)
+
+	paths, err := getDeviceConfigFilePaths()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(paths))
+	assert.Equal(t, foo, paths[0])
+}
+
+// Test_getDeviceConfigFilePaths_Env7 tests getting the filepaths for config files
+// when the override environment variable is specified, and references a directory
+// that exists with multiple valid files.
+func Test_getDeviceConfigFilePaths_Env7(t *testing.T) {
+	// Set up the test dir
+	test.SetupTestDir(t)
+	defer test.ClearTestDir(t)
+
+	// Add files to the dir
+	foo := test.WriteTempFile(t, "foo.yaml", "", os.ModePerm)
+	bar := test.WriteTempFile(t, "bar.yml", "", os.ModePerm)
+	baz := test.WriteTempFile(t, "baz.yaml", "", os.ModePerm)
+
+	// Set up the test env
+	test.SetEnv(t, EnvDevicePath, test.TempDir)
+	defer test.RemoveEnv(t, EnvDevicePath)
+
+	paths, err := getDeviceConfigFilePaths()
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(paths))
+	assert.Equal(t, bar, paths[0])
+	assert.Equal(t, baz, paths[1])
+	assert.Equal(t, foo, paths[2])
+}
+
+// Test_getDeviceConfigFilePaths_Default1 tests getting the filepaths for config
+// files when a search dir does not exist.
+func Test_getDeviceConfigFilePaths_Default1(t *testing.T) {
+	// override the search paths for the test, use a bogus dir
+	deviceConfigSearchPaths = []string{"/a/b/c/"}
+
+	paths, err := getDeviceConfigFilePaths()
+	assert.Error(t, err)
+	assert.Nil(t, paths)
+}
+
+// Test_getDeviceConfigFilePaths_Default2 tests getting the filepaths for config
+// files when a search dir is empty.
+func Test_getDeviceConfigFilePaths_Default2(t *testing.T) {
+	// Set up the test dir
+	test.SetupTestDir(t)
+	defer test.ClearTestDir(t)
+
+	// override the search paths for the test, just use the temp dir
+	deviceConfigSearchPaths = []string{test.TempDir}
+
+	paths, err := getDeviceConfigFilePaths()
+	assert.Error(t, err)
+	assert.Nil(t, paths)
+}
+
+// Test_getDeviceConfigFilePaths_Default3 tests getting the filepaths for config
+// files when a search dir contains no valid configs.
+func Test_getDeviceConfigFilePaths_Default3(t *testing.T) {
+	// Set up the test dir
+	test.SetupTestDir(t)
+	defer test.ClearTestDir(t)
+
+	// Add a file to the dir
+	_ = test.WriteTempFile(t, "foo.json", "", os.ModePerm)
+
+	// override the search paths for the test, just use the temp dir
+	deviceConfigSearchPaths = []string{test.TempDir}
+
+	paths, err := getDeviceConfigFilePaths()
+	assert.Error(t, err)
+	assert.Nil(t, paths)
+}
+
+// Test_getDeviceConfigFilePaths_Default4 tests getting the filepaths for config
+// files when a search dir contains one valid config.
+func Test_getDeviceConfigFilePaths_Default4(t *testing.T) {
+	// Set up the test dir
+	test.SetupTestDir(t)
+	defer test.ClearTestDir(t)
+
+	// Add a file to the dir
+	foo := test.WriteTempFile(t, "foo.yaml", "", os.ModePerm)
+
+	// override the search paths for the test, just use the temp dir
+	deviceConfigSearchPaths = []string{test.TempDir}
+
+	paths, err := getDeviceConfigFilePaths()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(paths))
+	assert.Equal(t, foo, paths[0])
+}
+
+// Test_getDeviceConfigFilePaths_Default5 tests getting the filepaths for config
+// files when a search dir contains multiple valid configs.
+func Test_getDeviceConfigFilePaths_Default5(t *testing.T) {
+	// Set up the test dir
+	test.SetupTestDir(t)
+	defer test.ClearTestDir(t)
+
+	// Add a file to the dir
+	foo := test.WriteTempFile(t, "foo.yaml", "", os.ModePerm)
+	bar := test.WriteTempFile(t, "bar.yml", "", os.ModePerm)
+	baz := test.WriteTempFile(t, "baz.yaml", "", os.ModePerm)
+
+	// override the search paths for the test, just use the temp dir
+	deviceConfigSearchPaths = []string{test.TempDir}
+
+	paths, err := getDeviceConfigFilePaths()
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(paths))
+	assert.Equal(t, bar, paths[0])
+	assert.Equal(t, baz, paths[1])
+	assert.Equal(t, foo, paths[2])
+}
+
+// TestGetDeviceConfigsFromFile tests getting ConfigContext for all device configs found.
+// In this case, no config files will be found.
+func TestGetDeviceConfigsFromFile(t *testing.T) {
+	// Set up the test dir
+	test.SetupTestDir(t)
+	defer test.ClearTestDir(t)
+
+	// Set up the test env
+	test.SetEnv(t, EnvDevicePath, test.TempDir)
+	defer test.RemoveEnv(t, EnvDevicePath)
+
+	ctxs, err := GetDeviceConfigsFromFile()
+	assert.Error(t, err)
+	assert.Nil(t, ctxs)
+}
+
+// TestGetDeviceConfigsFromFile2 tests getting ConfigContext for all device configs found.
+// In this case, one config will be found, but will have invalid yaml.
+func TestGetDeviceConfigsFromFile2(t *testing.T) {
+	// Set up the test dir
+	test.SetupTestDir(t)
+	defer test.ClearTestDir(t)
+
+	data := `
+location::
+rack
+  name: foo
+board:
+  name: bar
+`
+
+	// Add a file to the dir
+	foo := test.WriteTempFile(t, "foo.yaml", data, os.ModePerm)
+
+	// Set up the test env
+	test.SetEnv(t, EnvDevicePath, foo)
+	defer test.RemoveEnv(t, EnvDevicePath)
+
+	ctxs, err := GetDeviceConfigsFromFile()
+	assert.Error(t, err)
+	assert.Nil(t, ctxs)
+}
+
+// TestGetDeviceConfigsFromFile3 tests getting ConfigContext for all device configs found.
+// In this case, one valid config is found.
+func TestGetDeviceConfigsFromFile3(t *testing.T) {
+	// Set up the test dir
+	test.SetupTestDir(t)
+	defer test.ClearTestDir(t)
+
+	data := `
+version: "1.0"
+`
+
+	// Add a file to the dir
+	foo := test.WriteTempFile(t, "foo.yaml", data, os.ModePerm)
+
+	// Set up the test env
+	test.SetEnv(t, EnvDevicePath, test.TempDir)
+	defer test.RemoveEnv(t, EnvDevicePath)
+
+	ctxs, err := GetDeviceConfigsFromFile()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(ctxs))
+	assert.Equal(t, foo, ctxs[0].Source)
+
+	assert.True(t, ctxs[0].IsDeviceConfig())
+	cfg := ctxs[0].Config.(*DeviceConfig)
+	assert.Equal(t, "1.0", cfg.Version)
+}
+
+// TestGetDeviceConfigsFromFile4 tests getting ConfigContext for all device configs found.
+// In this case, multiple valid configs are found.
+func TestGetDeviceConfigsFromFile4(t *testing.T) {
+	// Set up the test dir
+	test.SetupTestDir(t)
+	defer test.ClearTestDir(t)
+
+	data := `
+version: "1.0"
+`
+
+	// Add a file to the dir
+	foo := test.WriteTempFile(t, "foo.yaml", data, os.ModePerm)
+	bar := test.WriteTempFile(t, "bar.yml", data, os.ModePerm)
+
+	// Set up the test env
+	test.SetEnv(t, EnvDevicePath, test.TempDir)
+	defer test.RemoveEnv(t, EnvDevicePath)
+
+	ctxs, err := GetDeviceConfigsFromFile()
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(ctxs))
+
+	barCtx := ctxs[0]
+	assert.Equal(t, bar, barCtx.Source)
+	assert.True(t, barCtx.IsDeviceConfig())
+	cfg := barCtx.Config.(*DeviceConfig)
+	assert.Equal(t, "1.0", cfg.Version)
+
+	fooCtx := ctxs[1]
+	assert.Equal(t, foo, fooCtx.Source)
+	assert.True(t, fooCtx.IsDeviceConfig())
+	cfg = fooCtx.Config.(*DeviceConfig)
+	assert.Equal(t, "1.0", cfg.Version)
+}
+
+// TestNewPluginConfig tests getting a new plugin config from file. In this case,
+// we set the search path from env. The path will not exist.
+func TestNewPluginConfig(t *testing.T) {
+	// Reset the global viper instance for the test
+	viper.Reset()
+
+	// Set up the test env
+	test.SetEnv(t, EnvPluginConfig, "foo/bar/baz")
+	defer test.RemoveEnv(t, EnvPluginConfig)
+
+	cfg, err := NewPluginConfig()
+	assert.Error(t, err)
+	assert.Nil(t, cfg)
+}
+
+// TestNewPluginConfig2 tests getting a new plugin config from file. In this case,
+// we set the search path from env. The path will exist, but will not contain any
+// configs.
+func TestNewPluginConfig2(t *testing.T) {
+	// Reset the global viper instance for the test
+	viper.Reset()
+
+	// Set up the test dir
+	test.SetupTestDir(t)
+	defer test.ClearTestDir(t)
+
+	// Set up the test env
+	test.SetEnv(t, EnvPluginConfig, test.TempDir)
+	defer test.RemoveEnv(t, EnvPluginConfig)
+
+	cfg, err := NewPluginConfig()
+	assert.Error(t, err)
+	assert.Nil(t, cfg)
+}
+
+// TestNewPluginConfig3 tests getting a new plugin config from file. In this case,
+// we set the search path from env. The path will exist and will contain an invalid
+// config.
+func TestNewPluginConfig3(t *testing.T) {
+	// Reset the global viper instance for the test
+	viper.Reset()
+
+	// Set up the test dir
+	test.SetupTestDir(t)
+	defer test.ClearTestDir(t)
+
+	// Data for the test config
+	data := `
+version:: "1.0"
+debug true
+settings
+  mode: serial
+`
+
+	// Add a file to the dir
+	_ = test.WriteTempFile(t, "config.yaml", data, os.ModePerm)
+
+	// Set up the test env
+	test.SetEnv(t, EnvPluginConfig, test.TempDir)
+	defer test.RemoveEnv(t, EnvPluginConfig)
+
+	cfg, err := NewPluginConfig()
+	assert.Error(t, err)
+	assert.Nil(t, cfg)
+}
+
+// TestNewPluginConfig4 tests getting a new plugin config from file. In this case,
+// we set the search path from env. The path will exist and contain a valid config.
+func TestNewPluginConfig4(t *testing.T) {
+	// Reset the global viper instance for the test
+	viper.Reset()
+
+	// Set up the test dir
+	test.SetupTestDir(t)
+	defer test.ClearTestDir(t)
+
+	// Data for the test config
+	data := `
+version: "1.0"
+debug: true
+network:
+  type: tcp
+  address: ":5001"
+settings:
+  mode: serial
+  read:
+    interval: 3s
+`
+
+	// Add a file to the dir
+	_ = test.WriteTempFile(t, "config.yml", data, os.ModePerm)
+
+	// Set up the test env
+	test.SetEnv(t, EnvPluginConfig, test.TempDir)
+	defer test.RemoveEnv(t, EnvPluginConfig)
+
+	cfg, err := NewPluginConfig()
+	assert.NoError(t, err)
+	assert.NotNil(t, cfg)
+
+	// Check the configured values
+	assert.Equal(t, "1.0", cfg.Version)
+	assert.Equal(t, true, cfg.Debug)
+	assert.Equal(t, "tcp", cfg.Network.Type)
+	assert.Equal(t, ":5001", cfg.Network.Address)
+	assert.Equal(t, "serial", cfg.Settings.Mode)
+	assert.Equal(t, "3s", cfg.Settings.Read.Interval)
+
+	// Check some of the default values that were not overwritten
+	assert.Equal(t, 100, cfg.Settings.Read.Buffer)
+	assert.Equal(t, true, cfg.Settings.Read.Enabled)
+	assert.Equal(t, 100, cfg.Settings.Write.Buffer)
+	assert.Equal(t, 100, cfg.Settings.Write.Max)
+	assert.Equal(t, true, cfg.Settings.Write.Enabled)
+	assert.Equal(t, "1s", cfg.Settings.Write.Interval)
+	assert.Equal(t, "5m", cfg.Settings.Transaction.TTL)
+
+	assert.Nil(t, cfg.Limiter)
+}
+
+// TestNewPluginConfig5 tests getting a new plugin config from file. In this case,
+// we will use the default search path and find a valid config.
+func TestNewPluginConfig5(t *testing.T) {
+	// Reset the global viper instance for the test
+	viper.Reset()
+
+	// Set up the test dir
+	test.SetupTestDir(t)
+	defer test.ClearTestDir(t)
+
+	// Data for the test config
+	data := `
+version: "1.0"
+debug: false
+network:
+  type: unix
+  address: "test.sock"
+settings:
+  mode: parallel
+  read:
+    interval: 1s
+    buffer: 150
+  write:
+    enabled: false
+limiter:
+  rate: 100
+  burst: 50
+`
+
+	// Add a file to the dir
+	_ = test.WriteTempFile(t, "config.yml", data, os.ModePerm)
+
+	// Set the search path to be the temp dir
+	pluginConfigSearchPaths = []string{test.TempDir}
+
+	cfg, err := NewPluginConfig()
+	assert.NoError(t, err)
+	assert.NotNil(t, cfg)
+
+	// Check the configured values
+	assert.Equal(t, "1.0", cfg.Version)
+	assert.Equal(t, false, cfg.Debug)
+	assert.Equal(t, "unix", cfg.Network.Type)
+	assert.Equal(t, "test.sock", cfg.Network.Address)
+	assert.Equal(t, "parallel", cfg.Settings.Mode)
+	assert.Equal(t, "1s", cfg.Settings.Read.Interval)
+	assert.Equal(t, 150, cfg.Settings.Read.Buffer)
+	assert.Equal(t, false, cfg.Settings.Write.Enabled)
+	assert.Equal(t, 100, cfg.Limiter.Rate)
+	assert.Equal(t, 50, cfg.Limiter.Burst)
+
+	// Check some of the default values that were not overwritten
+	assert.Equal(t, true, cfg.Settings.Read.Enabled)
+	assert.Equal(t, 100, cfg.Settings.Write.Buffer)
+	assert.Equal(t, 100, cfg.Settings.Write.Max)
+	assert.Equal(t, "1s", cfg.Settings.Write.Interval)
+	assert.Equal(t, "5m", cfg.Settings.Transaction.TTL)
 }

--- a/sdk/cfg/validation.go
+++ b/sdk/cfg/validation.go
@@ -78,14 +78,13 @@ func (validator *SchemeValidator) Validate(context *ConfigContext, domain string
 }
 
 // clearState clears the state tracked for a single validation run.
-// TODO - make sure we can still return errors correctly with this.
 func (validator *SchemeValidator) clearState() {
 	validator.context = nil
 	validator.errors = nil
 	validator.version = nil
 }
 
-// validate is the entrypoint for validation.
+// validate is the entry point for validation.
 func (validator *SchemeValidator) validate(config interface{}) {
 	val := reflect.ValueOf(config)
 

--- a/sdk/cfg/validation.go
+++ b/sdk/cfg/validation.go
@@ -46,14 +46,19 @@ type SchemeValidator struct {
 // This function takes a ConfigContext, which provides both the SchemeVersion to
 // validate against, and the config to validate, and a "source", which is attributed
 // to the errors in the event that any are found.
-func (validator *SchemeValidator) Validate(context *ConfigContext, domain string) error {
-	// Before we start, apply the state to the validator.
+func (validator *SchemeValidator) Validate(context *ConfigContext, domain string) *errors.MultiError {
+	// Once we're done validating, we'll want to clear the state from this validation.
+	defer validator.clearState()
+
+	// Before we start validating, apply the state to the validator.
+	validator.errors = errors.NewMultiError(domain)
+
 	version, err := context.Config.GetSchemeVersion()
 	if err != nil {
-		return err
+		validator.errors.Add(errors.NewValidationError(context.Source, err.Error()))
+		return validator.errors
 	}
 	validator.context = context
-	validator.errors = errors.NewMultiError(domain)
 	validator.version = version
 
 	// We will also want to add to the MultiError context to specify the
@@ -69,7 +74,7 @@ func (validator *SchemeValidator) Validate(context *ConfigContext, domain string
 	validator.validate(context.Config)
 
 	// Return validation errors, if any were found.
-	return validator.errors.Err()
+	return validator.errors
 }
 
 // clearState clears the state tracked for a single validation run.
@@ -110,7 +115,7 @@ func (validator *SchemeValidator) walk(v reflect.Value) {
 		validator.walkStructFields(v)
 
 		// If the struct implements the ConfigComponent interface, validate the struct.
-		ifaceType := reflect.TypeOf((*ConfigComponent)(nil)).Elem()
+		ifaceType := reflect.TypeOf(new(ConfigComponent)).Elem()
 		if v.Type().Implements(ifaceType) {
 			v.Interface().(ConfigComponent).Validate(validator.errors)
 		}
@@ -119,6 +124,9 @@ func (validator *SchemeValidator) walk(v reflect.Value) {
 		for i := 0; i < v.Len(); i++ {
 			validator.walk(v.Index(i))
 		}
+
+	case reflect.Ptr, reflect.Interface:
+		validator.walk(v.Elem())
 	}
 }
 
@@ -161,14 +169,15 @@ func (validator *SchemeValidator) validateField(field reflect.Value, structField
 			addedInScheme, err := NewSchemeVersion(tag)
 			if err != nil {
 				validator.errors.Add(err)
-			}
-			if version.IsLessThan(addedInScheme) {
-				validator.errors.Add(errors.NewFieldNotSupportedError(
-					validator.context.Source,
-					structField.Name,
-					addedInScheme.String(),
-					version.String(),
-				))
+			} else {
+				if version.IsLessThan(addedInScheme) {
+					validator.errors.Add(errors.NewFieldNotSupportedError(
+						validator.context.Source,
+						structField.Name,
+						addedInScheme.String(),
+						version.String(),
+					))
+				}
 			}
 		}
 
@@ -178,12 +187,13 @@ func (validator *SchemeValidator) validateField(field reflect.Value, structField
 			deprecatedInScheme, err := NewSchemeVersion(tag)
 			if err != nil {
 				validator.errors.Add(err)
-			}
-			if version.IsGreaterOrEqualTo(deprecatedInScheme) {
-				logger.Warnf(
-					"config field '%s' was deprecated in scheme version %s (current config scheme: %s)",
-					structField.Name, deprecatedInScheme.String(), version.String(),
-				)
+			} else {
+				if version.IsGreaterOrEqualTo(deprecatedInScheme) {
+					logger.Warnf(
+						"config field '%s' was deprecated in scheme version %s (current config scheme: %s)",
+						structField.Name, deprecatedInScheme.String(), version.String(),
+					)
+				}
 			}
 		}
 
@@ -193,21 +203,22 @@ func (validator *SchemeValidator) validateField(field reflect.Value, structField
 			removedInScheme, err := NewSchemeVersion(tag)
 			if err != nil {
 				validator.errors.Add(err)
-			}
-			if version.IsGreaterOrEqualTo(removedInScheme) {
-				validator.errors.Add(errors.NewFieldRemovedError(
-					validator.context.Source,
-					structField.Name,
-					removedInScheme.String(),
-					version.String(),
-				))
+			} else {
+				if version.IsGreaterOrEqualTo(removedInScheme) {
+					validator.errors.Add(errors.NewFieldRemovedError(
+						validator.context.Source,
+						structField.Name,
+						removedInScheme.String(),
+						version.String(),
+					))
+				}
 			}
 		}
 	}
 }
 
 // isEmptyValue checks if a value is its empty type.
-func (validator *SchemeValidator) isEmptyValue(v reflect.Value) bool {
+func (validator *SchemeValidator) isEmptyValue(v reflect.Value) bool { // nolint: gocyclo
 	switch v.Kind() {
 	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
 		return v.Len() == 0
@@ -221,8 +232,18 @@ func (validator *SchemeValidator) isEmptyValue(v reflect.Value) bool {
 		return v.Float() == 0
 	case reflect.Interface, reflect.Ptr:
 		return v.IsNil()
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			isEmpty := validator.isEmptyValue(v.Field(i))
+			if !isEmpty {
+				return false
+			}
+		}
+		// If we get here, then all fields of the struct are empty,
+		// so the struct is empty.
+		return true
 	default:
-		logger.Warn("No case for empty value check: %v", v.Kind())
+		logger.Warnf("No case for empty value check: %v", v.Kind())
 	}
 	return false
 }

--- a/sdk/cfg/validation_test.go
+++ b/sdk/cfg/validation_test.go
@@ -1,0 +1,514 @@
+package cfg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vapor-ware/synse-sdk/sdk/errors"
+)
+
+// FIXME -- some of this stuff could probably move to internal/test
+
+//
+// Test Structures / Type Definitions
+//
+
+// simpleTestConfig is a simple struct that fulfils both the ConfigBase
+// and ConfigComponent interface. It is used to test simple validation
+// cases.
+type simpleTestConfig struct {
+	ConfigVersion
+
+	TestField string `addedIn:"1.0" deprecatedIn:"1.5" removedIn:"2.0"`
+
+	BadAddedInTag      string `addedIn:"xyz.1"`
+	BadDeprecatedInTag string `deprecatedIn:"xyz.1"`
+	BadRemovedInTag    string `removedIn:"xyz.1"`
+}
+
+func (config simpleTestConfig) Validate(multiErr *errors.MultiError) {
+	_, err := config.GetSchemeVersion()
+	if err != nil {
+		multiErr.Add(errors.NewValidationError(multiErr.Context["source"], err.Error()))
+	}
+
+	if config.TestField == "" {
+		multiErr.Add(errors.NewFieldRequiredError(multiErr.Context["source"], "testField"))
+	}
+}
+
+// complexTestConfig is a simple struct that fulfils both the ConfigBase
+// and ConfigComponent interface. It is used to test complex validation
+// cases where there are nested and grouped components.
+type complexTestConfig struct {
+	ConfigVersion
+
+	Foo      bool               `addedIn:"1.0" removedIn:"1.5"`
+	Simples  []simpleTestConfig `addedIn:"1.5"`
+	FloatVal float64            `addedIn:"1.0" deprecatedIn:"3.0"`
+	IntVal   int32              `addedIn:"1.0"`
+	UintVal  uint8              `addedIn:"1.0" deprecatedIn:"2.0" removedIn:"3.0"`
+
+	RootUser *nestedStruct   `addedIn:"1.0"`
+	Users    []*nestedStruct `addedIn:"1.5"`
+}
+
+func (config complexTestConfig) Validate(multiErr *errors.MultiError) {
+	_, err := config.GetSchemeVersion()
+	if err != nil {
+		multiErr.Add(errors.NewValidationError(multiErr.Context["source"], err.Error()))
+	}
+
+	if config.UintVal > 8 {
+		multiErr.Add(errors.NewInvalidValueError(
+			multiErr.Context["source"],
+			"uintVal",
+			"less than or equal to 8",
+		))
+	}
+}
+
+type nestedStruct struct {
+	User string `addedIn:"1.0"`
+	Pass string `addedIn:"1.0"`
+}
+
+func (n nestedStruct) Validate(multiError *errors.MultiError) {
+	if n.User == "" {
+		multiError.Add(errors.NewFieldRequiredError(multiError.Context["source"], "user"))
+	}
+}
+
+//
+// Helper Functions
+//
+
+// checkValidationCleanup checks to make sure that the validator cleaned up
+// after a Validation run. This prevents previous run state from persisting
+// to the next run.
+func checkValidationCleanup(t *testing.T) {
+	assert.Nil(t, Validator.context)
+	assert.Nil(t, Validator.errors)
+	assert.Nil(t, Validator.version)
+}
+
+//
+// Test Cases
+//
+
+// TestSchemeValidator_Validate_Simple_Ok tests validating a simple struct where everything is ok.
+func TestSchemeValidator_Validate_Simple_Ok(t *testing.T) {
+	toValidate := &ConfigContext{
+		Source: "<simple test config>",
+		Config: &simpleTestConfig{
+			ConfigVersion: ConfigVersion{Version: "1.0"},
+			TestField:     "foo",
+		},
+	}
+
+	err := Validator.Validate(toValidate, "test")
+	assert.NoError(t, err.Err())
+
+	// check that validation cleanup was successful
+	checkValidationCleanup(t)
+}
+
+// TestSchemeValidator_Validate_Simple_UnsupportedVersion tests validating a simple struct where
+// the ConfigVersion of the struct is less than that of a specified field.
+func TestSchemeValidator_Validate_Simple_UnsupportedVersion(t *testing.T) {
+	toValidate := &ConfigContext{
+		Source: "<simple test config>",
+		Config: &simpleTestConfig{
+			ConfigVersion: ConfigVersion{Version: "0.5"}, // config version less than addedIn tag for both fields
+			TestField:     "foo",
+		},
+	}
+
+	err := Validator.Validate(toValidate, "test")
+	assert.Error(t, err.Err())
+	assert.Equal(t, 2, len(err.Errors), err.Error())
+
+	// check that validation cleanup was successful
+	checkValidationCleanup(t)
+}
+
+// TestSchemeValidator_Validate_Simple_DeprecatedVersion1 tests validating a simple struct where
+// the ConfigVersion of the struct is equal to the deprecatedIn tag of a field.
+func TestSchemeValidator_Validate_Simple_DeprecatedVersion1(t *testing.T) {
+	toValidate := &ConfigContext{
+		Source: "<simple test config>",
+		Config: &simpleTestConfig{
+			ConfigVersion: ConfigVersion{Version: "1.5"}, // equal to deprecatedIn tag for TestField
+			TestField:     "foo",
+		},
+	}
+
+	err := Validator.Validate(toValidate, "test")
+	assert.NoError(t, err.Err()) // deprecated logs warning, no error
+
+	// check that validation cleanup was successful
+	checkValidationCleanup(t)
+}
+
+// TestSchemeValidator_Validate_Simple_DeprecatedVersion2 tests validating a simple struct where
+// the ConfigVersion of the struct is greater than the deprecatedIn tag of a field.
+func TestSchemeValidator_Validate_Simple_DeprecatedVersion2(t *testing.T) {
+	toValidate := &ConfigContext{
+		Source: "<simple test config>",
+		Config: &simpleTestConfig{
+			ConfigVersion: ConfigVersion{Version: "1.8"}, // greater than deprecatedIn tag for TestField
+			TestField:     "foo",
+		},
+	}
+
+	err := Validator.Validate(toValidate, "test")
+	assert.NoError(t, err.Err()) // deprecated logs warning, no error
+
+	// check that validation cleanup was successful
+	checkValidationCleanup(t)
+}
+
+// TestSchemeValidator_Validate_Simple_RemovedVersion1 tests validating a simple struct where
+// the ConfigVersion of the struct is equal to the removedIn tag of a field.
+func TestSchemeValidator_Validate_Simple_RemovedVersion1(t *testing.T) {
+	toValidate := &ConfigContext{
+		Source: "<simple test config>",
+		Config: &simpleTestConfig{
+			ConfigVersion: ConfigVersion{Version: "2.0"}, // equal to removedIn tag for TestField
+			TestField:     "foo",
+		},
+	}
+
+	err := Validator.Validate(toValidate, "test")
+	assert.Error(t, err.Err())
+	assert.Equal(t, 1, len(err.Errors), err.Error())
+
+	// check that validation cleanup was successful
+	checkValidationCleanup(t)
+}
+
+// TestSchemeValidator_Validate_Simple_RemovedVersion2 tests validating a simple struct where
+// the ConfigVersion of the struct is greater than the removedIn tag of a field.
+func TestSchemeValidator_Validate_Simple_RemovedVersion2(t *testing.T) {
+	toValidate := &ConfigContext{
+		Source: "<simple test config>",
+		Config: &simpleTestConfig{
+			ConfigVersion: ConfigVersion{Version: "2.1"}, // greater than removedIn tag for TestField
+			TestField:     "foo",
+		},
+	}
+
+	err := Validator.Validate(toValidate, "test")
+	assert.Error(t, err.Err())
+	assert.Equal(t, 1, len(err.Errors), err.Error())
+
+	// check that validation cleanup was successful
+	checkValidationCleanup(t)
+}
+
+// TestSchemeValidator_Validate_Error tests validating a simple struct where
+// the versions resolve, but the Validate function fails for one field.
+func TestSchemeValidator_Validate_Error(t *testing.T) {
+	toValidate := &ConfigContext{
+		Source: "<simple test config>",
+		Config: &simpleTestConfig{
+			ConfigVersion: ConfigVersion{Version: "1.0"},
+			TestField:     "", // TestField required, will fail Validate()
+		},
+	}
+
+	err := Validator.Validate(toValidate, "test")
+	assert.Error(t, err.Err())
+	assert.Equal(t, 1, len(err.Errors), err.Error())
+
+	// check that validation cleanup was successful
+	checkValidationCleanup(t)
+}
+
+// TestSchemeValidator_Validate_Error2 tests validating a simple struct where
+// the version is out of bounds and the Validate function fails for a field.
+// In this case, the field that is required but not specified is the one out
+// of bounds of the version. If a field is not set, we won't validate its version,
+// so it should only result in one of those errors being captured.
+func TestSchemeValidator_Validate_Error2(t *testing.T) {
+	toValidate := &ConfigContext{
+		Source: "<simple test config>",
+		Config: &simpleTestConfig{
+			ConfigVersion: ConfigVersion{Version: "3.0"},
+			TestField:     "", // TestField required, will fail Validate()
+		},
+	}
+
+	err := Validator.Validate(toValidate, "test")
+	assert.Error(t, err.Err())
+	assert.Equal(t, 1, len(err.Errors), err.Error())
+
+	// check that validation cleanup was successful
+	checkValidationCleanup(t)
+}
+
+// TestSchemeValidator_Validate_Simple_BadConfigScheme tests validating a simple struct where
+// the ConfigVersion specified a bad scheme version.
+func TestSchemeValidator_Validate_Simple_BadConfigScheme(t *testing.T) {
+	toValidate := &ConfigContext{
+		Source: "<simple test config>",
+		Config: &simpleTestConfig{
+			ConfigVersion: ConfigVersion{Version: "xyz.xyz"}, // bad scheme version
+			TestField:     "foo",
+		},
+	}
+
+	err := Validator.Validate(toValidate, "test")
+	assert.Error(t, err.Err())
+	assert.Equal(t, 1, len(err.Errors), err.Error())
+
+	// check that validation cleanup was successful
+	checkValidationCleanup(t)
+}
+
+// TestSchemeValidator_Validate_Simple_BadAddedInTag tests validating a simple struct where
+// a field specifies a bad "addedIn" tag.
+func TestSchemeValidator_Validate_Simple_BadAddedInTag(t *testing.T) {
+	toValidate := &ConfigContext{
+		Source: "<simple test config>",
+		Config: &simpleTestConfig{
+			ConfigVersion: ConfigVersion{Version: "1.0"},
+			TestField:     "foo",
+			BadAddedInTag: "bar", // this field has a bad addedIn tag in the struct definition
+		},
+	}
+
+	err := Validator.Validate(toValidate, "test")
+	assert.Error(t, err.Err())
+	assert.Equal(t, 1, len(err.Errors), err.Error())
+
+	// check that validation cleanup was successful
+	checkValidationCleanup(t)
+}
+
+// TestSchemeValidator_Validate_Simple_BadDeprecatedInTag tests validating a simple struct where
+// a field specifies a bad "deprecatedIn" tag.
+func TestSchemeValidator_Validate_Simple_BadDeprecatedInTag(t *testing.T) {
+	toValidate := &ConfigContext{
+		Source: "<simple test config>",
+		Config: &simpleTestConfig{
+			ConfigVersion:      ConfigVersion{Version: "1.0"},
+			TestField:          "foo",
+			BadDeprecatedInTag: "bar", // this field has a bad deprecatedIn tag in the struct definition
+		},
+	}
+
+	err := Validator.Validate(toValidate, "test")
+	assert.Error(t, err.Err())
+	assert.Equal(t, 1, len(err.Errors), err.Error())
+
+	// check that validation cleanup was successful
+	checkValidationCleanup(t)
+}
+
+// TestSchemeValidator_Validate_Simple_BadRemovedInTag tests validating a simple struct where
+// a field specifies a bad "removedIn" tag.
+func TestSchemeValidator_Validate_Simple_BadRemovedInTag(t *testing.T) {
+	toValidate := &ConfigContext{
+		Source: "<simple test config>",
+		Config: &simpleTestConfig{
+			ConfigVersion:   ConfigVersion{Version: "1.0"},
+			TestField:       "foo",
+			BadRemovedInTag: "bar", // this field has a bad removedIn tag in the struct definition
+		},
+	}
+
+	err := Validator.Validate(toValidate, "test")
+	assert.Error(t, err.Err())
+	assert.Equal(t, 1, len(err.Errors), err.Error())
+
+	// check that validation cleanup was successful
+	checkValidationCleanup(t)
+}
+
+// TestSchemeValidator_validate passes a bad value to the validate function, so we expect
+// it to fail.
+func TestSchemeValidator_validate(t *testing.T) {
+	defer Validator.clearState()
+
+	// Validate expects either an interface, pointer, or struct. If an interface
+	// or pointer, it should ultimately resolve down to a struct. Here we will
+	// give a pointer to a slice.
+	x := []string{"foo"}
+
+	// Since all of the setup is done in Validate (the exported function), we need to
+	// ensure we have all the pieces we need here manually.
+	multiErr := errors.NewMultiError("<validate test>")
+	Validator.errors = multiErr
+	Validator.context = NewConfigContext("test", &simpleTestConfig{})
+
+	Validator.validate(x)
+
+	assert.Error(t, multiErr.Err())
+	assert.Equal(t, 1, len(multiErr.Errors), multiErr.Error())
+}
+
+// TestSchemeValidator_Validate_Complex_Ok tests validating a complex struct where everything is ok.
+func TestSchemeValidator_Validate_Complex_Ok(t *testing.T) {
+	toValidate := &ConfigContext{
+		Source: "<complex test config>",
+		Config: &complexTestConfig{
+			ConfigVersion: ConfigVersion{Version: "1.0"},
+			Foo:           true,
+			FloatVal:      20,
+			IntVal:        3,
+			UintVal:       2,
+			RootUser: &nestedStruct{
+				User: "admin",
+				Pass: "admin",
+			},
+		},
+	}
+
+	err := Validator.Validate(toValidate, "test")
+	assert.NoError(t, err.Err())
+
+	// check that validation cleanup was successful
+	checkValidationCleanup(t)
+}
+
+// TestSchemeValidator_Validate_Complex_Ok2 tests validating a complex struct where everything is ok,
+// but some values are specified as the zero value for that type.
+func TestSchemeValidator_Validate_Complex_Ok2(t *testing.T) {
+	toValidate := &ConfigContext{
+		Source: "<complex test config>",
+		Config: &complexTestConfig{
+			ConfigVersion: ConfigVersion{Version: "1.0"},
+			Foo:           false,
+			FloatVal:      0,
+			IntVal:        0,
+			UintVal:       0,
+			RootUser: &nestedStruct{
+				User: "admin",
+				Pass: "admin",
+			},
+		},
+	}
+
+	err := Validator.Validate(toValidate, "test")
+	assert.NoError(t, err.Err())
+
+	// check that validation cleanup was successful
+	checkValidationCleanup(t)
+}
+
+// TestSchemeValidator_Validate_Complex_Error tests validating a complex struct where
+// there are errors due to SchemeVersion mismatches. In this case, it is for fields
+// specified in a version before they are supported.
+func TestSchemeValidator_Validate_Complex_Error(t *testing.T) {
+	toValidate := &ConfigContext{
+		Source: "<complex test config>",
+		Config: &complexTestConfig{
+			ConfigVersion: ConfigVersion{Version: "1.0"},
+			Simples: []simpleTestConfig{
+				{
+					ConfigVersion: ConfigVersion{Version: "1.0"},
+					TestField:     "foo",
+				},
+			},
+			Foo:      true,
+			FloatVal: 20,
+			IntVal:   3,
+			UintVal:  2,
+			RootUser: &nestedStruct{
+				User: "admin",
+				Pass: "admin",
+			},
+			Users: []*nestedStruct{
+				{
+					User: "other",
+					Pass: "foobar",
+				},
+			},
+		},
+	}
+
+	err := Validator.Validate(toValidate, "test")
+	assert.Error(t, err.Err())
+	assert.Equal(t, 2, len(err.Errors), err.Error())
+
+	// check that validation cleanup was successful
+	checkValidationCleanup(t)
+}
+
+// TestSchemeValidator_Validate_Complex_Error2 tests validating a complex struct where
+// there are errors due to SchemeVersion mismatches. In this case, it is for fields
+// specified in a version after they were removed.
+func TestSchemeValidator_Validate_Complex_Error2(t *testing.T) {
+	toValidate := &ConfigContext{
+		Source: "<complex test config>",
+		Config: &complexTestConfig{
+			ConfigVersion: ConfigVersion{Version: "3.0"},
+			Simples: []simpleTestConfig{
+				{
+					ConfigVersion: ConfigVersion{Version: "3.0"},
+					TestField:     "foo",
+				},
+			},
+			Foo:      true,
+			FloatVal: 20,
+			IntVal:   3,
+			UintVal:  2,
+			RootUser: &nestedStruct{
+				User: "admin",
+				Pass: "admin",
+			},
+			Users: []*nestedStruct{
+				{
+					User: "other",
+					Pass: "foobar",
+				},
+			},
+		},
+	}
+
+	err := Validator.Validate(toValidate, "test")
+	assert.Error(t, err.Err())
+	assert.Equal(t, 3, len(err.Errors), err.Error())
+
+	// check that validation cleanup was successful
+	checkValidationCleanup(t)
+}
+
+// TestSchemeValidator_Validate_Complex_Error3 tests validating a complex struct where
+// there are errors due to SchemeVersion mismatches. In this case, it is for ConfigComponent
+// validation errors.
+func TestSchemeValidator_Validate_Complex_Error3(t *testing.T) {
+	toValidate := &ConfigContext{
+		Source: "<complex test config>",
+		Config: &complexTestConfig{
+			ConfigVersion: ConfigVersion{Version: "1.5"},
+			Simples: []simpleTestConfig{
+				{
+					ConfigVersion: ConfigVersion{Version: "1.0"},
+					TestField:     "", // error #1
+				},
+			},
+			FloatVal: 20,
+			IntVal:   3,
+			UintVal:  9, // error #2
+			RootUser: &nestedStruct{
+				User: "", // error #3
+				Pass: "admin",
+			},
+			Users: []*nestedStruct{
+				{
+					User: "", // error #4
+					Pass: "foobar",
+				},
+			},
+		},
+	}
+
+	err := Validator.Validate(toValidate, "test")
+	assert.Error(t, err.Err())
+	assert.Equal(t, 4, len(err.Errors), err.Error())
+
+	// check that validation cleanup was successful
+	checkValidationCleanup(t)
+}

--- a/sdk/cfg/validation_test.go
+++ b/sdk/cfg/validation_test.go
@@ -7,8 +7,6 @@ import (
 	"github.com/vapor-ware/synse-sdk/sdk/errors"
 )
 
-// FIXME -- some of this stuff could probably move to internal/test
-
 //
 // Test Structures / Type Definitions
 //

--- a/sdk/cfg/versioning.go
+++ b/sdk/cfg/versioning.go
@@ -29,13 +29,14 @@ func NewSchemeVersion(versionString string) (*SchemeVersion, error) {
 	}
 
 	s := strings.Split(versionString, ".")
-	if len(s) == 1 {
+	switch len(s) {
+	case 1:
 		maj, err = strconv.Atoi(s[0])
 		if err != nil {
 			return nil, err
 		}
 		min = 0
-	} else {
+	case 2:
 		maj, err = strconv.Atoi(s[0])
 		if err != nil {
 			return nil, err
@@ -44,6 +45,8 @@ func NewSchemeVersion(versionString string) (*SchemeVersion, error) {
 		if err != nil {
 			return nil, err
 		}
+	default:
+		return nil, fmt.Errorf("too many version components - should only have MAJOR[.MINOR]")
 	}
 
 	return &SchemeVersion{
@@ -98,35 +101,12 @@ type ConfigVersion struct {
 }
 
 // parseScheme parses the Version field into a SchemeVersion.
-func (configVersion *ConfigVersion) parseScheme() (err error) {
-	var min, maj int
-
-	if configVersion.Version == "" {
-		return fmt.Errorf("no version info found")
+func (configVersion *ConfigVersion) parseScheme() error {
+	scheme, err := NewSchemeVersion(configVersion.Version)
+	if err != nil {
+		return err
 	}
-
-	s := strings.Split(configVersion.Version, ".")
-	if len(s) == 1 {
-		maj, err = strconv.Atoi(s[0])
-		if err != nil {
-			return
-		}
-		min = 0
-	} else {
-		maj, err = strconv.Atoi(s[0])
-		if err != nil {
-			return
-		}
-		min, err = strconv.Atoi(s[1])
-		if err != nil {
-			return
-		}
-	}
-
-	configVersion.scheme = &SchemeVersion{
-		Major: maj,
-		Minor: min,
-	}
+	configVersion.scheme = scheme
 	return nil
 }
 

--- a/sdk/cfg/versioning_test.go
+++ b/sdk/cfg/versioning_test.go
@@ -1,0 +1,360 @@
+package cfg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestNewSchemeVersion_Ok tests creating a new SchemeVersion with no errors.
+func TestNewSchemeVersion_Ok(t *testing.T) {
+	var testTable = []struct {
+		desc     string
+		in       string
+		expected SchemeVersion
+	}{
+		{
+			desc:     "Version with only major specified",
+			in:       "1",
+			expected: SchemeVersion{1, 0},
+		},
+		{
+			desc:     "Version with major and 0-valued minor",
+			in:       "1.0",
+			expected: SchemeVersion{1, 0},
+		},
+		{
+			desc:     "Version with 0-valued major and minor",
+			in:       "0.1",
+			expected: SchemeVersion{0, 1},
+		},
+		{
+			desc:     "Version with non-0 major and minor",
+			in:       "2.5",
+			expected: SchemeVersion{2, 5},
+		},
+		{
+			desc:     "Version with large major/minor",
+			in:       "12345.12345",
+			expected: SchemeVersion{12345, 12345},
+		},
+		{
+			desc:     "Version with double zero major",
+			in:       "00.1",
+			expected: SchemeVersion{0, 1},
+		},
+		{
+			desc:     "Version with double zero minor",
+			in:       "1.00",
+			expected: SchemeVersion{1, 0},
+		},
+	}
+
+	for _, testCase := range testTable {
+		sv, err := NewSchemeVersion(testCase.in)
+		assert.NoError(t, err, testCase.desc)
+		assert.NotNil(t, sv, testCase.desc)
+		assert.IsType(t, &SchemeVersion{}, sv, testCase.desc)
+		assert.Equal(t, testCase.expected.Major, sv.Major, testCase.desc)
+		assert.Equal(t, testCase.expected.Minor, sv.Minor, testCase.desc)
+	}
+}
+
+// TestNewSchemeVersion_Error tests creating a new SchemeVersion with errors.
+func TestNewSchemeVersion_Error(t *testing.T) {
+	var testTable = []struct {
+		desc string
+		in   string
+	}{
+		{
+			desc: "Empty string used as version",
+			in:   "",
+		},
+		{
+			desc: "Invalid major version, no minor (not an int)",
+			in:   "xyz",
+		},
+		{
+			desc: "Invalid major version (not an int)",
+			in:   "xyz.0",
+		},
+		{
+			desc: "Invalid minor version (not an int)",
+			in:   "1.xyz",
+		},
+		{
+			desc: "Invalid major and minor versions (not an int)",
+			in:   "xyz.xyz",
+		},
+		{
+			desc: "Extra version number components",
+			in:   "1.2.3.4",
+		},
+	}
+
+	for _, testCase := range testTable {
+		sv, err := NewSchemeVersion(testCase.in)
+		assert.Nil(t, sv, testCase.desc)
+		assert.Error(t, err, testCase.desc)
+	}
+}
+
+// TestSchemeVersion_String tests converting a SchemeVersion to a string
+func TestSchemeVersion_String(t *testing.T) {
+	var testTable = []struct {
+		scheme   SchemeVersion
+		expected string
+	}{
+		{
+			scheme:   SchemeVersion{0, 1},
+			expected: "0.1",
+		},
+		{
+			scheme:   SchemeVersion{1, 0},
+			expected: "1.0",
+		},
+		{
+			scheme:   SchemeVersion{1, 1},
+			expected: "1.1",
+		},
+		{
+			scheme:   SchemeVersion{1234, 4321},
+			expected: "1234.4321",
+		},
+	}
+
+	for _, testCase := range testTable {
+		actual := testCase.scheme.String()
+		assert.Equal(t, testCase.expected, actual)
+	}
+}
+
+// TestSchemeVersion_IsEqual test equality of SchemeVersions
+func TestSchemeVersion_IsEqual(t *testing.T) {
+	var testTable = []struct {
+		scheme1 *SchemeVersion
+		scheme2 *SchemeVersion
+		equal   bool
+	}{
+		{
+			scheme1: &SchemeVersion{1, 0},
+			scheme2: &SchemeVersion{1, 0},
+			equal:   true,
+		},
+		{
+			scheme1: &SchemeVersion{0, 1},
+			scheme2: &SchemeVersion{0, 1},
+			equal:   true,
+		},
+		{
+			scheme1: &SchemeVersion{4, 51},
+			scheme2: &SchemeVersion{4, 51},
+			equal:   true,
+		},
+		{
+			scheme1: &SchemeVersion{1, 0},
+			scheme2: &SchemeVersion{2, 0},
+			equal:   false,
+		},
+		{
+			scheme1: &SchemeVersion{1, 1},
+			scheme2: &SchemeVersion{1, 2},
+			equal:   false,
+		},
+	}
+
+	for _, testCase := range testTable {
+		actual := testCase.scheme1.IsEqual(testCase.scheme2)
+		assert.Equal(t, testCase.equal, actual)
+	}
+}
+
+// TestSchemeVersion_IsLessThan tests if one SchemeVersion is less than another
+func TestSchemeVersion_IsLessThan(t *testing.T) {
+	var testTable = []struct {
+		scheme1  *SchemeVersion
+		scheme2  *SchemeVersion
+		lessThan bool
+	}{
+		{
+			scheme1:  &SchemeVersion{1, 0},
+			scheme2:  &SchemeVersion{1, 0},
+			lessThan: false,
+		},
+		{
+			scheme1:  &SchemeVersion{0, 1},
+			scheme2:  &SchemeVersion{0, 1},
+			lessThan: false,
+		},
+		{
+			scheme1:  &SchemeVersion{4, 51},
+			scheme2:  &SchemeVersion{4, 51},
+			lessThan: false,
+		},
+		{
+			scheme1:  &SchemeVersion{1, 0},
+			scheme2:  &SchemeVersion{2, 0},
+			lessThan: true,
+		},
+		{
+			scheme1:  &SchemeVersion{1, 1},
+			scheme2:  &SchemeVersion{1, 2},
+			lessThan: true,
+		},
+		{
+			scheme1:  &SchemeVersion{1, 2},
+			scheme2:  &SchemeVersion{1, 1},
+			lessThan: false,
+		},
+	}
+
+	for _, testCase := range testTable {
+		actual := testCase.scheme1.IsLessThan(testCase.scheme2)
+		assert.Equal(t, testCase.lessThan, actual)
+	}
+}
+
+// TestSchemeVersion_IsGreaterOrEqualTo tests if one SchemeVersion is greater than
+// or qual to another
+func TestSchemeVersion_IsGreaterOrEqualTo(t *testing.T) {
+	var testTable = []struct {
+		scheme1 *SchemeVersion
+		scheme2 *SchemeVersion
+		gte     bool
+	}{
+		{
+			scheme1: &SchemeVersion{1, 0},
+			scheme2: &SchemeVersion{1, 0},
+			gte:     true,
+		},
+		{
+			scheme1: &SchemeVersion{0, 1},
+			scheme2: &SchemeVersion{0, 1},
+			gte:     true,
+		},
+		{
+			scheme1: &SchemeVersion{4, 51},
+			scheme2: &SchemeVersion{4, 51},
+			gte:     true,
+		},
+		{
+			scheme1: &SchemeVersion{1, 0},
+			scheme2: &SchemeVersion{2, 0},
+			gte:     false,
+		},
+		{
+			scheme1: &SchemeVersion{1, 1},
+			scheme2: &SchemeVersion{1, 2},
+			gte:     false,
+		},
+		{
+			scheme1: &SchemeVersion{1, 2},
+			scheme2: &SchemeVersion{1, 1},
+			gte:     true,
+		},
+		{
+			scheme1: &SchemeVersion{2, 1},
+			scheme2: &SchemeVersion{1, 2},
+			gte:     true,
+		},
+	}
+
+	for _, testCase := range testTable {
+		actual := testCase.scheme1.IsGreaterOrEqualTo(testCase.scheme2)
+		assert.Equal(t, testCase.gte, actual)
+	}
+}
+
+// TestConfigVersion_GetSchemeVersion_Ok tests getting the scheme version from a ConfigVersion
+func TestConfigVersion_GetSchemeVersion_Ok(t *testing.T) {
+	var testTable = []struct {
+		desc    string
+		version string
+		scheme  SchemeVersion
+	}{
+		{
+			desc:    "Version with only major specified",
+			version: "1",
+			scheme:  SchemeVersion{1, 0},
+		},
+		{
+			desc:    "Version with major and 0-valued minor",
+			version: "1.0",
+			scheme:  SchemeVersion{1, 0},
+		},
+		{
+			desc:    "Version with 0-valued major and minor",
+			version: "0.1",
+			scheme:  SchemeVersion{0, 1},
+		},
+		{
+			desc:    "Version with non-0 major and minor",
+			version: "2.5",
+			scheme:  SchemeVersion{2, 5},
+		},
+		{
+			desc:    "Version with large major/minor",
+			version: "12345.12345",
+			scheme:  SchemeVersion{12345, 12345},
+		},
+		{
+			desc:    "Version with double zero major",
+			version: "00.1",
+			scheme:  SchemeVersion{0, 1},
+		},
+		{
+			desc:    "Version with double zero minor",
+			version: "1.00",
+			scheme:  SchemeVersion{1, 0},
+		},
+	}
+
+	for _, testCase := range testTable {
+		cfgVer := ConfigVersion{Version: testCase.version}
+		sv, err := cfgVer.GetSchemeVersion()
+		assert.NoError(t, err, testCase.desc)
+		assert.Equal(t, testCase.scheme.Major, sv.Major, testCase.desc)
+		assert.Equal(t, testCase.scheme.Minor, sv.Minor, testCase.desc)
+	}
+}
+
+// TestConfigVersion_GetSchemeVersion_Error tests getting the scheme version from a ConfigVersion
+// which results in error
+func TestConfigVersion_GetSchemeVersion_Error(t *testing.T) {
+	var testTable = []struct {
+		desc    string
+		version string
+	}{
+		{
+			desc:    "Empty string used as version",
+			version: "",
+		},
+		{
+			desc:    "Invalid major version, no minor (not an int)",
+			version: "xyz",
+		},
+		{
+			desc:    "Invalid major version (not an int)",
+			version: "xyz.0",
+		},
+		{
+			desc:    "Invalid minor version (not an int)",
+			version: "1.xyz",
+		},
+		{
+			desc:    "Invalid major and minor versions (not an int)",
+			version: "xyz.xyz",
+		},
+		{
+			desc:    "Extra version number components",
+			version: "1.2.3.4",
+		},
+	}
+
+	for _, testCase := range testTable {
+		cfgVer := ConfigVersion{Version: testCase.version}
+		sv, err := cfgVer.GetSchemeVersion()
+		assert.Error(t, err, testCase.desc)
+		assert.Nil(t, sv, testCase.desc)
+	}
+}


### PR DESCRIPTION
This adds in tests for the new config pieces for SDK v1. Test coverage for the new config is at around 98%.

There are still some cases I want to add tests for, but I'll open separate issues for that. This is big enough as it is.

With these tests providing some amount of verification that things are working as intended, this should fix #213, #209, and makes #195 effectively complete.