### PR TITLE
Update Plugin API to use PluginOptions

### DIFF
--- a/sdk/defaults.go
+++ b/sdk/defaults.go
@@ -1,0 +1,43 @@
+package sdk
+
+import (
+	"fmt"
+
+	"github.com/vapor-ware/synse-sdk/sdk/config"
+)
+
+// defaultDeviceIdentifier is the default implementation that fulfils the DeviceIdentifier
+// type for a plugin.
+//
+// This implementation creates a string by joining all values found in the provided
+// device data map. Non-string values in the map are cast to a string.
+func defaultDeviceIdentifier(data map[string]interface{}) string {
+	var identifier string
+	for _, value := range data {
+		// Instead of implementing our own type checking and casting, just
+		// use Sprint. Note that this may be meaningless for complex types.
+		// TODO: write tests/check to see how this behaves with things like
+		//  maps/lists. I have a feeling that maps will not produce a deterministic
+		//  string because they are unordered, so we may need custom handling for that.
+		identifier += fmt.Sprint(value)
+	}
+	return identifier
+}
+
+// defaultDynamicDeviceRegistration is the default implementation that fulfils the
+// DynamicDeviceRegistrar type for a plugin.
+//
+// This implementation simply returns an empty slice. A plugin will not do any dynamic
+// registration by default.
+func defaultDynamicDeviceRegistration(data map[string]interface{}) ([]*Device, error) {
+	return []*Device{}, nil
+}
+
+// defaultDynamicDeviceConfigRegistration is the default implementation that fulfils the
+// DynamicDeviceConfigRegistrar type for a plugin.
+//
+// This implementation simply returns an empty slice. A plugin will not do any dynamic
+// registration by default.
+func defaultDynamicDeviceConfigRegistration(map[string]interface{}) ([]*config.DeviceConfig, error) {
+	return []*config.DeviceConfig{}, nil
+}

--- a/sdk/defaults/defaults.go
+++ b/sdk/defaults/defaults.go
@@ -1,1 +1,0 @@
-package defaults

--- a/sdk/plugin.go
+++ b/sdk/plugin.go
@@ -10,8 +10,60 @@ import (
 	"github.com/vapor-ware/synse-sdk/sdk/policies"
 )
 
+/*
+FIXME: this can be removed later, just adding as a note for now
+According to the 1.0 Design Doc, we want there to be two ways of configuring a plugin.
+ 1. Simple Plugin
+ 2. Custom Plugin
+
+A Simple Plugin would just use default handlers, and should be pretty easy to init, e.g.
+
+  sdk.New()
+or
+  sdk.NewPlugin()
+
+A Custom Plugin would take a little more work in that it would need to define some interfaces/
+something in order to provide custom functionality. This could be done a few different ways.
+
+1.) A set of interfaces.
+  The plugin developer could define their own struct that fulfils some number of interfaces that
+  provide the functionality for whatever they want. This isn't too bad and seems kinda nice, but
+  internally, it gets kinda weird to parse all of this.
+
+2.) A sdk.CustomPlugin function that takes functions as arguments.
+  Those functions can be applied for the functionality needed, if specified. With this, the author
+  would only have to define the functions. The downside being that this initializer could become
+  really big and everything the author doesn't want a custom override for would have to be specified
+  as nil... not great.
+
+3.) A PluginOptions struct to define custom functionality
+  I think this may be the best way of doing it.. sorta a middle ground between the other two?
+  Basically, we can have something like
+
+  sdk.NewPlugin(... options)
+
+  Where an option would be the bits of configurable functionality? TBD how we define an option though,
+  especially in this context. Perhaps it would make more sense to have a struct,
+
+  options {
+    DeviceIdentifier func()...
+  }
+
+  and then just have them pass in that struct? or something like that?
+
+
+*/
+
 // Plugin is the New Plugin. This will replace Plugin once v1.0 work is completed.
 type Plugin struct {
+
+	name string
+	maintainer string
+	description string
+	vcs string
+
+
+
 	policies []policies.ConfigPolicy
 
 	preRunActions      []pluginAction
@@ -19,8 +71,14 @@ type Plugin struct {
 	deviceSetupActions map[string][]deviceAction
 }
 
-func NewPlugin() {
-
+// NewPlugin creates a new instance of a Synse Plugin.
+func NewPlugin(name, maintainer, description, vcs string) *Plugin {
+	return &Plugin{
+		name: name,
+		maintainer: maintainer,
+		description: description,
+		vcs: vcs,
+	}
 }
 
 // SetConfigPolicies sets the config policies for the plugin. Config policies will

--- a/sdk/plugin.go
+++ b/sdk/plugin.go
@@ -10,75 +10,99 @@ import (
 	"github.com/vapor-ware/synse-sdk/sdk/policies"
 )
 
-/*
-FIXME: this can be removed later, just adding as a note for now
-According to the 1.0 Design Doc, we want there to be two ways of configuring a plugin.
- 1. Simple Plugin
- 2. Custom Plugin
+// FIXME -- these function type definitions should probably move somewhere else.
+type DeviceIdentifier func(map[string]interface{}) string
 
-A Simple Plugin would just use default handlers, and should be pretty easy to init, e.g.
-
-  sdk.New()
-or
-  sdk.NewPlugin()
-
-A Custom Plugin would take a little more work in that it would need to define some interfaces/
-something in order to provide custom functionality. This could be done a few different ways.
-
-1.) A set of interfaces.
-  The plugin developer could define their own struct that fulfils some number of interfaces that
-  provide the functionality for whatever they want. This isn't too bad and seems kinda nice, but
-  internally, it gets kinda weird to parse all of this.
-
-2.) A sdk.CustomPlugin function that takes functions as arguments.
-  Those functions can be applied for the functionality needed, if specified. With this, the author
-  would only have to define the functions. The downside being that this initializer could become
-  really big and everything the author doesn't want a custom override for would have to be specified
-  as nil... not great.
-
-3.) A PluginOptions struct to define custom functionality
-  I think this may be the best way of doing it.. sorta a middle ground between the other two?
-  Basically, we can have something like
-
-  sdk.NewPlugin(... options)
-
-  Where an option would be the bits of configurable functionality? TBD how we define an option though,
-  especially in this context. Perhaps it would make more sense to have a struct,
-
-  options {
-    DeviceIdentifier func()...
-  }
-
-  and then just have them pass in that struct? or something like that?
-
-
-*/
+type DynamicDeviceRegistrar func(map[string]interface{}) ([]*Device, error)
+type DynamicDeviceConfigRegistrar func(map[string]interface{}) ([]*config.DeviceConfig, error)
 
 // Plugin is the New Plugin. This will replace Plugin once v1.0 work is completed.
 type Plugin struct {
-
-	name string
-	maintainer string
-	description string
-	vcs string
-
-
-
 	policies []policies.ConfigPolicy
+
+	deviceIdentifier             DeviceIdentifier
+	dynamicDeviceRegistrar       DynamicDeviceRegistrar
+	dynamicDeviceConfigRegistrar DynamicDeviceConfigRegistrar
 
 	preRunActions      []pluginAction
 	postRunActions     []pluginAction
 	deviceSetupActions map[string][]deviceAction
 }
 
-// NewPlugin creates a new instance of a Synse Plugin.
-func NewPlugin(name, maintainer, description, vcs string) *Plugin {
-	return &Plugin{
-		name: name,
-		maintainer: maintainer,
-		description: description,
-		vcs: vcs,
+// FIXME: options should probably move somewhere else.
+type PluginOption func(*Plugin)
+
+// CustomDeviceIdentifier lets you set a custom function for creating a deterministic
+// identifier for a device using the config data for the device.
+func CustomDeviceIdentifier(identifier DeviceIdentifier) PluginOption {
+	return func(plugin *Plugin) {
+		plugin.deviceIdentifier = identifier
 	}
+}
+
+// CustomDynamicDeviceRegistration lets you set a custom function for dynamically registering
+// Device instances using the data from the "dynamic registration" field in the Plugin config.
+func CustomDynamicDeviceRegistration(registrar DynamicDeviceRegistrar) PluginOption {
+	return func(plugin *Plugin) {
+		plugin.dynamicDeviceRegistrar = registrar
+	}
+}
+
+// CustomDynamicDeviceConfigRegistration lets you set a custom function for dynamically
+// registering DeviceConfig instances using the data from the "dynamic registration" field
+// in the Plugin config.
+func CustomDynamicDeviceConfigRegistration(registrar DynamicDeviceConfigRegistrar) PluginOption {
+	return func(plugin *Plugin) {
+		plugin.dynamicDeviceConfigRegistrar = registrar
+	}
+}
+
+// defaultOptions defines the default plugin options.
+var defaultOptions = []PluginOption{
+	defaultDeviceIdentifierOption,
+	defaultDynamicDeviceRegistrationOption,
+	defaultDynamicDeviceConfigRegistrationOption,
+}
+
+// defaultDeviceIdentifierOption applies the default behavior for creating a deterministic
+// identifier to the plugin, if it does not already have one set.
+func defaultDeviceIdentifierOption(plugin *Plugin) {
+	if plugin.deviceIdentifier == nil {
+		plugin.deviceIdentifier = defaultDeviceIdentifier
+	}
+}
+
+// defaultDynamicDeviceRegistrationOption applies the default behavior for dynamic device
+// registration to the plugin, if it does not already have one set.
+func defaultDynamicDeviceRegistrationOption(plugin *Plugin) {
+	if plugin.dynamicDeviceRegistrar == nil {
+		plugin.dynamicDeviceRegistrar = defaultDynamicDeviceRegistration
+	}
+}
+
+// defaultDynamicDeviceConfigRegistrationOption applies the default behavior for dynamic
+// device config registration to the plugin, if it does not already have one set.
+func defaultDynamicDeviceConfigRegistrationOption(plugin *Plugin) {
+	if plugin.dynamicDeviceConfigRegistrar == nil {
+		plugin.dynamicDeviceConfigRegistrar = defaultDynamicDeviceConfigRegistration
+	}
+}
+
+// NewPlugin creates a new instance of a Synse Plugin.
+func NewPlugin(options ...PluginOption) *Plugin {
+	plugin := Plugin{}
+
+	// Set custom options for the plugin.
+	for _, option := range options {
+		option(&plugin)
+	}
+
+	// Apply defaults to any required field that was not set from an option.
+	for _, option := range defaultOptions {
+		option(&plugin)
+	}
+
+	return &plugin
 }
 
 // SetConfigPolicies sets the config policies for the plugin. Config policies will


### PR DESCRIPTION
This work originally started as trying to do the "plugin as an interface" work (section 4.1.4), but after doing some experimentation there and some research, I found a better, cleaner approach. 

This introduces a "PluginOption", which basically can be set for each bit of functionality a user wants to customize. Instead of having to define a struct that implements X number of interfaces, like was planned, or jam a bunch of functions/`nil`s into a Handlers struct, like we were doing before, the Plugin should now take in whatever options the author specifies and apply those. For anything that hasn't been specified, default options will be applied. 

This means we get an interface like this for simple plugins that need no additional configuration:
```go
plugin := sdk.NewPlugin()
```

And like this for plugins that need more customization
```go
func MyCustomIdentifierFunc(map[string]interface{}) string {
    return "foobar"
}

plugin := sdk.NewPlugin(
    sdk.CustomDeviceIdentifier(MyCustomIdentifierFunc)
)
```

\* *(names of things subject to change)*

This addresses:
- #205
- #204 
- #191 