### PR TITLE
Rework of the device registration flow, make some data global

### DIFF
--- a/sdk/actions.go
+++ b/sdk/actions.go
@@ -1,4 +1,55 @@
 package sdk
 
+import (
+	"github.com/vapor-ware/synse-sdk/sdk/errors"
+	"github.com/vapor-ware/synse-sdk/sdk/logger"
+)
+
 type pluginAction func(p *Plugin) error
 type deviceAction func(p *Plugin, d *Device) error
+
+func execPreRun(plugin *Plugin) *errors.MultiError {
+	var multiErr = errors.NewMultiError("Pre Run Actions")
+
+	if len(plugin.preRunActions) > 0 {
+		logger.Debug("Executing Pre Run Actions:")
+		for _, action := range plugin.preRunActions {
+			logger.Debugf(" * %v", action)
+			err := action(plugin)
+			if err != nil {
+				logger.Errorf("Failed pre-run action %v: %v", action, err)
+				multiErr.Add(err)
+			}
+		}
+	}
+	return multiErr
+}
+
+func execDeviceSetup(plugin *Plugin) *errors.MultiError {
+	var multiErr = errors.NewMultiError("Device Setup Actions")
+
+	if len(plugin.deviceSetupActions) > 0 {
+		logger.Debug("Executing Device Setup Actions:")
+		for filter, acts := range plugin.deviceSetupActions {
+			devices, err := filterDevices(filter)
+			if err != nil {
+				logger.Errorf("Failed to filter devices for setup actions: %v", err)
+				multiErr.Add(err)
+				continue
+			}
+			logger.Debugf("* %v (%v devices match filter %v)", acts, len(devices), filter)
+			for _, d := range devices {
+				for _, action := range acts {
+					err := action(plugin, d)
+					if err != nil {
+						logger.Errorf("Failed device setup action %v: %v", action, err)
+						multiErr.Add(err)
+						continue
+					}
+				}
+			}
+		}
+	}
+
+	return multiErr
+}

--- a/sdk/actions.go
+++ b/sdk/actions.go
@@ -74,6 +74,5 @@ func execDeviceSetup(plugin *Plugin) *errors.MultiError {
 			}
 		}
 	}
-
 	return multiErr
 }

--- a/sdk/config/device.go
+++ b/sdk/config/device.go
@@ -159,6 +159,11 @@ type DeviceKind struct {
 	// This behavior can be changed by setting the DeviceInstance.InheritKindOutputs
 	// flag to false.
 	Outputs []*DeviceOutput `yaml:"outputs,omitempty" addedIn:"1.0"`
+
+	// HandlerName specifies the name of the DeviceHandler to match this DeviceKind
+	// with. By default, a DeviceKind will match with a DeviceHandler using its
+	// `Kind` field. This field can be set to override that behavior.
+	HandlerName string `yaml:"handlerName,omitempty" addedIn:"1.0"`
 }
 
 // Validate validates that the DeviceKind has no configuration errors.
@@ -203,6 +208,12 @@ type DeviceInstance struct {
 	//
 	// If false, this will not inherit any of the DeviceKind's outputs.
 	InheritKindOutputs bool `yaml:"inheritKindOutputs,omitempty" addedIn:"1.0"`
+
+	// HandlerName specifies the name of the DeviceHandler to match this DeviceInstance
+	// with. By default, a DeviceInstance will match with a DeviceHandler using
+	// the `Kind` field of its DeviceKind. This field can be set to override
+	// that behavior.
+	HandlerName string `yaml:"handlerName,omitempty" addedIn:"1.0"`
 }
 
 // Validate validates that the DeviceInstance has no configuration errors.

--- a/sdk/config/device.go
+++ b/sdk/config/device.go
@@ -35,6 +35,18 @@ func (config DeviceConfig) Validate(multiErr *errors.MultiError) {
 	}
 }
 
+// GetLocation gets a location from the DeviceConfig by name, if it exists.
+// If the specified location name is not associated with any location in the
+// DeviceConfig, an error is returned.
+func (config *DeviceConfig) GetLocation(name string) (*Location, error) {
+	for _, l := range config.Locations {
+		if l.Name == name {
+			return l, nil
+		}
+	}
+	return nil, fmt.Errorf("no location with name '%s' was found", name)
+}
+
 // Location defines a location (rack, board) which will be associated with
 // DeviceInstances. The locational information defined here is used by Synse
 // Server to route commands to the proper device instance.

--- a/sdk/devices.go
+++ b/sdk/devices.go
@@ -13,21 +13,35 @@ var deviceMap = make(map[string]*Device)
 // DeviceHandler specifies the read and write handlers for a Device
 // based on its type and model.
 type DeviceHandler struct {
-	// FIXME: this used to be based off of the type/model.. we could have it
-	// be based off of the device kind, or we could just not require it to have
-	// any inherent association with a device, and leave it up to the plugin to
-	// somehow map them?
-	//
-	// The above only really makes sense if there are cases where we do not want
-	// to associate it to a device kind. I think in most basic cases, it is fine
-	// to associate. The question is: in dynamic cases, do we want that association
-	// still?
-	//
-	// Will need to think this through a bit more once I have some more brain power.
 
+	// Name is the name of the handler. This is how the handler will be referenced
+	// and associated with Device instances via their DeviceConfig. This name should
+	// be the same as the "Kind" of the device which it corresponds with.
+	//
+	// Additionally, there are cases where we may not want the DeviceHandler to match
+	// on the name of the Kind, or we may want a subset of a Device Kind's instances
+	// to match to a different handler. In that case, the "handlerName" field can be
+	// set in the DeviceConfig at either the DeviceKind level (where it would apply
+	// for all instances of that kind), or at the DeviceInstance level (where it would
+	// apply for only that instance.
+	//
+	// If the "handlerName" field is specified, it will be used to match against
+	// this Name field. Otherwise, the Kind of the device will be used to match
+	// against this Name field.
+	Name string
+
+	// Write is a function that handles Write requests for the device. If the
+	// device does not support writing, this can be left as nil.
 	Write func(*Device, *WriteData) error
-	Read  func(*Device) ([]*Reading, error)
 
+	// Read is a function that handles Read requests for the device. If the device
+	// does not support reading, this can be left as nil.
+	Read func(*Device) ([]*Reading, error)
+
+	// BulkRead is a function that handles bulk reading for the device. A bulk read
+	// is where all devices of a given kind are read at once, instead of individually.
+	// If a device does not support bulk read, this can be left as nil. Additionally,
+	// a device can only be bulk read if there is no Read handler set.
 	BulkRead func([]*Device) ([]*ReadContext, error)
 }
 

--- a/sdk/devices.go
+++ b/sdk/devices.go
@@ -7,8 +7,20 @@ import (
 	"github.com/vapor-ware/synse-sdk/sdk/types"
 )
 
-// The deviceMap holds all of the known devices configured for the plugin.
-var deviceMap = make(map[string]*Device)
+var (
+	// The deviceMap holds all of the known devices configured for the plugin.
+	deviceMap map[string]*Device
+
+	// The deviceHandlers list holds all of the DeviceHandlers that are registered
+	// with the plugin.
+	deviceHandlers []*DeviceHandler
+)
+
+func init() {
+	// Initialize the global variables so they are never nil.
+	deviceMap = map[string]*Device{}
+	deviceHandlers = []*DeviceHandler{}
+}
 
 // DeviceHandler specifies the read and write handlers for a Device
 // based on its type and model.

--- a/sdk/devices.go
+++ b/sdk/devices.go
@@ -127,42 +127,6 @@ func NewOutputFromConfig(config *config.DeviceOutput) (*Output, error) {
 	}, nil
 }
 
-//// NewDevice creates a new instance of a Device.
-////
-//// A Device serves as the internal model for a single physical or virtual
-//// device that a plugin manages, e.g. a temperature sensor. The Device
-//// meta information is joined from the device's prototype config and its
-//// instance config.
-//func NewDevice(p *config.PrototypeConfig, d *config.DeviceConfig, h *DeviceHandler, plugin *Plugin) (*Device, error) {
-//	if plugin.handlers.DeviceIdentifier == nil {
-//		return nil, fmt.Errorf("identifier function not defined for device")
-//	}
-//
-//	if p.Type != d.Type {
-//		return nil, fmt.Errorf("prototype and instance config mismatch (type): %v != %v", p.Type, d.Type)
-//	}
-//
-//	if p.Model != d.Model {
-//		return nil, fmt.Errorf("prototype and instance config mismatch (model): %v != %v", p.Model, d.Model)
-//	}
-//
-//	dev := Device{
-//		Type:         p.Type,
-//		Model:        p.Model,
-//		Manufacturer: p.Manufacturer,
-//		Protocol:     p.Protocol,
-//		Output:       p.Output,
-//		Location:     d.Location,
-//		Data:         d.Data,
-//		Handler:      h,
-//		Identifier:   plugin.handlers.DeviceIdentifier,
-//		pconfig:      p,
-//		dconfig:      d,
-//		bulkRead:     h.doesBulkRead(),
-//	}
-//	return &dev, nil
-//}
-
 // Read performs the read action for the device, as set by its DeviceHandler.
 //
 // If reading is not supported on the device, an UnsupportedCommandError is
@@ -208,7 +172,7 @@ func (device *Device) IsWritable() bool {
 func (device *Device) ID() string {
 	if device.id == "" {
 		protocolComp := device.Identifier(device.Data)
-		device.id = newUID(device.Protocol, device.Type, device.Model, protocolComp)
+		device.id = newUID(device.Plugin, device.Kind, protocolComp)
 	}
 	return device.id
 }
@@ -216,8 +180,9 @@ func (device *Device) ID() string {
 // GUID generates a globally unique ID string by creating a composite
 // string from the rack, board, and device UID.
 func (device *Device) GUID() string {
-	rack, _ := device.Location.GetRack()
-	return makeIDString(rack, device.Location.Board, device.ID())
+	rack, _ := device.Location.Rack.Get()
+	board, _ := device.Location.Board.Get()
+	return makeIDString(rack, board, device.ID())
 }
 
 // encode translates the SDK Device to its corresponding gRPC Device.

--- a/sdk/devices.go
+++ b/sdk/devices.go
@@ -64,7 +64,7 @@ type Device struct {
 
 	Info string
 
-	Location config.Location
+	Location *config.Location
 
 	Data map[string]interface{}
 
@@ -85,6 +85,20 @@ type Output struct {
 
 	Info string
 	Data map[string]interface{}
+}
+
+// NewOutputFromConfig creates a new Output from the DeviceOutput config struct.
+func NewOutputFromConfig(config *config.DeviceOutput) (*Output, error) {
+	t, err := getTypeByName(config.Type)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Output{
+		ReadingType: *t,
+		Info:        config.Info,
+		Data:        config.Data,
+	}, nil
 }
 
 //// NewDevice creates a new instance of a Device.

--- a/sdk/flags.go
+++ b/sdk/flags.go
@@ -1,6 +1,8 @@
 package sdk
 
-import "flag"
+import (
+	"flag"
+)
 
 var (
 	flagDebug   bool

--- a/sdk/meta.go
+++ b/sdk/meta.go
@@ -33,3 +33,6 @@ func SetPluginMeta(name, maintainer, desc, vcs string) {
 		VCS:         vcs,
 	}
 }
+
+// FIXME: we should have a check somewhere to ensure that there is a Name specified.
+// I think that is the only thing that is required here.

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -1,0 +1,64 @@
+package sdk
+
+// A PluginOption sets optional configurations or functional capabilities for
+// a plugin. This includes things like device identification and device
+// registration behaviors.
+type PluginOption func(*Plugin)
+
+// defaultOptions defines the default plugin options. These are applied to a
+// new Plugin (via `NewPlugin`) if there are no corresponding custom options
+// specified.
+var defaultOptions = []PluginOption{
+	defaultDeviceIdentifierOption,
+	defaultDynamicDeviceRegistrationOption,
+	defaultDynamicDeviceConfigRegistrationOption,
+}
+
+// CustomDeviceIdentifier lets you set a custom function for creating a deterministic
+// identifier for a device using the config data for the device.
+func CustomDeviceIdentifier(identifier DeviceIdentifier) PluginOption {
+	return func(plugin *Plugin) {
+		plugin.deviceIdentifier = identifier
+	}
+}
+
+// defaultDeviceIdentifierOption applies the default behavior for creating a deterministic
+// identifier to the plugin, if it does not already have one set.
+func defaultDeviceIdentifierOption(plugin *Plugin) {
+	if plugin.deviceIdentifier == nil {
+		plugin.deviceIdentifier = defaultDeviceIdentifier
+	}
+}
+
+// CustomDynamicDeviceRegistration lets you set a custom function for dynamically registering
+// Device instances using the data from the "dynamic registration" field in the Plugin config.
+func CustomDynamicDeviceRegistration(registrar DynamicDeviceRegistrar) PluginOption {
+	return func(plugin *Plugin) {
+		plugin.dynamicDeviceRegistrar = registrar
+	}
+}
+
+// defaultDynamicDeviceRegistrationOption applies the default behavior for dynamic device
+// registration to the plugin, if it does not already have one set.
+func defaultDynamicDeviceRegistrationOption(plugin *Plugin) {
+	if plugin.dynamicDeviceRegistrar == nil {
+		plugin.dynamicDeviceRegistrar = defaultDynamicDeviceRegistration
+	}
+}
+
+// CustomDynamicDeviceConfigRegistration lets you set a custom function for dynamically
+// registering DeviceConfig instances using the data from the "dynamic registration" field
+// in the Plugin config.
+func CustomDynamicDeviceConfigRegistration(registrar DynamicDeviceConfigRegistrar) PluginOption {
+	return func(plugin *Plugin) {
+		plugin.dynamicDeviceConfigRegistrar = registrar
+	}
+}
+
+// defaultDynamicDeviceConfigRegistrationOption applies the default behavior for dynamic
+// device config registration to the plugin, if it does not already have one set.
+func defaultDynamicDeviceConfigRegistrationOption(plugin *Plugin) {
+	if plugin.dynamicDeviceConfigRegistrar == nil {
+		plugin.dynamicDeviceConfigRegistrar = defaultDynamicDeviceConfigRegistration
+	}
+}

--- a/sdk/plugin.go
+++ b/sdk/plugin.go
@@ -25,39 +25,6 @@ type DynamicDeviceRegistrar func(map[string]interface{}) ([]*Device, error)
 // is specific to the plugin/protocol.
 type DynamicDeviceConfigRegistrar func(map[string]interface{}) ([]*config.DeviceConfig, error)
 
-/*
-
-The tricky thing about plugins:
-
-  We want to have a Plugin represent the thing doing the work and to have it
-  hold the API for the user. At the same time, a lot of the data structures
-  that we have should probably be global structures. This way, we do not have
-  to constantly force things into the API/function sigs just so we can access
-  a piece of data.
-
-  With that in mind, all of this stuff really is tied to the plugin. There
-  shouldn't be more than one plugin active at a time in a single project so
-  using globals is okay, I think.
-
-  What are some things that would be good to have as global?
-    - the device map
-	- the registered handlers list
-	- the config
-	- the transaction cache
-	- the data manager
-	- the plugin server?.. this may not need to be global and could be tied
-	  directly to the plugin, I guess.
-
-  So, the question becomes: How do we do all of this while maintaining a
-  sane and useful API, and not making the underlying implementation too
-  convoluted?
-
-  We could just have the plugin be global................................
-  If the plugin is global, all of the data that is associated with it should
-  effectively be global as well. That seems kinda gross though.
-
-*/
-
 // A Plugin represents an instance of a Synse Plugin. Synse Plugins are used
 // as data providers and device controllers for Synse Server.
 type Plugin struct {
@@ -160,10 +127,6 @@ func (plugin *Plugin) Run() error {
 
 	// ** "Registration" steps **
 
-	// FIXME: at this point, we will need to resolve dynamic registration stuff.
-	//   - if dynamic registration makes Devices, just add to the global map.
-	//   - if dynamic registration makes Config artifacts, add to the unified config.
-	//     (or maybe this happens in th processConfig step, before unification?)
 	// Initialize Device instances for each of the devices configured with
 	// the plugin.
 	plugin.registerDevices()

--- a/sdk/plugin.go
+++ b/sdk/plugin.go
@@ -312,6 +312,15 @@ func (plugin *Plugin) registerDevices() {
 	// devices from config
 
 	// devices from dynamic registration
+	devices, err := plugin.dynamicDeviceRegistrar()
+	if err != nil {
+		// todo: error
+	}
+
+	deviceConfigs, err := plugin.dynamicDeviceConfigRegistrar()
+	if err != nil {
+		// todo: error
+	}
 
 }
 

--- a/sdk/type.go
+++ b/sdk/type.go
@@ -1,8 +1,16 @@
-package types
+package sdk
 
 import (
 	"strings"
 )
+
+var (
+	outputTypeMap map[string]*ReadingType
+)
+
+func init() {
+	outputTypeMap = map[string]*ReadingType{}
+}
 
 /*
 TODO:

--- a/sdk/type_test.go
+++ b/sdk/type_test.go
@@ -1,4 +1,4 @@
-package types
+package sdk
 
 import (
 	"testing"

--- a/sdk/utils.go
+++ b/sdk/utils.go
@@ -32,7 +32,7 @@ func getHandlerForDevice(handlerName string) (*DeviceHandler, error) {
 }
 
 // makeDevices
-func makeDevices(config *config.DeviceConfig, plugin *Plugin) ([]*Device, error) {
+func makeDevices(config *config.DeviceConfig) ([]*Device, error) {
 	logger.Debugf("makeDevices start")
 
 	// the list of devices we made
@@ -118,46 +118,6 @@ func makeDevices(config *config.DeviceConfig, plugin *Plugin) ([]*Device, error)
 		}
 
 	}
-
-	//var devices []*Device
-	//for _, dev := range deviceConfigs {
-	//	var protoconfig *config.PrototypeConfig
-	//	found := false
-	//
-	//	for _, proto := range protoConfigs {
-	//		if proto.Type == dev.Type && proto.Model == dev.Model {
-	//			protoconfig = proto
-	//			found = true
-	//			break
-	//		}
-	//	}
-	//
-	//	if !found {
-	//		logger.Warnf("Did not find prototype matching instance for %v-%v", dev.Type, dev.Model)
-	//		continue
-	//	}
-	//	logger.Debugf("Found prototype matching instance config for %v %v", dev.Type, dev.Model)
-	//
-	//	handler, err := getHandlerForDevice(plugin.deviceHandlers, dev)
-	//	if err != nil {
-	//		logger.Errorf("found no handler for device %v: %v", dev, err)
-	//		return nil, err
-	//	}
-	//
-	//	d, err := NewDevice(
-	//		protoconfig,
-	//		dev,
-	//		handler,
-	//		plugin,
-	//	)
-	//	if err != nil {
-	//		logger.Errorf("failed to create new device: %v", err)
-	//		return nil, err
-	//	}
-	//	devices = append(devices, d)
-	//}
-	//
-	//logger.Debugf("finished making devices: %v", devices)
 	return devices, nil
 }
 

--- a/sdk/utils.go
+++ b/sdk/utils.go
@@ -23,7 +23,7 @@ func makeIDString(rack, board, device string) string {
 // getHandlerForDevice gets the DeviceHandler for the device, based on its
 // Type and Model.
 func getHandlerForDevice(handlerName string) (*DeviceHandler, error) {
-	for _, handler := range registeredHandlers {
+	for _, handler := range deviceHandlers {
 		if handler.Name == handlerName {
 			return handler, nil
 		}


### PR DESCRIPTION
This PR does a lot of the rework for device registration flow. There is still work to do there, but the basics are either there or sketched out, so it should just be a matter of filling it in.

This also makes a bunch of data structures global to the SDK, instead of plugin-specific. There is still some work to do with this, but it should make things a bit easier because we now shouldn't have to pass along a reference to the plugin everywhere and then traverse fields to get the info we want.

Related:
- #186 