### PR TITLE
Add basic scheme for dynamic registration config

### DIFF
--- a/sdk/config/plugin.go
+++ b/sdk/config/plugin.go
@@ -133,11 +133,17 @@ func (settings NetworkSettings) Validate(multiErr *errors.MultiError) {
 // DynamicRegistrationSettings specifies configuration and data for
 // the dynamic registration of devices.
 type DynamicRegistrationSettings struct {
+	// The plugin configuration for dynamic registration. This map holds the
+	// plugin-specific data that can be used to dynamically register new devices.
+	// As an example, this could hold the information for connecting with a server,
+	// or it could contain a bus address, etc.
+	Config map[string]interface{} `yaml:"config,omitempty" addedIn:"1.0"`
 }
 
 // Validate validates that the DynamicRegistrationSettings has no configuration errors.
 func (settings DynamicRegistrationSettings) Validate(multiErr *errors.MultiError) {
-	// todo
+	// nothing to validate here.
+	return
 }
 
 // LimiterSettings specifies configurations for a rate limiter on reads
@@ -189,8 +195,7 @@ type ReadSettings struct {
 
 // Validate validates that the ReadSettings has no configuration errors.
 func (settings ReadSettings) Validate(multiErr *errors.MultiError) {
-	// Try parsing the interval to validate it is a correctly specified
-	// duration string.
+	// Try parsing the interval to validate it is a correctly specified duration string.
 	_, err := settings.GetInterval()
 	if err != nil {
 		multiErr.Add(errors.NewValidationError(multiErr.Context["source"], err.Error()))
@@ -236,8 +241,7 @@ type WriteSettings struct {
 
 // Validate validates that the WriteSettings has no configuration errors.
 func (settings WriteSettings) Validate(multiErr *errors.MultiError) {
-	// Try parsing the interval to validate it is a correctly specified
-	// duration string.
+	// Try parsing the interval to validate it is a correctly specified duration string.
 	_, err := settings.GetInterval()
 	if err != nil {
 		multiErr.Add(errors.NewValidationError(multiErr.Context["source"], err.Error()))
@@ -277,8 +281,7 @@ type TransactionSettings struct {
 
 // Validate validates that the TransactionSettings has no configuration errors.
 func (settings TransactionSettings) Validate(multiErr *errors.MultiError) {
-	// Try parsing the interval to validate it is a correctly specified
-	// duration string.
+	// Try parsing the interval to validate it is a correctly specified duration string.
 	_, err := settings.GetTTL()
 	if err != nil {
 		multiErr.Add(errors.NewValidationError(multiErr.Context["source"], err.Error()))

--- a/sdk/plugin.go
+++ b/sdk/plugin.go
@@ -272,7 +272,7 @@ func (plugin *Plugin) processConfig() error {
 	}
 
 	// Get device config from dynamic registration, if anything is set there.
-	deviceConfigs, err := plugin.dynamicDeviceConfigRegistrar() // TODO: pass in correct param
+	deviceConfigs, err := plugin.dynamicDeviceConfigRegistrar(PluginConfig.DynamicRegistration.Config)
 	if err != nil {
 		return err
 	}
@@ -336,7 +336,7 @@ func (plugin *Plugin) processConfig() error {
 func (plugin *Plugin) registerDevices() error {
 
 	// devices from dynamic registration
-	devices, err := plugin.dynamicDeviceRegistrar() // TODO: pass in correct param
+	devices, err := plugin.dynamicDeviceRegistrar(PluginConfig.DynamicRegistration.Config)
 	if err != nil {
 		return err
 	}

--- a/sdk/policies/policies.go
+++ b/sdk/policies/policies.go
@@ -5,7 +5,6 @@ package policies
 type ConfigPolicy uint8
 
 const (
-
 	// ignore first iota value since we don't want a zero-value.
 	_ ConfigPolicy = iota
 


### PR DESCRIPTION
Fixes #237

There was some additional stuff that could have gone into here, particularly around retries / re-registration of the dynamic registration functions, but that got deep into the weeds and just opened up more questions for me.

Ultimately, it should really be up to the user (at least for now) to implement retries, etc. as needed. Its hard to build that functionality in because the use cases for it can vary so much. Perhaps re-registration/retry will be added at a later date. For now, I think this is good enough.