### PR TITLE
Implement post-run actions, cleanup

### DIFF
--- a/sdk/actions.go
+++ b/sdk/actions.go
@@ -32,10 +32,10 @@ type deviceAction func(p *Plugin, d *Device) error
 
 // execPreRun executes the pre-run actions for the plugin.
 func execPreRun(plugin *Plugin) *errors.MultiError {
-	var multiErr = errors.NewMultiError("Pre Run Actions")
+	var multiErr = errors.NewMultiError("pre-run actions")
 
 	if len(preRunActions) > 0 {
-		logger.Debug("Executing Pre Run Actions:")
+		logger.Debug("Executing pre-run actions:")
 		for _, action := range preRunActions {
 			logger.Debugf(" * %v", action)
 			err := action(plugin)
@@ -48,12 +48,29 @@ func execPreRun(plugin *Plugin) *errors.MultiError {
 	return multiErr
 }
 
+// execPostRun executes the post-run actions for the plugin.
+func execPostRun(plugin *Plugin) *errors.MultiError {
+	var multiErr = errors.NewMultiError("post-run actions")
+
+	if len(postRunActions) > 0 {
+		logger.Debug("Executing post-run actions:")
+		for _, action := range postRunActions {
+			logger.Debug(" * %v", action)
+			err := action(plugin)
+			if err != nil {
+				multiErr.Add(err)
+			}
+		}
+	}
+	return multiErr
+}
+
 // execDeviceSetup executes the device setup actions for the plugin.
 func execDeviceSetup(plugin *Plugin) *errors.MultiError {
-	var multiErr = errors.NewMultiError("Device Setup Actions")
+	var multiErr = errors.NewMultiError("device setup actions")
 
 	if len(deviceSetupActions) > 0 {
-		logger.Debug("Executing Device Setup Actions:")
+		logger.Debug("Executing device setup actions:")
 		for filter, acts := range deviceSetupActions {
 			devices, err := filterDevices(filter)
 			if err != nil {

--- a/sdk/plugin.go
+++ b/sdk/plugin.go
@@ -240,8 +240,7 @@ func (plugin *Plugin) resolveFlags() {
 
 	// Print out the version info for the plugin.
 	if flagVersion {
-		versionInfo := GetVersion()
-		fmt.Println(versionInfo.Format())
+		fmt.Println(Version.Format())
 		os.Exit(0)
 	}
 }
@@ -442,8 +441,7 @@ func (plugin *Plugin) logStartupInfo() {
 	metainfo.log()
 
 	// Log plugin version info
-	version := GetVersion()
-	logger.Info(version.Format())
+	Version.Log()
 
 	// Log registered devices
 	logger.Info("Registered Devices:")

--- a/sdk/plugin.go
+++ b/sdk/plugin.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"os"
 
+	"os/signal"
+	"syscall"
+
 	"github.com/vapor-ware/synse-sdk/sdk/config"
 	"github.com/vapor-ware/synse-sdk/sdk/errors"
 	"github.com/vapor-ware/synse-sdk/sdk/logger"
@@ -36,11 +39,14 @@ type Plugin struct {
 	policies []policies.ConfigPolicy
 
 	server *Server
+	quit   chan os.Signal
 }
 
 // NewPlugin creates a new instance of a Synse Plugin.
 func NewPlugin(options ...PluginOption) *Plugin {
-	plugin := Plugin{}
+	plugin := Plugin{
+		quit: make(chan os.Signal),
+	}
 
 	// Set custom options for the plugin.
 	for _, option := range options {
@@ -128,6 +134,10 @@ func (plugin *Plugin) RegisterDeviceHandlers(handlers ...*DeviceHandler) {
 // are started, Plugin setup and validation will happen. If successful, pre-run
 // actions are executed, and device setup actions are executed, if defined.
 func (plugin *Plugin) Run() (err error) {
+	// Register system calls for graceful stopping.
+	signal.Notify(plugin.quit, syscall.SIGTERM)
+	signal.Notify(plugin.quit, syscall.SIGINT)
+	go plugin.Stop()
 
 	// The plugin name must be set as metainfo, since it is used in the Device
 	// model. Check if it is set here. If not, return an error.
@@ -215,9 +225,22 @@ func (plugin *Plugin) Run() (err error) {
 
 	// startServer
 	return plugin.server.Serve()
+}
 
-	// TODO: post run actions (https://github.com/vapor-ware/synse-sdk/issues/85)
-	return nil
+func (plugin *Plugin) Stop() {
+	sig := <-plugin.quit
+	logger.Infof("Stopping plugin (%s)...", sig.String())
+
+	// TODO: any other stop/cleanup actions should go here (closing channels, etc)
+
+	multiErr := execPostRun(plugin)
+	if multiErr.HasErrors() {
+		logger.Error(multiErr)
+		os.Exit(1)
+	}
+
+	logger.Info("[done]")
+	os.Exit(0)
 }
 
 // FIXME: its not clear that these private functions need to hang off the Plugin struct..

--- a/sdk/server.go
+++ b/sdk/server.go
@@ -64,15 +64,14 @@ func (server *Server) Test(ctx context.Context, request *synse.Empty) (*synse.St
 // Version is the handler for the Synse GRPC Plugin service's `Version` RPC method.
 func (server *Server) Version(ctx context.Context, request *synse.Empty) (*synse.VersionInfo, error) {
 	logger.Debug("gRPC server: version")
-	ver := GetVersion()
 	return &synse.VersionInfo{
-		PluginVersion: ver.PluginVersion,
-		SdkVersion:    ver.SDKVersion,
-		BuildDate:     ver.BuildDate,
-		GitCommit:     ver.GitCommit,
-		GitTag:        ver.GitTag,
-		Arch:          ver.Arch,
-		Os:            ver.OS,
+		PluginVersion: Version.PluginVersion,
+		SdkVersion:    Version.SDKVersion,
+		BuildDate:     Version.BuildDate,
+		GitCommit:     Version.GitCommit,
+		GitTag:        Version.GitTag,
+		Arch:          Version.Arch,
+		Os:            Version.OS,
 	}, nil
 }
 
@@ -124,20 +123,19 @@ func (server *Server) Devices(request *synse.DeviceFilter, stream synse.Plugin_D
 // Metainfo is the handler for the Synse GRPC Plugin service's `Metainfo` RPC method.
 func (server *Server) Metainfo(ctx context.Context, request *synse.Empty) (*synse.Metadata, error) {
 	logger.Debug("gRPC server: metainfo")
-	ver := GetVersion()
 	return &synse.Metadata{
 		Name:        metainfo.Name,
 		Maintainer:  metainfo.Maintainer,
 		Description: metainfo.Description,
 		Vcs:         metainfo.VCS,
 		Version: &synse.VersionInfo{
-			PluginVersion: ver.PluginVersion,
-			SdkVersion:    ver.SDKVersion,
-			BuildDate:     ver.BuildDate,
-			GitCommit:     ver.GitCommit,
-			GitTag:        ver.GitTag,
-			Arch:          ver.Arch,
-			Os:            ver.OS,
+			PluginVersion: Version.PluginVersion,
+			SdkVersion:    Version.SDKVersion,
+			BuildDate:     Version.BuildDate,
+			GitCommit:     Version.GitCommit,
+			GitTag:        Version.GitTag,
+			Arch:          Version.Arch,
+			Os:            Version.OS,
 		},
 	}, nil
 }

--- a/sdk/utils.go
+++ b/sdk/utils.go
@@ -4,12 +4,10 @@ import (
 	"crypto/md5" // #nosec
 	"fmt"
 	"io"
-	"os"
 	"strings"
 	"time"
 
 	"github.com/vapor-ware/synse-sdk/sdk/config"
-	"github.com/vapor-ware/synse-sdk/sdk/logger"
 )
 
 // makeIDString makes a compound string out of the given rack, board, and
@@ -17,134 +15,6 @@ import (
 // for a given device.
 func makeIDString(rack, board, device string) string {
 	return strings.Join([]string{rack, board, device}, "-")
-}
-
-// getHandlerForDevice gets the DeviceHandler for a device, based on the handler name.
-func getHandlerForDevice(handlerName string) (*DeviceHandler, error) {
-	for _, handler := range deviceHandlers {
-		if handler.Name == handlerName {
-			return handler, nil
-		}
-	}
-	return nil, fmt.Errorf("no handler found with name: %s", handlerName)
-}
-
-// makeDevices creates Device instances from a DeviceConfig. The DeviceConfig
-// used here should be a unified config, meaning that all DeviceConfigs (either from
-// different files or from file and dynamic registration) are merged into a single
-// DeviceConfig. This should only be called once all configs have been parsed and
-// validated to ensure that the information we have is all correct.
-func makeDevices(config *config.DeviceConfig) ([]*Device, error) {
-	var devices []*Device
-
-	// The DeviceConfig we get here should be the unified config.
-	for _, kind := range config.Devices {
-		for _, instance := range kind.Instances {
-
-			// Get the outputs for the instance.
-			instanceOutputs, err := getInstanceOutputs(kind, instance)
-
-			// Get the location
-			l, err := config.GetLocation(instance.Location)
-			if err != nil {
-				return nil, err
-			}
-			location, err := NewLocationFromConfig(l)
-			if err != nil {
-				return nil, err
-			}
-
-			// Get the DeviceHandler. If a specific handlerName is set in the config,
-			// we will use that as the definitive handler. Otherwise, use the kind.
-			handlerName := kind.Name
-			if kind.HandlerName != "" {
-				handlerName = kind.HandlerName
-			}
-			if instance.HandlerName != "" {
-				handlerName = instance.HandlerName
-			}
-			handler, err := getHandlerForDevice(handlerName)
-			if err != nil {
-				return nil, err
-			}
-
-			device := &Device{
-				// The name of the device kind. This is essentially the identifier
-				// for the device type.
-				Kind: kind.Name,
-
-				// Any metadata associated with the device kind.
-				Metadata: kind.Metadata,
-
-				// The name of the plugin.
-				Plugin: metainfo.Name,
-
-				// Device-level information. This is not output-specific info.
-				Info: instance.Info,
-
-				// The location of the device.
-				Location: location,
-
-				// Any data associated with the device instance.
-				Data: instance.Data,
-
-				// The outputs supported by the device. A device output may
-				// supply more info, like Data, Info, Type, etc, so that should
-				// be accounted for when doing readings/writing stuff..
-				Outputs: instanceOutputs,
-
-				// The read/write handler for the device. Handlers should be registered globally.
-				Handler: handler,
-			}
-
-			devices = append(devices, device)
-		}
-	}
-	return devices, nil
-}
-
-// getInstanceOutputs get the Outputs for a single device instance. It converts
-// the instance's DeviceOutput to an Output type, and by doing so unifies that
-// output with its corresponding OutputType information.
-//
-// If output inheritance is enable for the instance (which is it by default),
-// this will also take the DeviceOutputs defined by the instance's kind.
-func getInstanceOutputs(kind *config.DeviceKind, instance *config.DeviceInstance) ([]*Output, error) {
-	var instanceOutputs []*Output
-
-	// Create the outputs specific to the instance first.
-	for _, o := range instance.Outputs {
-		output, err := NewOutputFromConfig(o)
-		if err != nil {
-			return nil, err
-		}
-		instanceOutputs = append(instanceOutputs, output)
-	}
-
-	// If output inheritance is not disabled, we will take any outputs
-	// from the DeviceKind as well. If there is an output with the same
-	// name already set from the instance config, we will ignore it.
-	if !instance.DisableOutputInheritance {
-		for _, o := range kind.Outputs {
-			output, err := NewOutputFromConfig(o)
-			if err != nil {
-				return nil, err
-			}
-			// Check if the output is already being tracked
-			duplicate := false
-			for _, tracked := range instanceOutputs {
-				if tracked.Name == output.Name {
-					duplicate = true
-					break
-				}
-			}
-			if !duplicate {
-				instanceOutputs = append(instanceOutputs, output)
-			}
-		}
-	}
-
-	return instanceOutputs, nil
 }
 
 // getTypeByName gets the output type with the given name. If an output type does
@@ -155,34 +25,6 @@ func getTypeByName(name string) (*config.OutputType, error) {
 		return nil, fmt.Errorf("no output type with name '%s' found", name)
 	}
 	return t, nil
-}
-
-// setupSocket is used to make sure the path for unix socket used for gRPC communication
-// is set up and accessible locally. Creates the directory for the socket. Returns the
-// directoryName and err.
-func setupSocket(name string) (string, error) {
-	socket := fmt.Sprintf("%s/%s", sockPath, name)
-
-	_, err := os.Stat(sockPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			if err = os.MkdirAll(sockPath, os.ModePerm); err != nil {
-				return "", err
-			}
-		} else {
-			logger.Errorf("failed to create socket path %v: %v", sockPath, err)
-			return "", err
-		}
-	} else {
-		err = os.Remove(socket)
-		if err != nil {
-			if !os.IsNotExist(err) {
-				logger.Errorf("failed to remove existing socket %v: %v", socket, err)
-				return "", err
-			}
-		}
-	}
-	return socket, nil
 }
 
 // newUID creates a new unique identifier for a Device. This id should be

--- a/sdk/version.go
+++ b/sdk/version.go
@@ -5,6 +5,7 @@ import (
 
 	"bytes"
 	"text/template"
+
 	"github.com/vapor-ware/synse-sdk/sdk/logger"
 )
 
@@ -44,7 +45,6 @@ func init() {
 		PluginVersion: setField(PluginVersion),
 	}
 }
-
 
 // BinVersion describes the version of the binary for a plugin.
 //

--- a/sdk/version.go
+++ b/sdk/version.go
@@ -5,10 +5,15 @@ import (
 
 	"bytes"
 	"text/template"
+	"github.com/vapor-ware/synse-sdk/sdk/logger"
 )
 
 // SDKVersion specifies the version of the Synse Plugin SDK.
 const SDKVersion = "1.0.0"
+
+// version is a reference to a BinVersion that can be used to get
+// the version info for a plugin.
+var Version *BinVersion
 
 var (
 	// BuildDate is the timestamp for when the build happened.
@@ -27,6 +32,20 @@ var (
 	PluginVersion string
 )
 
+func init() {
+	Version = &BinVersion{
+		Arch:          runtime.GOARCH,
+		OS:            runtime.GOOS,
+		SDKVersion:    SDKVersion,
+		BuildDate:     setField(BuildDate),
+		GitCommit:     setField(GitCommit),
+		GitTag:        setField(GitTag),
+		GoVersion:     setField(GoVersion),
+		PluginVersion: setField(PluginVersion),
+	}
+}
+
+
 // BinVersion describes the version of the binary for a plugin.
 //
 // This should be populated via build-time args passed in for
@@ -43,7 +62,6 @@ type BinVersion struct {
 }
 
 // Format returns a formatted string with all of the BinVersion info.
-// This string can be logged or printed out.
 func (version *BinVersion) Format() string {
 	var info bytes.Buffer
 
@@ -62,22 +80,16 @@ func (version *BinVersion) Format() string {
 	return info.String()
 }
 
-// FIXME: instead of having this be a function call, we could do this in an init function
-
-// GetVersion gets the version information for the plugin. It builds
-// a BinVersion using the variables that should be set as build-time
-// arguments.
-func GetVersion() *BinVersion {
-	return &BinVersion{
-		Arch:          runtime.GOARCH,
-		OS:            runtime.GOOS,
-		SDKVersion:    SDKVersion,
-		BuildDate:     setField(BuildDate),
-		GitCommit:     setField(GitCommit),
-		GitTag:        setField(GitTag),
-		GoVersion:     setField(GoVersion),
-		PluginVersion: setField(PluginVersion),
-	}
+// Log logs out the BinVersion at info level.
+func (version *BinVersion) Log() {
+	logger.Info("Version Info:")
+	logger.Infof("  Plugin Version: %s", version.PluginVersion)
+	logger.Infof("  SDK Version:    %s", version.SDKVersion)
+	logger.Infof("  Git Commit:     %s", version.GitCommit)
+	logger.Infof("  Git Tag:        %s", version.GitTag)
+	logger.Infof("  Build Date:     %s", version.BuildDate)
+	logger.Infof("  Go Version:     %s", version.GoVersion)
+	logger.Infof("  OS/Arch:        %s/%s", version.OS, version.Arch)
 }
 
 // setField is a helper function that checks whether a field is set.

--- a/sdk/version_test.go
+++ b/sdk/version_test.go
@@ -6,53 +6,53 @@ import (
 
 	"github.com/stretchr/testify/assert"
 )
-
-// TestGetVersion gets the version and verifies that all fields are
-// set correctly. In this case, we do not have all variables set, so
-// we expect some fields to contain the default "empty" string.
-func TestGetVersion(t *testing.T) {
-	version := GetVersion()
-
-	// These fields are not set via global vars, so they should be empty
-	assert.Equal(t, "-", version.BuildDate)
-	assert.Equal(t, "-", version.GitCommit)
-	assert.Equal(t, "-", version.GitTag)
-	assert.Equal(t, "-", version.GoVersion)
-	assert.Equal(t, "-", version.PluginVersion)
-
-	// These should be set.
-	assert.Equal(t, runtime.GOOS, version.OS)
-	assert.Equal(t, runtime.GOARCH, version.Arch)
-	assert.Equal(t, SDKVersion, version.SDKVersion)
-}
-
-// TestGetVersion2 gets the version info when there are some variable set.
-func TestGetVersion2(t *testing.T) {
-	GitCommit = "123"
-	GitTag = "456"
-	PluginVersion = "1.2.3"
-
-	version := GetVersion()
-
-	// These fields are not set via global vars, so they should be empty
-	assert.Equal(t, "-", version.BuildDate)
-	assert.Equal(t, "-", version.GoVersion)
-
-	// These should be set.
-	assert.Equal(t, GitCommit, version.GitCommit)
-	assert.Equal(t, GitTag, version.GitTag)
-	assert.Equal(t, PluginVersion, version.PluginVersion)
-	assert.Equal(t, runtime.GOOS, version.OS)
-	assert.Equal(t, runtime.GOARCH, version.Arch)
-	assert.Equal(t, SDKVersion, version.SDKVersion)
-}
-
-// TestBinVersion_Format tests printing out the version info string.
-func TestBinVersion_Format(t *testing.T) {
-	version := GetVersion()
-	versionStr := version.Format()
-
-	// the version string will be different depending on when/where the
-	// test is run, so just verify that the string isn't empty..
-	assert.NotEmpty(t, versionStr)
-}
+//
+//// TestGetVersion gets the version and verifies that all fields are
+//// set correctly. In this case, we do not have all variables set, so
+//// we expect some fields to contain the default "empty" string.
+//func TestGetVersion(t *testing.T) {
+//	version := GetVersion()
+//
+//	// These fields are not set via global vars, so they should be empty
+//	assert.Equal(t, "-", version.BuildDate)
+//	assert.Equal(t, "-", version.GitCommit)
+//	assert.Equal(t, "-", version.GitTag)
+//	assert.Equal(t, "-", version.GoVersion)
+//	assert.Equal(t, "-", version.PluginVersion)
+//
+//	// These should be set.
+//	assert.Equal(t, runtime.GOOS, version.OS)
+//	assert.Equal(t, runtime.GOARCH, version.Arch)
+//	assert.Equal(t, SDKVersion, version.SDKVersion)
+//}
+//
+//// TestGetVersion2 gets the version info when there are some variable set.
+//func TestGetVersion2(t *testing.T) {
+//	GitCommit = "123"
+//	GitTag = "456"
+//	PluginVersion = "1.2.3"
+//
+//	version := GetVersion()
+//
+//	// These fields are not set via global vars, so they should be empty
+//	assert.Equal(t, "-", version.BuildDate)
+//	assert.Equal(t, "-", version.GoVersion)
+//
+//	// These should be set.
+//	assert.Equal(t, GitCommit, version.GitCommit)
+//	assert.Equal(t, GitTag, version.GitTag)
+//	assert.Equal(t, PluginVersion, version.PluginVersion)
+//	assert.Equal(t, runtime.GOOS, version.OS)
+//	assert.Equal(t, runtime.GOARCH, version.Arch)
+//	assert.Equal(t, SDKVersion, version.SDKVersion)
+//}
+//
+//// TestBinVersion_Format tests printing out the version info string.
+//func TestBinVersion_Format(t *testing.T) {
+//	version := GetVersion()
+//	versionStr := version.Format()
+//
+//	// the version string will be different depending on when/where the
+//	// test is run, so just verify that the string isn't empty..
+//	assert.NotEmpty(t, versionStr)
+//}

--- a/sdk/version_test.go
+++ b/sdk/version_test.go
@@ -1,11 +1,5 @@
 package sdk
 
-import (
-	"runtime"
-	"testing"
-
-	"github.com/stretchr/testify/assert"
-)
 //
 //// TestGetVersion gets the version and verifies that all fields are
 //// set correctly. In this case, we do not have all variables set, so


### PR DESCRIPTION
This PR:
- adds support for post-run actions (#85)
- adds a socket-cleanup post-run action (#14)
- cleans up utils.go (#232)
- makes the version a global var instead of a function call
- various other bits of cleanup/reorganization