### PR TITLE
Add in config policies and constraints

### DIFF
--- a/sdk/defaults/defaults.go
+++ b/sdk/defaults/defaults.go
@@ -1,0 +1,1 @@
+package defaults

--- a/sdk/flags.go
+++ b/sdk/flags.go
@@ -1,0 +1,15 @@
+package sdk
+
+import "flag"
+
+var (
+	flagDebug   bool
+	flagVersion bool
+	flagDryRun  bool
+)
+
+func init() {
+	flag.BoolVar(&flagDebug, "debug", false, "run the plugin with debug logging")
+	flag.BoolVar(&flagVersion, "version", false, "print plugin version information")
+	flag.BoolVar(&flagDryRun, "dry-run", false, "perform a dry run to verify the plugin is functional")
+}

--- a/sdk/plugin.go
+++ b/sdk/plugin.go
@@ -4,12 +4,107 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"flag"
+	"os"
+
 	"github.com/vapor-ware/synse-sdk/sdk/config"
 	"github.com/vapor-ware/synse-sdk/sdk/logger"
 )
 
 type pluginAction func(p *Plugin) error
 type deviceAction func(p *Plugin, d *Device) error
+
+type NPlugin struct {
+}
+
+func (plugin *NPlugin) Run() {
+
+	// ** "Config" steps **
+
+	// Check for command line flags. If any flags are set that require an
+	// action, that action will be resolved here.
+	plugin.resolveFlags()
+
+	// Check for configuration policies. If no policy was set by the plugin,
+	// this will fall back on the default policies.
+	plugin.checkPolicies()
+
+	// Read in all configs and verify that they are correct.
+	plugin.processConfig()
+
+	// ** "Making" steps **
+
+	// FIXME: at this point, we will need to resolve dynamic registration stuff.
+	//   - if dynamic registration makes Devices, just add to the global map.
+	//   - if dynamic registration makes Config artifacts, add to the unified config.
+	// (or maybe this happens in th processConfig step, before unification?)
+
+	// Initialize Device instances for each of the devices configured with
+	// the plugin.
+	plugin.makeDevices()
+
+	// makeTransactionCache
+	// makeDataManager
+	// makeServer
+
+	// ** "Action" steps **
+
+	// preRunActions
+	// deviceSetupActions
+
+	// "Starting" steps **
+
+	// startDataManager
+	// startServer
+
+	// profit
+
+}
+
+// FIXME: its not clear that these private functions need to hang off the Plugin struct..
+
+// resolveFlags parses flags passed to the plugin.
+//
+// Not all flags will result in an action, so not all flags are checked
+// here. Only the flags that cause immediate actions will be processed here.
+// Only SDK supported flags are parsed here. If a plugin specifies additional
+// flags, they should be resolved in their own pre-run action.
+func (plugin *NPlugin) resolveFlags() {
+	flag.Parse()
+
+	// --help is already provided by the flag package, so we don't have
+	// to handle that here.
+
+	// Print out the version info for the plugin.
+	if flagVersion {
+		versionInfo := GetVersion()
+		fmt.Print(versionInfo.Format())
+		os.Exit(0)
+	}
+}
+
+// checkPolicies checks for policies registered with the plugin. If no policies
+// were set, the defaults will be used.
+func (plugin *NPlugin) checkPolicies() {
+	// TODO: implement config policies
+}
+
+// processConfig handles plugin configuration in a number of steps. The behavior
+// of config handling is dependent on the config policy that is set. If no config
+// policies are set, the plugin will terminate in error.
+//
+// There are four major steps to processing plugin configuration: reading in the
+// config, validating the config scheme, config unification, and verifying the
+// config data is correct. These steps should happen for all config types.
+func (plugin *NPlugin) processConfig() {
+	// TODO: implement config processing.. this can probably be done soon, since we have most of what we need.
+}
+
+// makeDevices converts the plugin configuration into the Device instances that
+// represent the physical/virtual devices that the plugin will manage.
+func (plugin *NPlugin) makeDevices() {
+	// TODO: implement
+}
 
 // Plugin represents an instance of a Synse plugin. Along with metadata
 // and definable handlers, it contains a gRPC server to handle the plugin
@@ -303,7 +398,7 @@ func (p *Plugin) logInfo() {
 
 	// Log out the version info
 	versionInfo := GetVersion()
-	versionInfo.Log()
+	logger.Info(versionInfo.Format())
 
 	// Log out configuration info
 	logger.Infof("Plugin Config:")

--- a/sdk/policies/constraints.go
+++ b/sdk/policies/constraints.go
@@ -1,0 +1,69 @@
+package policies
+
+import (
+	"fmt"
+
+	"github.com/vapor-ware/synse-sdk/sdk/errors"
+)
+
+type constraint func([]ConfigPolicy) error
+
+var constraints = []constraint{
+	constraintDeviceConfigNecessity,
+	constraintPluginConfigNecessity,
+}
+
+// CheckConstraints checks the given slice of ConfigPolicies for constraint
+// violations. All constraints are checked and all violations returned.
+func CheckConstraints(policies []ConfigPolicy) *errors.MultiError {
+	multiErr := errors.NewMultiError("ConfigPolicy Constraints")
+	for _, constr := range constraints {
+		err := constr(policies)
+		if err != nil {
+			multiErr.Add(err)
+		}
+	}
+	return multiErr
+}
+
+// constraintPluginConfigNecessity checks that both PluginConfigRequired and
+// PluginConfigOptional are not specified.
+func constraintPluginConfigNecessity(policies []ConfigPolicy) error {
+	var (
+		hasReq, hasOpt bool
+	)
+	for _, policy := range policies {
+		switch policy {
+		case PluginConfigRequired:
+			hasReq = true
+		case PluginConfigOptional:
+			hasOpt = true
+		}
+	}
+	if hasReq && hasOpt {
+		// FIXME: custom config policy error?
+		return fmt.Errorf("both PluginConfigRequired and PluginConfigOptional are specified, but are mutually exclusive")
+	}
+	return nil
+}
+
+// constraintDeviceConfigNecessity checks that both DeviceConfigRequired and
+// DeviceConfigOptional are not specified.
+func constraintDeviceConfigNecessity(policies []ConfigPolicy) error {
+	var (
+		hasReq, hasOpt bool
+	)
+	for _, policy := range policies {
+		switch policy {
+		case DeviceConfigRequired:
+			hasReq = true
+		case DeviceConfigOptional:
+			hasOpt = true
+		}
+	}
+	if hasReq && hasOpt {
+		// FIXME: custom config policy error?
+		return fmt.Errorf("both DeviceConfigRequired and DeviceConfigOptional are specified, but are mutually exclusive")
+	}
+	return nil
+}

--- a/sdk/policies/constraints_test.go
+++ b/sdk/policies/constraints_test.go
@@ -1,0 +1,135 @@
+package policies
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Test_constraintPluginConfigNecessity tests the PluginConfigNecessity constraint.
+func Test_constraintPluginConfigNecessity(t *testing.T) {
+	var testTable = []struct {
+		desc     string
+		policies []ConfigPolicy
+		hasErr   bool
+	}{
+		{
+			desc:     "no policies - should not fail",
+			policies: []ConfigPolicy{},
+			hasErr:   false,
+		},
+		{
+			desc:     "no PluginConfig policies - should not fail",
+			policies: []ConfigPolicy{DeviceConfigOptional, DeviceConfigRequired},
+			hasErr:   false,
+		},
+		{
+			desc:     "one PluginConfig policy - should not fail",
+			policies: []ConfigPolicy{PluginConfigOptional},
+			hasErr:   false,
+		},
+		{
+			desc:     "conflicting PluginConfig policies - should fail",
+			policies: []ConfigPolicy{PluginConfigOptional, PluginConfigRequired},
+			hasErr:   true,
+		},
+	}
+
+	for _, testCase := range testTable {
+		err := constraintPluginConfigNecessity(testCase.policies)
+		if testCase.hasErr {
+			assert.Error(t, err, testCase.desc)
+		} else {
+			assert.NoError(t, err, testCase.desc)
+		}
+	}
+}
+
+// Test_constraintDeviceConfigNecessity tests the DeviceConfigNecessity constraint.
+func Test_constraintDeviceConfigNecessity(t *testing.T) {
+	var testTable = []struct {
+		desc     string
+		policies []ConfigPolicy
+		hasErr   bool
+	}{
+		{
+			desc:     "no policies - should not fail",
+			policies: []ConfigPolicy{},
+			hasErr:   false,
+		},
+		{
+			desc:     "no DeviceConfig policies - should not fail",
+			policies: []ConfigPolicy{PluginConfigRequired, PluginConfigOptional},
+			hasErr:   false,
+		},
+		{
+			desc:     "one DeviceConfig policy - should not fail",
+			policies: []ConfigPolicy{DeviceConfigRequired},
+			hasErr:   false,
+		},
+		{
+			desc:     "conflicting DeviceConfig policies - should fail",
+			policies: []ConfigPolicy{DeviceConfigRequired, DeviceConfigOptional},
+			hasErr:   true,
+		},
+	}
+
+	for _, testCase := range testTable {
+		err := constraintDeviceConfigNecessity(testCase.policies)
+		if testCase.hasErr {
+			assert.Error(t, err, testCase.desc)
+		} else {
+			assert.NoError(t, err, testCase.desc)
+		}
+	}
+}
+
+// TestCheckConstraints tests checking constraints against lists of ConfigPolicies
+func TestCheckConstraints(t *testing.T) {
+	var testTable = []struct {
+		desc     string
+		policies []ConfigPolicy
+		errCount int
+	}{
+		{
+			desc:     "no policies - should not fail",
+			policies: []ConfigPolicy{},
+			errCount: 0,
+		},
+		{
+			desc:     "one DeviceConfig policy - should not fail",
+			policies: []ConfigPolicy{DeviceConfigOptional},
+			errCount: 0,
+		},
+		{
+			desc:     "one PluginConfig policy - should not fail",
+			policies: []ConfigPolicy{PluginConfigRequired},
+			errCount: 0,
+		},
+		{
+			desc:     "one DeviceConfig and PluginConfig policy - should not fail",
+			policies: []ConfigPolicy{DeviceConfigRequired, PluginConfigOptional},
+			errCount: 0,
+		},
+		{
+			desc:     "conflicting DeviceConfig policies - should fail",
+			policies: []ConfigPolicy{DeviceConfigRequired, DeviceConfigOptional, PluginConfigOptional},
+			errCount: 1,
+		},
+		{
+			desc:     "conflicting PluginConfig policies - should fail",
+			policies: []ConfigPolicy{PluginConfigOptional, PluginConfigRequired, DeviceConfigOptional},
+			errCount: 1,
+		},
+		{
+			desc:     "conflicting DeviceConfig and PluginConfig policies - should fail",
+			policies: []ConfigPolicy{DeviceConfigRequired, DeviceConfigOptional, PluginConfigOptional, PluginConfigRequired},
+			errCount: 2,
+		},
+	}
+
+	for _, testCase := range testTable {
+		multiErr := CheckConstraints(testCase.policies)
+		assert.Equal(t, testCase.errCount, len(multiErr.Errors), testCase.desc)
+	}
+}

--- a/sdk/policies/policies.go
+++ b/sdk/policies/policies.go
@@ -1,0 +1,1 @@
+package policies

--- a/sdk/policies/policies.go
+++ b/sdk/policies/policies.go
@@ -1,1 +1,41 @@
 package policies
+
+// ConfigPolicy is a type that defines a behavior profile for the plugin
+// on how it should handle configurations and configuration errors.
+type ConfigPolicy uint8
+
+const (
+	// PluginConfigOptional is a policy that allows no plugin config to
+	// be specified, so the plugin can just use default values. This is
+	// the default policy for plugins.
+	PluginConfigOptional ConfigPolicy = iota
+
+	// PluginConfigRequired is a policy that requires a plugin to have a
+	// plugin configuration specified.
+	PluginConfigRequired
+
+	// DeviceConfigOptional is a policy that allows no device config files
+	// to be specified. Some plugins may not device config files, as they
+	// could use dynamic registration exclusively.
+	DeviceConfigOptional
+
+	// DeviceConfigRequired is a policy that requires device config files to
+	// be present for the plugin to run. This is the default policy for plugins.
+	DeviceConfigRequired
+)
+
+// policyStrings maps ConfigPolicies to their name.
+var policyStrings = map[ConfigPolicy]string{
+	PluginConfigOptional: "PluginConfigOptional",
+	PluginConfigRequired: "PluginConfigRequired",
+	DeviceConfigOptional: "DeviceConfigOptional",
+	DeviceConfigRequired: "DeviceConfigRequired",
+}
+
+// String returns the name of the ConfigPolicy.
+func (policy ConfigPolicy) String() string {
+	if name, ok := policyStrings[policy]; ok {
+		return name
+	}
+	return "unknown"
+}

--- a/sdk/policies/policies_test.go
+++ b/sdk/policies/policies_test.go
@@ -45,3 +45,125 @@ func TestConfigPolicy_String(t *testing.T) {
 		assert.Equal(t, testCase.expected, actual, testCase.desc)
 	}
 }
+
+// TestPolicyManager_GetDeviceConfigPolicy tests getting the device config
+// policy from the global PolicyManager.
+func TestPolicyManager_GetDeviceConfigPolicy(t *testing.T) {
+
+	// Get the device config policy when none is set - this should give the
+	// default.
+	assert.Empty(t, PolicyManager.deviceConfigPolicy)
+	policy := PolicyManager.GetDeviceConfigPolicy()
+	assert.Equal(t, DeviceConfigRequired, policy)
+
+	// Get the device config policy when Optional is set.
+	PolicyManager.deviceConfigPolicy = DeviceConfigOptional
+	policy = PolicyManager.GetDeviceConfigPolicy()
+	assert.Equal(t, DeviceConfigOptional, policy)
+
+	// Get the device config policy when Required is set.
+	PolicyManager.deviceConfigPolicy = DeviceConfigRequired
+	policy = PolicyManager.GetDeviceConfigPolicy()
+	assert.Equal(t, DeviceConfigRequired, policy)
+}
+
+// TestPolicyManager_GetPluginConfigPolicy tests getting the plugin config
+// policy from the global PolicyManager.
+func TestPolicyManager_GetPluginConfigPolicy(t *testing.T) {
+
+	// Get the plugin config policy when none is set - this should give the
+	// default.
+	assert.Empty(t, PolicyManager.pluginConfigPolicy)
+	policy := PolicyManager.GetPluginConfigPolicy()
+	assert.Equal(t, PluginConfigOptional, policy)
+
+	// Get the plugin config policy when Optional is set.
+	PolicyManager.pluginConfigPolicy = PluginConfigOptional
+	policy = PolicyManager.GetPluginConfigPolicy()
+	assert.Equal(t, PluginConfigOptional, policy)
+
+	// Get the plugin config policy when Required is set.
+	PolicyManager.pluginConfigPolicy = PluginConfigRequired
+	policy = PolicyManager.GetPluginConfigPolicy()
+	assert.Equal(t, PluginConfigRequired, policy)
+}
+
+// TestSet tests setting the global config policies.
+func TestSet(t *testing.T) {
+	var testTable = []struct{
+		desc string
+		policies []ConfigPolicy
+		expectedPluginPolicy ConfigPolicy
+		expectedDevicePolicy ConfigPolicy
+	}{
+		{
+			desc: "No policies set",
+			policies: []ConfigPolicy{},
+			expectedPluginPolicy: 0,
+			expectedDevicePolicy: 0,
+		},
+		{
+			desc: "One device config policy set",
+			policies: []ConfigPolicy{
+				DeviceConfigOptional,
+			},
+			expectedPluginPolicy: 0,
+			expectedDevicePolicy: DeviceConfigOptional,
+		},
+		{
+			desc: "One plugin config policy set",
+			policies: []ConfigPolicy{
+				PluginConfigOptional,
+			},
+			expectedPluginPolicy: PluginConfigOptional,
+			expectedDevicePolicy: 0,
+		},
+		{
+			desc: "Two device config policies set",
+			policies: []ConfigPolicy{
+				DeviceConfigRequired,
+				DeviceConfigOptional,
+			},
+			expectedPluginPolicy: 0,
+			expectedDevicePolicy: DeviceConfigOptional,
+		},
+		{
+			desc: "Two plugin config policies set",
+			policies: []ConfigPolicy{
+				PluginConfigRequired,
+				PluginConfigOptional,
+			},
+			expectedPluginPolicy: PluginConfigOptional,
+			expectedDevicePolicy: 0,
+		},
+		{
+			desc: "One of each policy",
+			policies: []ConfigPolicy{
+				PluginConfigRequired,
+				DeviceConfigOptional,
+			},
+			expectedPluginPolicy: PluginConfigRequired,
+			expectedDevicePolicy: DeviceConfigOptional,
+		},
+		{
+			desc: "Two of each policy",
+			policies: []ConfigPolicy{
+				DeviceConfigRequired,
+				DeviceConfigOptional,
+				PluginConfigRequired,
+				PluginConfigOptional,
+			},
+			expectedPluginPolicy: PluginConfigOptional,
+			expectedDevicePolicy: DeviceConfigOptional,
+		},
+	}
+
+	for _, testCase := range testTable {
+		// reset the policy manager every time
+		PolicyManager = policyManager{}
+
+		Set(testCase.policies)
+		assert.Equal(t, testCase.expectedDevicePolicy, PolicyManager.deviceConfigPolicy, testCase.desc)
+		assert.Equal(t, testCase.expectedPluginPolicy, PolicyManager.pluginConfigPolicy, testCase.desc)
+	}
+}

--- a/sdk/policies/policies_test.go
+++ b/sdk/policies/policies_test.go
@@ -1,0 +1,47 @@
+package policies
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestConfigPolicy_String tests getting the string name for ConfigPolicy instances.
+func TestConfigPolicy_String(t *testing.T) {
+	var testTable = []struct {
+		desc     string
+		policy   ConfigPolicy
+		expected string
+	}{
+		{
+			desc:     "String for PluginConfigRequired",
+			policy:   PluginConfigRequired,
+			expected: "PluginConfigRequired",
+		},
+		{
+			desc:     "String for PluginConfigOptional",
+			policy:   PluginConfigOptional,
+			expected: "PluginConfigOptional",
+		},
+		{
+			desc:     "String for DeviceConfigRequired",
+			policy:   DeviceConfigRequired,
+			expected: "DeviceConfigRequired",
+		},
+		{
+			desc:     "String for DeviceConfigOptional",
+			policy:   DeviceConfigOptional,
+			expected: "DeviceConfigOptional",
+		},
+		{
+			desc:     "String for custom policy",
+			policy:   ConfigPolicy(8),
+			expected: "unknown",
+		},
+	}
+
+	for _, testCase := range testTable {
+		actual := testCase.policy.String()
+		assert.Equal(t, testCase.expected, actual, testCase.desc)
+	}
+}

--- a/sdk/version.go
+++ b/sdk/version.go
@@ -56,7 +56,7 @@ func (version *BinVersion) Format() string {
   OS/Arch:        {{.OS}}/{{.Arch}}`
 
 	t := template.Must(template.New("version").Parse(out))
-	t.Execute(&info, version)
+	_ = t.Execute(&info, version)
 
 	return info.String()
 }

--- a/sdk/version.go
+++ b/sdk/version.go
@@ -3,7 +3,8 @@ package sdk
 import (
 	"runtime"
 
-	"github.com/vapor-ware/synse-sdk/sdk/logger"
+	"bytes"
+	"text/template"
 )
 
 // SDKVersion specifies the version of the Synse Plugin SDK.
@@ -42,16 +43,22 @@ type BinVersion struct {
 }
 
 // Log logs out the version information at INFO level.
-func (version *BinVersion) Log() {
-	logger.Info("Version Info:")
-	logger.Infof("  Plugin Version: %s", version.PluginVersion)
-	logger.Infof("  SDK Version:    %s", version.SDKVersion)
-	logger.Infof("  Git Commit:     %s", version.GitCommit)
-	logger.Infof("  Git Tag:        %s", version.GitTag)
-	logger.Infof("  Build Date:     %s", version.BuildDate)
-	logger.Infof("  Go Version:     %s", version.GoVersion)
-	logger.Infof("  OS:             %s", version.OS)
-	logger.Infof("  Arch:           %s", version.Arch)
+func (version *BinVersion) Format() string {
+	var info bytes.Buffer
+
+	out := `Version Info:
+  Plugin Version: {{.PluginVersion}}
+  SDK Version:    {{.SDKVersion}}
+  Git Commit:     {{.GitCommit}}
+  Git Tag:        {{.GitTag}}
+  Build Date:     {{.BuildDate}}
+  Go Version:     {{.GoVersion}}
+  OS/Arch:        {{.OS}}/{{.Arch}}`
+
+	t := template.Must(template.New("version").Parse(out))
+	t.Execute(&info, version)
+
+	return info.String()
 }
 
 // GetVersion gets the version information for the plugin. It builds

--- a/sdk/version_test.go
+++ b/sdk/version_test.go
@@ -47,11 +47,12 @@ func TestGetVersion2(t *testing.T) {
 	assert.Equal(t, SDKVersion, version.SDKVersion)
 }
 
-// TestBinVersion_Log tests logging out the version info.
-func TestBinVersion_Log(t *testing.T) {
-	// TODO - for now, we just log to make sure nothing goes wrong. We should
-	// really get the logger output and compare to it.
-
+// TestBinVersion_Format tests printing out the version info string.
+func TestBinVersion_Format(t *testing.T) {
 	version := GetVersion()
-	version.Log()
+	versionStr := version.Format()
+
+	// the version string will be different depending on when/where the
+	// test is run, so just verify that the string isn't empty..
+	assert.NotEmpty(t, versionStr)
 }


### PR DESCRIPTION
This is a fairly dirty PR that adds in policies and constraints, adds in basic command line flags for the plugin, adds in tests, and starts to frame up how the new `sdk.Plugin` will look. There are a few places that need to be cleaned up, but that will wait until the new Plugin is more developed and stable.