### PR TITLE
Add and update tests for the SDK

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -59,13 +59,13 @@
   branch = "sdk-1.0"
   name = "github.com/vapor-ware/synse-server-grpc"
   packages = ["go"]
-  revision = "1dca5df96dec9109d2f0c981be141179aa9dc475"
+  revision = "7922ce761ae1e8ea87f61527a88ae96f33ba43d9"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
-  revision = "5ba7f63082460102a45837dbd1827e10f9479ac0"
+  revision = "b47b1587369238182299fe4dad77d05b8b461e06"
 
 [[projects]]
   branch = "master"
@@ -88,7 +88,7 @@
     "unix",
     "windows"
   ]
-  revision = "c11f84a56e43e20a78cee75a7c034031ecf57d1f"
+  revision = "9527bec2660bd847c050fda93a0f0c6dee0800bb"
 
 [[projects]]
   name = "golang.org/x/text"
@@ -121,7 +121,7 @@
   branch = "master"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
-  revision = "4065a77fc542a455295382a23a996a08ed18813a"
+  revision = "81158efcc9f219c511e4d3c0d61a0e6e49c01a24"
 
 [[projects]]
   name = "google.golang.org/grpc"
@@ -151,8 +151,8 @@
     "tap",
     "transport"
   ]
-  revision = "41344da2231b913fa3d983840a57a6b1b7b631a1"
-  version = "v1.12.0"
+  revision = "22a49e732a507a11ac524e4ea5fd1a3e384b6fb8"
+  version = "v1.12.1"
 
 [[projects]]
   name = "gopkg.in/yaml.v2"

--- a/examples/c_plugin/plugin.go
+++ b/examples/c_plugin/plugin.go
@@ -41,22 +41,6 @@ var temperatureHandler = sdk.DeviceHandler{
 	},
 }
 
-// ProtocolIdentifier gets the unique identifiers out of the plugin-specific
-// configuration to be used in UID generation.
-func ProtocolIdentifier(data map[string]string) string {
-	return data["id"]
-}
-
-// checkErr is a helper used in the main function to check errors. If any errors
-// are present, this will exit with log.Fatal.
-func checkErr(err error) {
-	if err != nil {
-		log.Fatal(err)
-	}
-}
-
-// The main function - this is where we will configure, create, and run
-// the plugin.
 func main() {
 	// Set the metainfo for the plugin.
 	sdk.SetPluginMeta(
@@ -70,9 +54,12 @@ func main() {
 	plugin := sdk.NewPlugin()
 
 	// Register the output types
-	plugin.RegisterOutputTypes(
+	err := plugin.RegisterOutputTypes(
 		&temperatureOutput,
 	)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	// Register device handlers
 	plugin.RegisterDeviceHandlers(

--- a/examples/dynamic_registration/plugin.go
+++ b/examples/dynamic_registration/plugin.go
@@ -46,15 +46,14 @@ func ProtocolIdentifier(data map[string]interface{}) string {
 	return data["id"].(string)
 }
 
-// EnumerateDevices is used to auto-enumerate device configurations for plugins
+// DynamicDeviceConfig is used to dynamically register device configurations for plugins
 // that support it. This is plugin specific. The config parameter here is a map
-// of configuration values that are taken from the list defined in the plugin
-// config file under the "auto_enumerate" option. This method will be called on
-// each member of that list sequentially.
+// of configuration values that are taken from the config defined in the plugin
+// config file under the "dynamicRegistration" option.
 //
 // The example implementation here is a bit contrived - it takes a base address
 // from the config and creates 3 devices off of that base. This isn't necessarily
-// "auto-enumeration" by definition, but it is a valid usage. A more appropriate
+// "dynamic registration" by definition, but it is a valid usage. A more appropriate
 // example could be taking an IP from the configuration, and using that to hit some
 // endpoint which would give back all the information on the devices it manages.
 func DynamicDeviceConfig(cfg map[string]interface{}) ([]*config.DeviceConfig, error) {
@@ -72,7 +71,7 @@ func DynamicDeviceConfig(cfg map[string]interface{}) ([]*config.DeviceConfig, er
 		// should be gathered from whatever the real source of auto-enumeration is,
 		// e.g. for IPMI - the SDR records.
 		d := config.DeviceConfig{
-			ConfigVersion: config.ConfigVersion{
+			SchemeVersion: config.SchemeVersion{
 				Version: "1.0",
 			},
 			Locations: []*config.Location{
@@ -128,7 +127,10 @@ func main() {
 	)
 
 	// Register output types
-	plugin.RegisterOutputTypes(&temperatureOutput)
+	err := plugin.RegisterOutputTypes(&temperatureOutput)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	// Register device handlers
 	plugin.RegisterDeviceHandlers(&temperatureHandler)

--- a/examples/multi_device_plugin/plugin.go
+++ b/examples/multi_device_plugin/plugin.go
@@ -36,11 +36,14 @@ func main() {
 	)
 
 	// Register our output types with the plugin
-	plugin.RegisterOutputTypes(
+	err := plugin.RegisterOutputTypes(
 		&outputs.AirflowOutput,
 		&outputs.TemperatureOutput,
 		&outputs.VoltageOutput,
 	)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	// Register device handlers
 	plugin.RegisterDeviceHandlers(

--- a/examples/simple_plugin/plugin.go
+++ b/examples/simple_plugin/plugin.go
@@ -95,10 +95,13 @@ func main() {
 	plugin := sdk.NewPlugin()
 
 	// Register our output types with the Plugin.
-	plugin.RegisterOutputTypes(
+	err := plugin.RegisterOutputTypes(
 		&temperatureOutput,
 		&ledOutput,
 	)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	// Register our device handlers with the Plugin.
 	plugin.RegisterDeviceHandlers(

--- a/internal/test/grpc.go
+++ b/internal/test/grpc.go
@@ -1,0 +1,124 @@
+package test
+
+import (
+	"fmt"
+
+	"github.com/vapor-ware/synse-server-grpc/go"
+	"google.golang.org/grpc"
+)
+
+// MockCapabilitiesStream mocks the stream for the Capabilities request, with no error.
+type MockCapabilitiesStream struct {
+	grpc.ServerStream
+	Results map[string]*synse.DeviceCapability
+}
+
+// NewMockCapabilitiesStream creates a new mock capabilities stream.
+func NewMockCapabilitiesStream() *MockCapabilitiesStream {
+	return &MockCapabilitiesStream{
+		Results: map[string]*synse.DeviceCapability{},
+	}
+}
+
+// Send fulfils the stream interface for the mock grpc stream.
+func (mock *MockCapabilitiesStream) Send(capability *synse.DeviceCapability) error {
+	mock.Results[capability.Kind] = capability
+	return nil
+}
+
+// MockCapabilitiesStreamErr mocks the stream for the Capabilities request, with error.
+type MockCapabilitiesStreamErr struct {
+	grpc.ServerStream
+}
+
+// Send fulfils the stream interface for the mock grpc stream.
+func (mock *MockCapabilitiesStreamErr) Send(capability *synse.DeviceCapability) error {
+	return fmt.Errorf("grpc error")
+}
+
+// MockDevicesStream mocks the stream for the Devices request, with no error.
+type MockDevicesStream struct {
+	grpc.ServerStream
+	Results map[string]*synse.Device
+}
+
+// NewMockDevicesStream creates a new mock devices stream.
+func NewMockDevicesStream() *MockDevicesStream {
+	return &MockDevicesStream{
+		Results: map[string]*synse.Device{},
+	}
+}
+
+// Send fulfils the stream interface for the mock grpc stream.
+func (mock *MockDevicesStream) Send(device *synse.Device) error {
+	mock.Results[device.GetUid()] = device
+	return nil
+}
+
+// MockDevicesStreamErr mocks the stream for the Devices request, with error.
+type MockDevicesStreamErr struct {
+	grpc.ServerStream
+}
+
+// Send fulfils the stream interface for the mock grpc stream.
+func (mock *MockDevicesStreamErr) Send(device *synse.Device) error {
+	return fmt.Errorf("grpc error")
+}
+
+// MockReadStream mocks the stream for the Read request, with no error.
+type MockReadStream struct {
+	grpc.ServerStream
+	Results []*synse.Reading
+}
+
+// NewMockReadStream creates a new mock read stream.
+func NewMockReadStream() *MockReadStream {
+	return &MockReadStream{
+		Results: []*synse.Reading{},
+	}
+}
+
+// Send fulfils the stream interface for the mock grpc stream.
+func (mock *MockReadStream) Send(reading *synse.Reading) error {
+	mock.Results = append(mock.Results, reading)
+	return nil
+}
+
+// MockReadStreamErr mocks the stream for the Read request, with error.
+type MockReadStreamErr struct {
+	grpc.ServerStream
+}
+
+// Send fulfils the stream interface for the mock grpc stream.
+func (mock *MockReadStreamErr) Send(reading *synse.Reading) error {
+	return fmt.Errorf("grpc error")
+}
+
+// MockTransactionStream mocks the stream for the Transaction request, with no error.
+type MockTransactionStream struct {
+	grpc.ServerStream
+	Results map[string]*synse.WriteResponse
+}
+
+// NewMockTransactionStream creates a new mock transaction stream.
+func NewMockTransactionStream() *MockTransactionStream {
+	return &MockTransactionStream{
+		Results: map[string]*synse.WriteResponse{},
+	}
+}
+
+// Send fulfils the stream interface for the mock grpc stream.
+func (mock *MockTransactionStream) Send(write *synse.WriteResponse) error {
+	mock.Results[write.Id] = write
+	return nil
+}
+
+// MockTransactionStreamErr mocks the stream for the Transaction request, with error.
+type MockTransactionStreamErr struct {
+	grpc.ServerStream
+}
+
+// Send fulfils the stream interface for the mock grpc stream.
+func (mock *MockTransactionStreamErr) Send(write *synse.WriteResponse) error {
+	return fmt.Errorf("grpc error")
+}

--- a/sdk/actions_test.go
+++ b/sdk/actions_test.go
@@ -1,1 +1,442 @@
 package sdk
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// clearPreRunActions is a util to clear the pre run action slice.
+func clearPreRunActions() {
+	preRunActions = []pluginAction{}
+}
+
+// clearPostRunActions is a util to clear the post run action slice.
+func clearPostRunActions() {
+	postRunActions = []pluginAction{}
+}
+
+// clearDeviceSetupActions is a util to clear the device setup action map.
+func clearDeviceSetupActions() {
+	deviceSetupActions = map[string][]deviceAction{}
+}
+
+// TestActionsInit tests that the actions data structures were initialized
+// via the init function.
+func TestActionsInit(t *testing.T) {
+	assert.NotNil(t, preRunActions)
+	assert.Empty(t, preRunActions)
+	assert.NotNil(t, postRunActions)
+	assert.Empty(t, postRunActions)
+	assert.NotNil(t, deviceSetupActions)
+	assert.Empty(t, deviceSetupActions)
+}
+
+// Test_execPreRun tests running pre-run actions, when none are specified.
+func Test_execPreRun(t *testing.T) {
+	defer clearPreRunActions()
+
+	plugin := NewPlugin()
+	err := execPreRun(plugin)
+
+	assert.NoError(t, err.Err())
+}
+
+// Test_execPreRun1 tests running pre-run actions, when one is specified.
+func Test_execPreRun1(t *testing.T) {
+	defer clearPreRunActions()
+
+	c := 0
+	action := func(_ *Plugin) error {
+		c += 1
+		return nil
+	}
+
+	plugin := NewPlugin()
+	plugin.RegisterPreRunActions(action)
+
+	err := execPreRun(plugin)
+
+	assert.NoError(t, err.Err())
+	assert.Equal(t, 1, c)
+}
+
+// Test_execPreRun2 tests running pre-run actions, when multiple are specified.
+func Test_execPreRun2(t *testing.T) {
+	defer clearPreRunActions()
+
+	c := 0
+	action := func(_ *Plugin) error {
+		c += 1
+		return nil
+	}
+
+	plugin := NewPlugin()
+	plugin.RegisterPreRunActions(
+		action,
+		action,
+		action,
+	)
+
+	err := execPreRun(plugin)
+
+	assert.NoError(t, err.Err())
+	assert.Equal(t, 3, c)
+}
+
+// Test_execPreRun3 tests running pre-run actions, when one is specified, but that
+// one produces an error.
+func Test_execPreRun3(t *testing.T) {
+	defer clearPreRunActions()
+
+	c := 0
+	actionErr := func(_ *Plugin) error {
+		return fmt.Errorf("error")
+	}
+
+	plugin := NewPlugin()
+	plugin.RegisterPreRunActions(actionErr)
+
+	err := execPreRun(plugin)
+
+	assert.Error(t, err.Err())
+	assert.Equal(t, 0, c)
+}
+
+// Test_execPreRun4 tests running pre-run actions, when multiple are specified, and
+// one produces an error.
+func Test_execPreRun4(t *testing.T) {
+	defer clearPreRunActions()
+
+	c := 0
+	action := func(_ *Plugin) error {
+		c += 1
+		return nil
+	}
+	actionErr := func(_ *Plugin) error {
+		return fmt.Errorf("error")
+	}
+
+	plugin := NewPlugin()
+	plugin.RegisterPreRunActions(
+		action,
+		actionErr,
+		action,
+	)
+
+	err := execPreRun(plugin)
+
+	assert.Error(t, err.Err())
+	assert.Equal(t, 2, c)
+}
+
+// Test_execPreRun5 tests running pre-run actions, when multiple are specified, and
+// all produce an error.
+func Test_execPreRun5(t *testing.T) {
+	defer clearPreRunActions()
+
+	c := 0
+	actionErr := func(_ *Plugin) error {
+		return fmt.Errorf("error")
+	}
+
+	plugin := NewPlugin()
+	plugin.RegisterPreRunActions(
+		actionErr,
+		actionErr,
+		actionErr,
+	)
+
+	err := execPreRun(plugin)
+
+	assert.Error(t, err.Err())
+	assert.Equal(t, 0, c)
+}
+
+// Test_execPostRun tests running post-run actions, when none are specified.
+func Test_execPostRun(t *testing.T) {
+	defer clearPostRunActions()
+
+	plugin := NewPlugin()
+	err := execPostRun(plugin)
+
+	assert.NoError(t, err.Err())
+}
+
+// Test_execPostRun1 tests running post-run actions, when one is specified.
+func Test_execPostRun1(t *testing.T) {
+	defer clearPostRunActions()
+
+	c := 0
+	action := func(_ *Plugin) error {
+		c += 1
+		return nil
+	}
+
+	plugin := NewPlugin()
+	plugin.RegisterPostRunActions(action)
+
+	err := execPostRun(plugin)
+
+	assert.NoError(t, err.Err())
+	assert.Equal(t, 1, c)
+}
+
+// Test_execPostRun2 tests running post-run actions, when multiple are specified.
+func Test_execPostRun2(t *testing.T) {
+	defer clearPostRunActions()
+
+	c := 0
+	action := func(_ *Plugin) error {
+		c += 1
+		return nil
+	}
+
+	plugin := NewPlugin()
+	plugin.RegisterPostRunActions(
+		action,
+		action,
+		action,
+	)
+
+	err := execPostRun(plugin)
+
+	assert.NoError(t, err.Err())
+	assert.Equal(t, 3, c)
+}
+
+// Test_execPostRun3 tests running post-run actions, when one is specified, but
+// that one produces an error.
+func Test_execPostRun3(t *testing.T) {
+	defer clearPostRunActions()
+
+	c := 0
+	actionErr := func(_ *Plugin) error {
+		return fmt.Errorf("error")
+	}
+
+	plugin := NewPlugin()
+	plugin.RegisterPostRunActions(actionErr)
+
+	err := execPostRun(plugin)
+
+	assert.Error(t, err.Err())
+	assert.Equal(t, 0, c)
+}
+
+// Test_execPostRun4 tests running post-run actions, when multiple are specified,
+// and one produces an error.
+func Test_execPostRun4(t *testing.T) {
+	defer clearPostRunActions()
+
+	c := 0
+	action := func(_ *Plugin) error {
+		c += 1
+		return nil
+	}
+	actionErr := func(_ *Plugin) error {
+		return fmt.Errorf("error")
+	}
+
+	plugin := NewPlugin()
+	plugin.RegisterPostRunActions(
+		action,
+		actionErr,
+		action,
+	)
+
+	err := execPostRun(plugin)
+
+	assert.Error(t, err.Err())
+	assert.Equal(t, 2, c)
+}
+
+// Test_execPostRun5 tests running post-run actions, when multiple are specified,
+// and all produce an error.
+func Test_execPostRun5(t *testing.T) {
+	defer clearPostRunActions()
+
+	c := 0
+	actionErr := func(_ *Plugin) error {
+		return fmt.Errorf("error")
+	}
+
+	plugin := NewPlugin()
+	plugin.RegisterPostRunActions(
+		actionErr,
+		actionErr,
+		actionErr,
+	)
+
+	err := execPostRun(plugin)
+
+	assert.Error(t, err.Err())
+	assert.Equal(t, 0, c)
+}
+
+// Test_execDeviceSetup tests running device setup actions, when none are specified.
+func Test_execDeviceSetup(t *testing.T) {
+	defer clearDeviceSetupActions()
+
+	plugin := NewPlugin()
+	err := execDeviceSetup(plugin)
+
+	assert.NoError(t, err.Err())
+}
+
+// Test_execDeviceSetup1 tests running device setup actions, when one exists, but the
+// filter does not match anything.
+func Test_execDeviceSetup1(t *testing.T) {
+	defer clearDeviceSetupActions()
+
+	c := 0
+	action := func(_ *Plugin, _ *Device) error {
+		c += 1
+		return nil
+	}
+
+	plugin := NewPlugin()
+	plugin.RegisterDeviceSetupActions("kind=foo", action)
+	deviceMap["foobar"] = &Device{Kind: "test"}
+	defer delete(deviceMap, "foobar")
+
+	err := execDeviceSetup(plugin)
+
+	assert.NoError(t, err.Err())
+	assert.Equal(t, 0, c)
+}
+
+// Test_execDeviceSetup2 tests running device setup actions, when one exists and the
+// filter matches a device.
+func Test_execDeviceSetup2(t *testing.T) {
+	defer clearDeviceSetupActions()
+
+	c := 0
+	action := func(_ *Plugin, _ *Device) error {
+		c += 1
+		return nil
+	}
+
+	plugin := NewPlugin()
+	plugin.RegisterDeviceSetupActions("kind=test", action)
+	deviceMap["foobar"] = &Device{Kind: "test"}
+	defer delete(deviceMap, "foobar")
+
+	err := execDeviceSetup(plugin)
+
+	assert.NoError(t, err.Err())
+	assert.Equal(t, 1, c)
+}
+
+// Test_execDeviceSetup3 tests running device setup actions, when an invalid filter
+// is specified.
+func Test_execDeviceSetup3(t *testing.T) {
+	defer clearDeviceSetupActions()
+
+	c := 0
+	action := func(_ *Plugin, _ *Device) error {
+		c += 1
+		return nil
+	}
+
+	plugin := NewPlugin()
+	plugin.RegisterDeviceSetupActions("foo=test", action)
+	deviceMap["foobar"] = &Device{Kind: "test"}
+	defer delete(deviceMap, "foobar")
+
+	err := execDeviceSetup(plugin)
+
+	assert.Error(t, err.Err())
+	assert.Equal(t, 0, c)
+}
+
+// Test_execDeviceSetup4 tests running device setup actions, when there are multiple
+// actions for a device.
+func Test_execDeviceSetup4(t *testing.T) {
+	defer clearDeviceSetupActions()
+
+	c := 0
+	action := func(_ *Plugin, _ *Device) error {
+		c += 1
+		return nil
+	}
+
+	plugin := NewPlugin()
+	plugin.RegisterDeviceSetupActions("kind=test", action, action, action)
+	deviceMap["foobar"] = &Device{Kind: "test"}
+	defer delete(deviceMap, "foobar")
+
+	err := execDeviceSetup(plugin)
+
+	assert.NoError(t, err.Err())
+	assert.Equal(t, 3, c)
+
+}
+
+// Test_execDeviceSetup5 tests running device setup actions, when a single action exists
+// and fails.
+func Test_execDeviceSetup5(t *testing.T) {
+	defer clearDeviceSetupActions()
+
+	c := 0
+	actionErr := func(_ *Plugin, _ *Device) error {
+		return fmt.Errorf("error")
+	}
+
+	plugin := NewPlugin()
+	plugin.RegisterDeviceSetupActions("kind=test", actionErr)
+	deviceMap["foobar"] = &Device{Kind: "test"}
+	defer delete(deviceMap, "foobar")
+
+	err := execDeviceSetup(plugin)
+
+	assert.Error(t, err.Err())
+	assert.Equal(t, 0, c)
+}
+
+// Test_execDeviceSetup6 tests running device setup actions, when multiple actions exist
+// and some fail.
+func Test_execDeviceSetup6(t *testing.T) {
+	defer clearDeviceSetupActions()
+
+	c := 0
+	action := func(_ *Plugin, _ *Device) error {
+		c += 1
+		return nil
+	}
+	actionErr := func(_ *Plugin, _ *Device) error {
+		return fmt.Errorf("error")
+	}
+
+	plugin := NewPlugin()
+	plugin.RegisterDeviceSetupActions("kind=test", action, actionErr, action)
+	deviceMap["foobar"] = &Device{Kind: "test"}
+	defer delete(deviceMap, "foobar")
+
+	err := execDeviceSetup(plugin)
+
+	assert.Error(t, err.Err())
+	assert.Equal(t, 2, c)
+}
+
+// Test_execDeviceSetup7 tests running device setup actions, when multiple actions exist
+// and all fail.
+func Test_execDeviceSetup7(t *testing.T) {
+	defer clearDeviceSetupActions()
+
+	c := 0
+	actionErr := func(_ *Plugin, _ *Device) error {
+		return fmt.Errorf("error")
+	}
+
+	plugin := NewPlugin()
+	plugin.RegisterDeviceSetupActions("kind=test", actionErr, actionErr, actionErr)
+	deviceMap["foobar"] = &Device{Kind: "test"}
+	defer delete(deviceMap, "foobar")
+
+	err := execDeviceSetup(plugin)
+
+	assert.Error(t, err.Err())
+	assert.Equal(t, 0, c)
+}

--- a/sdk/actions_test.go
+++ b/sdk/actions_test.go
@@ -49,7 +49,7 @@ func Test_execPreRun1(t *testing.T) {
 
 	c := 0
 	action := func(_ *Plugin) error {
-		c += 1
+		c++
 		return nil
 	}
 
@@ -68,7 +68,7 @@ func Test_execPreRun2(t *testing.T) {
 
 	c := 0
 	action := func(_ *Plugin) error {
-		c += 1
+		c++
 		return nil
 	}
 
@@ -111,7 +111,7 @@ func Test_execPreRun4(t *testing.T) {
 
 	c := 0
 	action := func(_ *Plugin) error {
-		c += 1
+		c++
 		return nil
 	}
 	actionErr := func(_ *Plugin) error {
@@ -170,7 +170,7 @@ func Test_execPostRun1(t *testing.T) {
 
 	c := 0
 	action := func(_ *Plugin) error {
-		c += 1
+		c++
 		return nil
 	}
 
@@ -189,7 +189,7 @@ func Test_execPostRun2(t *testing.T) {
 
 	c := 0
 	action := func(_ *Plugin) error {
-		c += 1
+		c++
 		return nil
 	}
 
@@ -232,7 +232,7 @@ func Test_execPostRun4(t *testing.T) {
 
 	c := 0
 	action := func(_ *Plugin) error {
-		c += 1
+		c++
 		return nil
 	}
 	actionErr := func(_ *Plugin) error {
@@ -292,7 +292,7 @@ func Test_execDeviceSetup1(t *testing.T) {
 
 	c := 0
 	action := func(_ *Plugin, _ *Device) error {
-		c += 1
+		c++
 		return nil
 	}
 
@@ -314,7 +314,7 @@ func Test_execDeviceSetup2(t *testing.T) {
 
 	c := 0
 	action := func(_ *Plugin, _ *Device) error {
-		c += 1
+		c++
 		return nil
 	}
 
@@ -336,7 +336,7 @@ func Test_execDeviceSetup3(t *testing.T) {
 
 	c := 0
 	action := func(_ *Plugin, _ *Device) error {
-		c += 1
+		c++
 		return nil
 	}
 
@@ -358,7 +358,7 @@ func Test_execDeviceSetup4(t *testing.T) {
 
 	c := 0
 	action := func(_ *Plugin, _ *Device) error {
-		c += 1
+		c++
 		return nil
 	}
 
@@ -402,7 +402,7 @@ func Test_execDeviceSetup6(t *testing.T) {
 
 	c := 0
 	action := func(_ *Plugin, _ *Device) error {
-		c += 1
+		c++
 		return nil
 	}
 	actionErr := func(_ *Plugin, _ *Device) error {

--- a/sdk/config/config.go
+++ b/sdk/config/config.go
@@ -4,59 +4,59 @@ import (
 	"github.com/vapor-ware/synse-sdk/sdk/errors"
 )
 
-// ConfigComponent is an interface that all structs that define configuration
+// Component is an interface that all structs that define configuration
 // components should implement.
 //
 // This interface implements a Validate function which is used by the
 // SchemeValidator in order to validate each struct that makes up a configuration.
-type ConfigComponent interface {
+type Component interface {
 	Validate(*errors.MultiError)
 }
 
-// ConfigBase is an interface that the base configuration struct should
+// Base is an interface that the base configuration struct should
 // implement. This allows the SchemeValidator to get the SchemeVersion
 // for that given configuration.
-type ConfigBase interface {
-	GetSchemeVersion() (*SchemeVersion, error)
+type Base interface {
+	GetVersion() (*Version, error)
 }
 
-// ConfigContext is a structure that associates context with configuration info.
+// Context is a structure that associates context with configuration info.
 //
 // The context around some bit of configuration is useful in logging/errors, as
 // it lets us know which config we are talking about.
-type ConfigContext struct {
+type Context struct {
 	// Source is where the config came from.
 	Source string
 
 	// Config is the configuration itself. This should be a configuration struct
-	// that implements ConfigBase. That is to say, the config held in this context
+	// that implements Base. That is to say, the config held in this context
 	// should be the root config struct for that config type. This will allow us
 	// to get the scheme version of the configuration.
-	Config ConfigBase
+	Config Base
 }
 
-// NewConfigContext creates a new ConfigContext instance.
-func NewConfigContext(source string, config ConfigBase) *ConfigContext {
-	return &ConfigContext{
+// NewConfigContext creates a new Context instance.
+func NewConfigContext(source string, config Base) *Context {
+	return &Context{
 		Source: source,
 		Config: config,
 	}
 }
 
 // IsDeviceConfig checks whether the config in this context is a DeviceConfig.
-func (ctx *ConfigContext) IsDeviceConfig() bool {
+func (ctx *Context) IsDeviceConfig() bool {
 	_, ok := ctx.Config.(*DeviceConfig)
 	return ok
 }
 
 // IsPluginConfig checks whether the config in the context is a PluginConfig.
-func (ctx *ConfigContext) IsPluginConfig() bool {
+func (ctx *Context) IsPluginConfig() bool {
 	_, ok := ctx.Config.(*PluginConfig)
 	return ok
 }
 
 // IsOutputTypeConfig checks whether the config in the context is an OutputType config.
-func (ctx *ConfigContext) IsOutputTypeConfig() bool {
+func (ctx *Context) IsOutputTypeConfig() bool {
 	_, ok := ctx.Config.(*OutputType)
 	return ok
 }

--- a/sdk/config/config_test.go
+++ b/sdk/config/config_test.go
@@ -51,6 +51,11 @@ func TestConfigContext_IsDeviceConfig(t *testing.T) {
 			isDevCfg: false,
 			config:   &PluginConfig{},
 		},
+		{
+			desc:     "Config is a pointer to an OutputType",
+			isDevCfg: false,
+			config:   &OutputType{},
+		},
 	}
 
 	for _, testCase := range testTable {
@@ -81,6 +86,11 @@ func TestConfigContext_IsPluginConfig(t *testing.T) {
 			isPluginCfg: true,
 			config:      &PluginConfig{},
 		},
+		{
+			desc:        "Config is a pointer to an OutputType",
+			isPluginCfg: false,
+			config:      &OutputType{},
+		},
 	}
 
 	for _, testCase := range testTable {
@@ -91,5 +101,40 @@ func TestConfigContext_IsPluginConfig(t *testing.T) {
 
 		actual := ctx.IsPluginConfig()
 		assert.Equal(t, testCase.isPluginCfg, actual, testCase.desc)
+	}
+}
+
+// TestConfigContext_IsOutputTypeConfig tests whether the Config member is an OutputType config.
+func TestConfigContext_IsOutputTypeConfig(t *testing.T) {
+	var testTable = []struct {
+		desc         string
+		isOutputType bool
+		config       ConfigBase
+	}{
+		{
+			desc:         "Config is a pointer to an OutputType",
+			isOutputType: true,
+			config:       &OutputType{},
+		},
+		{
+			desc:         "Config is a pointer to a PluginConfig",
+			isOutputType: false,
+			config:       &PluginConfig{},
+		},
+		{
+			desc:         "Config is a pointer to a DeviceConfig",
+			isOutputType: false,
+			config:       &DeviceConfig{},
+		},
+	}
+
+	for _, testCase := range testTable {
+		ctx := ConfigContext{
+			Source: "test",
+			Config: testCase.config,
+		}
+
+		actual := ctx.IsOutputTypeConfig()
+		assert.Equal(t, testCase.isOutputType, actual, testCase.desc)
 	}
 }

--- a/sdk/config/config_test.go
+++ b/sdk/config/config_test.go
@@ -6,12 +6,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestNewConfigContext tests creating a new ConfigContext.
+// TestNewConfigContext tests creating a new Context.
 func TestNewConfigContext(t *testing.T) {
 	var testTable = []struct {
 		desc   string
 		source string
-		config ConfigBase
+		config Base
 	}{
 		{
 			desc:   "Config is a pointer to a DeviceConfig",
@@ -28,7 +28,7 @@ func TestNewConfigContext(t *testing.T) {
 	for _, testCase := range testTable {
 		ctx := NewConfigContext(testCase.source, testCase.config)
 		assert.NotNil(t, ctx, testCase.desc)
-		assert.IsType(t, &ConfigContext{}, ctx, testCase.desc)
+		assert.IsType(t, &Context{}, ctx, testCase.desc)
 		assert.Equal(t, testCase.source, ctx.Source, testCase.desc)
 		assert.Equal(t, testCase.config, ctx.Config, testCase.desc)
 	}
@@ -39,7 +39,7 @@ func TestConfigContext_IsDeviceConfig(t *testing.T) {
 	var testTable = []struct {
 		desc     string
 		isDevCfg bool
-		config   ConfigBase
+		config   Base
 	}{
 		{
 			desc:     "Config is a pointer to a DeviceConfig",
@@ -59,7 +59,7 @@ func TestConfigContext_IsDeviceConfig(t *testing.T) {
 	}
 
 	for _, testCase := range testTable {
-		ctx := ConfigContext{
+		ctx := Context{
 			Source: "test",
 			Config: testCase.config,
 		}
@@ -74,7 +74,7 @@ func TestConfigContext_IsPluginConfig(t *testing.T) {
 	var testTable = []struct {
 		desc        string
 		isPluginCfg bool
-		config      ConfigBase
+		config      Base
 	}{
 		{
 			desc:        "Config is a pointer to a DeviceConfig",
@@ -94,7 +94,7 @@ func TestConfigContext_IsPluginConfig(t *testing.T) {
 	}
 
 	for _, testCase := range testTable {
-		ctx := ConfigContext{
+		ctx := Context{
 			Source: "test",
 			Config: testCase.config,
 		}
@@ -109,7 +109,7 @@ func TestConfigContext_IsOutputTypeConfig(t *testing.T) {
 	var testTable = []struct {
 		desc         string
 		isOutputType bool
-		config       ConfigBase
+		config       Base
 	}{
 		{
 			desc:         "Config is a pointer to an OutputType",
@@ -129,7 +129,7 @@ func TestConfigContext_IsOutputTypeConfig(t *testing.T) {
 	}
 
 	for _, testCase := range testTable {
-		ctx := ConfigContext{
+		ctx := Context{
 			Source: "test",
 			Config: testCase.config,
 		}

--- a/sdk/config/device.go
+++ b/sdk/config/device.go
@@ -17,8 +17,8 @@ var (
 // instances of those kinds which a plugin will manage.
 type DeviceConfig struct {
 
-	// ConfigVersion is the version of the configuration scheme.
-	ConfigVersion `yaml:",inline"`
+	// SchemeVersion is the version of the configuration scheme.
+	SchemeVersion `yaml:",inline"`
 
 	// Locations are all of the locations that are defined by the configuration
 	// for device instances to reference.
@@ -29,12 +29,12 @@ type DeviceConfig struct {
 	Devices []*DeviceKind `yaml:"devices,omitempty" addedIn:"1.0"`
 }
 
-// NewDeviceConfig returns a new instance of a DeviceConfig with the ConfigVersion
+// NewDeviceConfig returns a new instance of a DeviceConfig with the SchemeVersion
 // set to the latest (most current) device config scheme version, and the Locations
 // and Devices fields initialized, but not filled.
 func NewDeviceConfig() *DeviceConfig {
 	return &DeviceConfig{
-		ConfigVersion: ConfigVersion{
+		SchemeVersion: SchemeVersion{
 			Version: currentDeviceSchemeVersion,
 		},
 		Locations: []*Location{},
@@ -47,7 +47,7 @@ func NewDeviceConfig() *DeviceConfig {
 // This is called before Devices are created.
 func (config DeviceConfig) Validate(multiErr *errors.MultiError) {
 	// A version must be specified and it must be of the correct format.
-	_, err := config.GetSchemeVersion()
+	_, err := config.GetVersion()
 	if err != nil {
 		multiErr.Add(errors.NewValidationError(multiErr.Context["source"], err.Error()))
 	}
@@ -92,6 +92,7 @@ func (location Location) Validate(multiErr *errors.MultiError) {
 	}
 }
 
+// Equals checks if another Location is equal to this Location.
 func (location *Location) Equals(other *Location) bool {
 	if location == other {
 		return true
@@ -154,6 +155,7 @@ func (locData *LocationData) Get() (string, error) {
 	return location, nil
 }
 
+// Equals checks if another LocationData is equal to this LocationData.
 func (locData *LocationData) Equals(other *LocationData) bool {
 	if locData == other {
 		return true

--- a/sdk/config/device_test.go
+++ b/sdk/config/device_test.go
@@ -109,20 +109,20 @@ func TestDeviceConfig_Validate_Ok(t *testing.T) {
 		{
 			desc: "DeviceConfig has valid version",
 			config: DeviceConfig{
-				ConfigVersion: ConfigVersion{Version: "1.0"},
+				SchemeVersion: SchemeVersion{Version: "1.0"},
 			},
 		},
 		{
 			desc: "DeviceConfig has valid version and location",
 			config: DeviceConfig{
-				ConfigVersion: ConfigVersion{Version: "1.0"},
+				SchemeVersion: SchemeVersion{Version: "1.0"},
 				Locations:     []*Location{{Name: "test", Rack: &LocationData{Name: "test"}, Board: &LocationData{Name: "test"}}},
 			},
 		},
 		{
 			desc: "DeviceConfig has valid version, location, and DeviceKind",
 			config: DeviceConfig{
-				ConfigVersion: ConfigVersion{Version: "1.0"},
+				SchemeVersion: SchemeVersion{Version: "1.0"},
 				Locations:     []*Location{{Name: "test", Rack: &LocationData{Name: "test"}, Board: &LocationData{Name: "test"}}},
 				Devices:       []*DeviceKind{{Name: "test"}},
 			},
@@ -130,14 +130,14 @@ func TestDeviceConfig_Validate_Ok(t *testing.T) {
 		{
 			desc: "DeviceConfig has valid version, invalid Locations (Locations not validated here)",
 			config: DeviceConfig{
-				ConfigVersion: ConfigVersion{Version: "1.0"},
+				SchemeVersion: SchemeVersion{Version: "1.0"},
 				Locations:     []*Location{{Name: ""}},
 			},
 		},
 		{
 			desc: "DeviceConfig has valid version and locations, invalid DeviceKinds (DeviceKinds not validated here)",
 			config: DeviceConfig{
-				ConfigVersion: ConfigVersion{Version: "1.0"},
+				SchemeVersion: SchemeVersion{Version: "1.0"},
 				Locations:     []*Location{{Name: "test", Rack: &LocationData{Name: "test"}, Board: &LocationData{Name: "test"}}},
 				Devices:       []*DeviceKind{{Name: ""}},
 			},
@@ -163,7 +163,7 @@ func TestDeviceConfig_Validate_Error(t *testing.T) {
 			desc:     "DeviceConfig has invalid version",
 			errCount: 1,
 			config: DeviceConfig{
-				ConfigVersion: ConfigVersion{Version: "abc"},
+				SchemeVersion: SchemeVersion{Version: "abc"},
 			},
 		},
 	}

--- a/sdk/config/plugin.go
+++ b/sdk/config/plugin.go
@@ -23,7 +23,9 @@ var (
 // NewDefaultPluginConfig creates a new instance of a PluginConfig with its
 // default values resolved.
 func NewDefaultPluginConfig() (*PluginConfig, error) {
-	config := &PluginConfig{}
+	config := &PluginConfig{
+		SchemeVersion: SchemeVersion{Version: currentPluginSchemeVersion},
+	}
 	err := defaults.Set(config)
 	if err != nil {
 		return nil, err
@@ -34,8 +36,8 @@ func NewDefaultPluginConfig() (*PluginConfig, error) {
 // PluginConfig contains the configuration options for the plugin.
 type PluginConfig struct {
 
-	// ConfigVersion is the version of the configuration scheme.
-	ConfigVersion `yaml:",inline"`
+	// SchemeVersion is the version of the configuration scheme.
+	SchemeVersion `yaml:",inline"`
 
 	// Debug is a flag that determines whether the plugin should run
 	// with debug logging or not.
@@ -62,7 +64,7 @@ type PluginConfig struct {
 // Validate validates that the PluginConfig has no configuration errors.
 func (config PluginConfig) Validate(multiErr *errors.MultiError) {
 	// A version must be specified and it must be of the correct format.
-	_, err := config.GetSchemeVersion()
+	_, err := config.GetVersion()
 	if err != nil {
 		// TODO -- using multiErr.Context["source"] assumes that all of the
 		// configs came from file. Need to see if there is a way to check
@@ -160,7 +162,6 @@ type DynamicRegistrationSettings struct {
 // Validate validates that the DynamicRegistrationSettings has no configuration errors.
 func (settings DynamicRegistrationSettings) Validate(multiErr *errors.MultiError) {
 	// nothing to validate here.
-	return
 }
 
 // LimiterSettings specifies configurations for a rate limiter on reads

--- a/sdk/config/plugin_test.go
+++ b/sdk/config/plugin_test.go
@@ -31,7 +31,7 @@ func TestPluginConfig_Validate_Ok(t *testing.T) {
 		{
 			desc: "PluginConfig has valid version and network",
 			config: PluginConfig{
-				ConfigVersion: ConfigVersion{Version: "1.0"},
+				SchemeVersion: SchemeVersion{Version: "1.0"},
 				Network: &NetworkSettings{
 					Type:    "tcp",
 					Address: "10.10.10.10",
@@ -41,7 +41,7 @@ func TestPluginConfig_Validate_Ok(t *testing.T) {
 		{
 			desc: "PluginConfig has valid version and network, invalid settings (not validated here)",
 			config: PluginConfig{
-				ConfigVersion: ConfigVersion{Version: "1.0"},
+				SchemeVersion: SchemeVersion{Version: "1.0"},
 				Network: &NetworkSettings{
 					Type:    "tcp",
 					Address: "10.10.10.10",
@@ -72,7 +72,7 @@ func TestPluginConfig_Validate_Error(t *testing.T) {
 			desc:     "PluginConfig has invalid version",
 			errCount: 1,
 			config: PluginConfig{
-				ConfigVersion: ConfigVersion{Version: "abc"},
+				SchemeVersion: SchemeVersion{Version: "abc"},
 				Network: &NetworkSettings{
 					Type:    "tcp",
 					Address: "10.10.10.10",
@@ -83,7 +83,7 @@ func TestPluginConfig_Validate_Error(t *testing.T) {
 			desc:     "PluginConfig has no network",
 			errCount: 1,
 			config: PluginConfig{
-				ConfigVersion: ConfigVersion{Version: "1.0"},
+				SchemeVersion: SchemeVersion{Version: "1.0"},
 			},
 		},
 		{

--- a/sdk/config/plugin_test.go
+++ b/sdk/config/plugin_test.go
@@ -7,6 +7,21 @@ import (
 	"github.com/vapor-ware/synse-sdk/sdk/errors"
 )
 
+// TestNewDefaultPluginConfig tests getting a default plugin config.
+func TestNewDefaultPluginConfig(t *testing.T) {
+	cfg, err := NewDefaultPluginConfig()
+	assert.NoError(t, err)
+	assert.NotNil(t, cfg)
+
+	assert.Equal(t, false, cfg.Debug)
+	assert.NotNil(t, cfg.Settings, "settings should not be nil")
+	assert.NotNil(t, cfg.Network, "network should not be nil")
+	assert.NotNil(t, cfg.DynamicRegistration, "dynamic registration should not be nil")
+	assert.NotNil(t, cfg.Context, "context should not be nil")
+
+	assert.Nil(t, cfg.Limiter, "limiter should be nil")
+}
+
 // TestPluginConfig_Validate_Ok tests validating a PluginConfig with no errors.
 func TestPluginConfig_Validate_Ok(t *testing.T) {
 	var testTable = []struct {
@@ -541,4 +556,13 @@ func TestTransactionSettings_Validate_Error(t *testing.T) {
 		assert.Error(t, merr.Err(), testCase.desc)
 		assert.Equal(t, testCase.errCount, len(merr.Errors), merr.Error())
 	}
+}
+
+// TestDynamicRegistrationSettings_Validate tests validating a DynamicRegistrationSetting.
+// Validation should always pass here.
+func TestDynamicRegistrationSettings_Validate(t *testing.T) {
+	merr := errors.NewMultiError("test")
+	config := DynamicRegistrationSettings{}
+	config.Validate(merr)
+	assert.NoError(t, merr.Err())
 }

--- a/sdk/config/reader.go
+++ b/sdk/config/reader.go
@@ -38,8 +38,8 @@ var (
 //
 // All ConfigContexts returned by this function will have their IsOutputTypeConfig
 // function return true.
-func GetOutputTypeConfigsFromFile() ([]*ConfigContext, error) {
-	var cfgs []*ConfigContext
+func GetOutputTypeConfigsFromFile() ([]*Context, error) {
+	var cfgs []*Context
 
 	// Search for output type config files. No name is specified as an arg here because
 	// output type config files do not require any particular name.
@@ -66,8 +66,8 @@ func GetOutputTypeConfigsFromFile() ([]*ConfigContext, error) {
 //
 // All ConfigContexts returned by this function will have their IsDeviceConfig
 // function return true.
-func GetDeviceConfigsFromFile() ([]*ConfigContext, error) {
-	var cfgs []*ConfigContext
+func GetDeviceConfigsFromFile() ([]*Context, error) {
+	var cfgs []*Context
 
 	// Search for device config files. No name is specified as an arg here because
 	// device config files do not require any particular name.
@@ -95,7 +95,7 @@ func GetDeviceConfigsFromFile() ([]*ConfigContext, error) {
 //
 // The ConfigContext returned by this function will have its IsPluginConfig
 // function return true.
-func GetPluginConfigFromFile() (*ConfigContext, error) {
+func GetPluginConfigFromFile() (*Context, error) {
 	// Search for the plugin config file. It should have the name "config".
 	files, err := findConfigs(pluginConfigSearchPaths, EnvPluginConfig, pluginConfigFileName)
 	if err != nil {

--- a/sdk/config/type.go
+++ b/sdk/config/type.go
@@ -11,8 +11,8 @@ import (
 // OutputType provides information about the output of a device reading.
 type OutputType struct {
 
-	// ConfigVersion is the version of the configuration scheme.
-	ConfigVersion `yaml:",inline"`
+	// SchemeVersion is the version of the configuration scheme.
+	SchemeVersion `yaml:",inline"`
 
 	// Name is the name of the output type. Each reading type
 	// should have a unique name. Names can be namespaced with
@@ -77,7 +77,7 @@ func (outputType *OutputType) GetScalingFactor() (float64, error) {
 // Precision is not applied at this level, but will instead be applied
 // in Synse Server before the corresponding reading is returned to the
 // user.
-func (outputType *OutputType) Apply(value interface{}) interface{} {
+func (outputType *OutputType) Apply(value interface{}) interface{} { // nolint: gocyclo
 	scalingFactor, err := outputType.GetScalingFactor()
 	if err != nil {
 		return value
@@ -127,7 +127,6 @@ type Unit struct {
 // Validate validates that the Unit has no configuration errors.
 func (unit Unit) Validate(multiErr *errors.MultiError) {
 	// nothing to validate here -- neither are required.
-	return
 }
 
 // Encode translates the SDK Unit type to the corresponding gRPC Unit type.

--- a/sdk/config/type.go
+++ b/sdk/config/type.go
@@ -64,6 +64,9 @@ func (outputType *OutputType) Type() string {
 
 // GetScalingFactor gets the scaling factor for the reading type.
 func (outputType *OutputType) GetScalingFactor() (float64, error) {
+	if outputType.ScalingFactor == "" {
+		return 1, nil
+	}
 	return strconv.ParseFloat(outputType.ScalingFactor, 64)
 }
 

--- a/sdk/config/type_test.go
+++ b/sdk/config/type_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/vapor-ware/synse-sdk/sdk/errors"
+	"github.com/vapor-ware/synse-server-grpc/go"
 )
 
 // TestOutputType_Type tests getting the type of the reading
@@ -30,5 +32,504 @@ func TestOutputType_Type(t *testing.T) {
 	for _, tc := range testTable {
 		readingType := OutputType{Name: tc.name}
 		assert.Equal(t, tc.expected, readingType.Type())
+	}
+}
+
+// TestOutputType_Validate_Ok tests validating the OutputType when there are no errors.
+func TestOutputType_Validate_Ok(t *testing.T) {
+	var testTable = []struct {
+		desc   string
+		output OutputType
+	}{
+		{
+			desc: "Valid OutputType instance",
+			output: OutputType{
+				Name: "test",
+			},
+		},
+	}
+
+	for _, testCase := range testTable {
+		merr := errors.NewMultiError("test")
+
+		testCase.output.Validate(merr)
+		assert.NoError(t, merr.Err(), testCase.desc)
+	}
+}
+
+// TestOutputType_Validate_Error tests validating the OutputType when there are errors.
+func TestOutputType_Validate_Error(t *testing.T) {
+	var testTable = []struct {
+		desc     string
+		errCount int
+		output   OutputType
+	}{
+		{
+			desc:     "OutputType requires name, but has none",
+			errCount: 1,
+			output:   OutputType{},
+		},
+		{
+			desc:     "OutputType has an invalid scaling factor",
+			errCount: 1,
+			output: OutputType{
+				Name:          "test",
+				ScalingFactor: "invalid factor",
+			},
+		},
+		{
+			desc:     "OutputType has an invalid scaling factor and no name",
+			errCount: 2,
+			output: OutputType{
+				ScalingFactor: "invalid factor",
+			},
+		},
+	}
+
+	for _, testCase := range testTable {
+		merr := errors.NewMultiError("test")
+
+		testCase.output.Validate(merr)
+		assert.Error(t, merr.Err(), testCase.desc)
+		assert.Equal(t, testCase.errCount, len(merr.Errors), merr.Error())
+	}
+}
+
+// TestOutputType_GetScalingFactor_Ok tests getting the scaling factor from the OutputType successfully.
+func TestOutputType_GetScalingFactor_Ok(t *testing.T) {
+	var testTable = []struct {
+		desc     string
+		output   OutputType
+		expected float64
+	}{
+		{
+			desc:     "no scaling factor set, get default",
+			output:   OutputType{},
+			expected: 1,
+		},
+		{
+			desc: "scaling factor is positive integer",
+			output: OutputType{
+				ScalingFactor: "2",
+			},
+			expected: 2,
+		},
+		{
+			desc: "scaling factor is positive integer with sign",
+			output: OutputType{
+				ScalingFactor: "+2",
+			},
+			expected: 2,
+		},
+		{
+			desc: "scaling factor is negative integer",
+			output: OutputType{
+				ScalingFactor: "-2",
+			},
+			expected: -2,
+		},
+		{
+			desc: "scaling factor is positive float",
+			output: OutputType{
+				ScalingFactor: "2.4",
+			},
+			expected: 2.4,
+		},
+		{
+			desc: "scaling factor is positive float with sign",
+			output: OutputType{
+				ScalingFactor: "+2.4",
+			},
+			expected: 2.4,
+		},
+		{
+			desc: "scaling factor is negative float",
+			output: OutputType{
+				ScalingFactor: "-2.4",
+			},
+			expected: -2.4,
+		},
+		{
+			desc: "scaling factor is float with positive exp",
+			output: OutputType{
+				ScalingFactor: "2.4e2",
+			},
+			expected: 240,
+		},
+		{
+			desc: "scaling factor is float with negative exp",
+			output: OutputType{
+				ScalingFactor: "2.4e-2",
+			},
+			expected: 0.024,
+		},
+		{
+			desc: "scaling factor is negative int with positive exp",
+			output: OutputType{
+				ScalingFactor: "-3E2",
+			},
+			expected: -300,
+		},
+		{
+			desc: "scaling factor is negative int with negative exp",
+			output: OutputType{
+				ScalingFactor: "-3e-3",
+			},
+			expected: -0.003,
+		},
+		{
+			desc: "scaling factor is decimal with no leading zero",
+			output: OutputType{
+				ScalingFactor: ".3e2",
+			},
+			expected: 30,
+		},
+		{
+			desc: "scaling factor is decimal with no leading zero and sign",
+			output: OutputType{
+				ScalingFactor: "+.3e2",
+			},
+			expected: 30,
+		},
+	}
+
+	for _, testCase := range testTable {
+		sf, err := testCase.output.GetScalingFactor()
+		assert.NoError(t, err, testCase.desc)
+		assert.Equal(t, testCase.expected, sf, testCase.desc)
+
+	}
+}
+
+// TestOutputType_GetScalingFactor_Error tests getting the scaling factor from the OutputType successfully.
+func TestOutputType_GetScalingFactor_Error(t *testing.T) {
+	var testTable = []struct {
+		desc   string
+		output OutputType
+	}{
+		{
+			desc: "invalid format",
+			output: OutputType{
+				ScalingFactor: "+ 0.0 E 3",
+			},
+		},
+		{
+			desc: "invalid string",
+			output: OutputType{
+				ScalingFactor: "foobar",
+			},
+		},
+		{
+			desc: "additional decimal",
+			output: OutputType{
+				ScalingFactor: "+0.124.2e4",
+			},
+		},
+	}
+
+	for _, testCase := range testTable {
+		sf, err := testCase.output.GetScalingFactor()
+		assert.Error(t, err, testCase.desc)
+		assert.Zero(t, sf, testCase.desc)
+	}
+}
+
+// TestOutputType_Apply tests applying the output transformations to the output value.
+func TestOutputType_Apply(t *testing.T) {
+	var testTable = []struct {
+		desc     string
+		output   OutputType
+		value    interface{}
+		expected interface{}
+	}{
+		{
+			desc: "multiply factor by value 0",
+			output: OutputType{
+				ScalingFactor: "3",
+			},
+			value:    0,
+			expected: 0,
+		},
+		{
+			desc: "multiply factor by value 1",
+			output: OutputType{
+				ScalingFactor: "3",
+			},
+			value:    1,
+			expected: 3,
+		},
+		{
+			desc: "multiply value by 0.5 factor",
+			output: OutputType{
+				ScalingFactor: "0.5",
+			},
+			value:    float64(1),
+			expected: 0.5,
+		},
+		{
+			desc: "value is a float64, factor is > 1",
+			output: OutputType{
+				ScalingFactor: "2",
+			},
+			value:    float64(3),
+			expected: float64(6),
+		},
+		{
+			desc: "value is a float64, factor is < 1",
+			output: OutputType{
+				ScalingFactor: "0.5",
+			},
+			value:    float64(3),
+			expected: float64(1.5),
+		},
+		{
+			desc: "value is a float32, factor is > 1",
+			output: OutputType{
+				ScalingFactor: "2",
+			},
+			value:    float32(3),
+			expected: float32(6),
+		},
+		{
+			desc: "value is a float32, factor is < 1",
+			output: OutputType{
+				ScalingFactor: "0.5",
+			},
+			value:    float32(3),
+			expected: float32(1.5),
+		},
+		{
+			desc: "value is a int64, factor is > 1",
+			output: OutputType{
+				ScalingFactor: "2",
+			},
+			value:    int64(3),
+			expected: int64(6),
+		},
+		{
+			desc: "value is a int64, factor is < 1",
+			output: OutputType{
+				ScalingFactor: "0.5",
+			},
+			value:    int64(3),
+			expected: int64(1),
+		},
+		{
+			desc: "value is a int32, factor is > 1",
+			output: OutputType{
+				ScalingFactor: "2",
+			},
+			value:    int32(3),
+			expected: int32(6),
+		},
+		{
+			desc: "value is a int32, factor is < 1",
+			output: OutputType{
+				ScalingFactor: "0.5",
+			},
+			value:    int32(3),
+			expected: int32(1),
+		},
+		{
+			desc: "value is a int16, factor is > 1",
+			output: OutputType{
+				ScalingFactor: "2",
+			},
+			value:    int16(3),
+			expected: int16(6),
+		},
+		{
+			desc: "value is a int16, factor is < 1",
+			output: OutputType{
+				ScalingFactor: "0.5",
+			},
+			value:    int16(3),
+			expected: int16(1),
+		},
+		{
+			desc: "value is a int8, factor is > 1",
+			output: OutputType{
+				ScalingFactor: "2",
+			},
+			value:    int8(3),
+			expected: int8(6),
+		},
+		{
+			desc: "value is a int8, factor is < 1",
+			output: OutputType{
+				ScalingFactor: "0.5",
+			},
+			value:    int8(3),
+			expected: int8(1),
+		},
+		{
+			desc: "value is a int, factor is > 1",
+			output: OutputType{
+				ScalingFactor: "2",
+			},
+			value:    int(3),
+			expected: int(6),
+		},
+		{
+			desc: "value is a int, factor is < 1",
+			output: OutputType{
+				ScalingFactor: "0.5",
+			},
+			value:    int(3),
+			expected: int(1),
+		},
+		{
+			desc: "value is a uint64, factor is > 1",
+			output: OutputType{
+				ScalingFactor: "2",
+			},
+			value:    uint64(3),
+			expected: uint64(6),
+		},
+		{
+			desc: "value is a uint64, factor is < 1",
+			output: OutputType{
+				ScalingFactor: "0.5",
+			},
+			value:    uint64(3),
+			expected: uint64(1),
+		},
+		{
+			desc: "value is a uint32, factor is > 1",
+			output: OutputType{
+				ScalingFactor: "2",
+			},
+			value:    uint32(3),
+			expected: uint32(6),
+		},
+		{
+			desc: "value is a uint32, factor is < 1",
+			output: OutputType{
+				ScalingFactor: "0.5",
+			},
+			value:    uint32(3),
+			expected: uint32(1),
+		},
+		{
+			desc: "value is a uint16, factor is > 1",
+			output: OutputType{
+				ScalingFactor: "2",
+			},
+			value:    uint32(3),
+			expected: uint32(6),
+		},
+		{
+			desc: "value is a uint16, factor is < 1",
+			output: OutputType{
+				ScalingFactor: "0.5",
+			},
+			value:    uint16(3),
+			expected: uint16(1),
+		},
+		{
+			desc: "value is a uint8, factor is > 1",
+			output: OutputType{
+				ScalingFactor: "2",
+			},
+			value:    uint8(3),
+			expected: uint8(6),
+		},
+		{
+			desc: "value is a uint8, factor is < 1",
+			output: OutputType{
+				ScalingFactor: "0.5",
+			},
+			value:    uint8(3),
+			expected: uint8(1),
+		},
+		{
+			desc: "value is a uint, factor is > 1",
+			output: OutputType{
+				ScalingFactor: "2",
+			},
+			value:    uint(3),
+			expected: uint(6),
+		},
+		{
+			desc: "value is a uint, factor is < 1",
+			output: OutputType{
+				ScalingFactor: "0.5",
+			},
+			value:    uint(3),
+			expected: uint(1),
+		},
+	}
+
+	for _, testCase := range testTable {
+		actual := testCase.output.Apply(testCase.value)
+		assert.Equal(t, testCase.expected, actual, testCase.desc)
+	}
+}
+
+// TestOutputType_Apply_Error tests applying when the scaling factor is invalid.
+func TestOutputType_Apply_Error(t *testing.T) {
+	output := OutputType{
+		ScalingFactor: "foobar",
+	}
+	actual := output.Apply(2)
+	assert.Equal(t, 2, actual, "on parse failure, nothing changes")
+}
+
+// TestUnit_Validate tests validating the Unit. There is nothing to validate here,
+// so it should all validate successfully.
+func TestUnit_Validate(t *testing.T) {
+	merr := errors.NewMultiError("test")
+	unit := Unit{}
+	unit.Validate(merr)
+	assert.NoError(t, merr.Err())
+}
+
+// TestUnit_Encode tests encoding the Unit to the gRPC message.
+func TestUnit_Encode(t *testing.T) {
+	var testTable = []struct {
+		desc    string
+		unit    Unit
+		message synse.Unit
+	}{
+		{
+			desc:    "empty unit",
+			unit:    Unit{},
+			message: synse.Unit{},
+		},
+		{
+			desc: "name and symbol specified",
+			unit: Unit{
+				Name:   "foo",
+				Symbol: "bar",
+			},
+			message: synse.Unit{
+				Name:   "foo",
+				Symbol: "bar",
+			},
+		},
+		{
+			desc: "only name specified",
+			unit: Unit{
+				Name: "foo",
+			},
+			message: synse.Unit{
+				Name: "foo",
+			},
+		},
+		{
+			desc: "only symbol specified",
+			unit: Unit{
+				Symbol: "bar",
+			},
+			message: synse.Unit{
+				Symbol: "bar",
+			},
+		},
+	}
+
+	for _, testCase := range testTable {
+		actual := testCase.unit.Encode()
+		assert.Equal(t, testCase.unit.Name, actual.GetName())
+		assert.Equal(t, testCase.unit.Symbol, actual.GetSymbol())
 	}
 }

--- a/sdk/config/unification.go
+++ b/sdk/config/unification.go
@@ -9,7 +9,7 @@ import (
 //
 // If any of the ConfigContexts given as a parameter do not represent a
 // DeviceConfig, an error is returned.
-func UnifyDeviceConfigs(ctxs []*ConfigContext) (*ConfigContext, error) {
+func UnifyDeviceConfigs(ctxs []*Context) (*Context, error) {
 
 	// FIXME (etd): figure out how to either:
 	//  i. merge the source info into the ConfigContext
@@ -21,7 +21,7 @@ func UnifyDeviceConfigs(ctxs []*ConfigContext) (*ConfigContext, error) {
 		return nil, fmt.Errorf("no ConfigContexts specified for unification")
 	}
 
-	var context *ConfigContext
+	var context *Context
 
 	for _, ctx := range ctxs {
 		if !ctx.IsDeviceConfig() {

--- a/sdk/config/unification_test.go
+++ b/sdk/config/unification_test.go
@@ -9,7 +9,7 @@ import (
 // TestUnifyDeviceConfigs_NoConfigs tests unifying configs when no
 // configs are given.
 func TestUnifyDeviceConfigs_NoConfigs(t *testing.T) {
-	ctx, err := UnifyDeviceConfigs([]*ConfigContext{})
+	ctx, err := UnifyDeviceConfigs([]*Context{})
 	assert.Error(t, err)
 	assert.Nil(t, ctx)
 }
@@ -17,7 +17,7 @@ func TestUnifyDeviceConfigs_NoConfigs(t *testing.T) {
 // TestUnifyDeviceConfigs_NoDeviceConfig tests unifying configs when the
 // contexts specified do not contain DeviceConfigs.
 func TestUnifyDeviceConfigs_NoDeviceConfig(t *testing.T) {
-	ctx, err := UnifyDeviceConfigs([]*ConfigContext{
+	ctx, err := UnifyDeviceConfigs([]*Context{
 		{
 			Source: "test",
 			Config: &PluginConfig{},
@@ -31,11 +31,11 @@ func TestUnifyDeviceConfigs_NoDeviceConfig(t *testing.T) {
 // TestUnifyDeviceConfigs tests unifying configs when there is only one config
 // to unify.
 func TestUnifyDeviceConfigs(t *testing.T) {
-	ctx, err := UnifyDeviceConfigs([]*ConfigContext{
+	ctx, err := UnifyDeviceConfigs([]*Context{
 		{
 			Source: "test",
 			Config: &DeviceConfig{
-				ConfigVersion: ConfigVersion{Version: "1.0"},
+				SchemeVersion: SchemeVersion{Version: "1.0"},
 				Locations: []*Location{
 					{
 						Name:  "test",
@@ -60,11 +60,11 @@ func TestUnifyDeviceConfigs(t *testing.T) {
 // TestUnifyDeviceConfigs2 tests unifying configs when there are multiple
 // configs to unify.
 func TestUnifyDeviceConfigs2(t *testing.T) {
-	ctx, err := UnifyDeviceConfigs([]*ConfigContext{
+	ctx, err := UnifyDeviceConfigs([]*Context{
 		{
 			Source: "test",
 			Config: &DeviceConfig{
-				ConfigVersion: ConfigVersion{Version: "1.0"},
+				SchemeVersion: SchemeVersion{Version: "1.0"},
 				Locations: []*Location{
 					{
 						Name:  "loc-1",
@@ -80,7 +80,7 @@ func TestUnifyDeviceConfigs2(t *testing.T) {
 		{
 			Source: "test",
 			Config: &DeviceConfig{
-				ConfigVersion: ConfigVersion{Version: "1.0"},
+				SchemeVersion: SchemeVersion{Version: "1.0"},
 				Locations: []*Location{
 					{
 						Name:  "loc-2",
@@ -101,7 +101,7 @@ func TestUnifyDeviceConfigs2(t *testing.T) {
 		{
 			Source: "test",
 			Config: &DeviceConfig{
-				ConfigVersion: ConfigVersion{Version: "1.0"},
+				SchemeVersion: SchemeVersion{Version: "1.0"},
 				Locations: []*Location{
 					{
 						Name:  "loc-4",

--- a/sdk/config/unification_test.go
+++ b/sdk/config/unification_test.go
@@ -1,1 +1,125 @@
 package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestUnifyDeviceConfigs_NoConfigs tests unifying configs when no
+// configs are given.
+func TestUnifyDeviceConfigs_NoConfigs(t *testing.T) {
+	ctx, err := UnifyDeviceConfigs([]*ConfigContext{})
+	assert.Error(t, err)
+	assert.Nil(t, ctx)
+}
+
+// TestUnifyDeviceConfigs_NoDeviceConfig tests unifying configs when the
+// contexts specified do not contain DeviceConfigs.
+func TestUnifyDeviceConfigs_NoDeviceConfig(t *testing.T) {
+	ctx, err := UnifyDeviceConfigs([]*ConfigContext{
+		{
+			Source: "test",
+			Config: &PluginConfig{},
+		},
+	})
+
+	assert.Error(t, err)
+	assert.Nil(t, ctx)
+}
+
+// TestUnifyDeviceConfigs tests unifying configs when there is only one config
+// to unify.
+func TestUnifyDeviceConfigs(t *testing.T) {
+	ctx, err := UnifyDeviceConfigs([]*ConfigContext{
+		{
+			Source: "test",
+			Config: &DeviceConfig{
+				ConfigVersion: ConfigVersion{Version: "1.0"},
+				Locations: []*Location{
+					{
+						Name:  "test",
+						Rack:  &LocationData{Name: "rack"},
+						Board: &LocationData{Name: "board"},
+					},
+				},
+				Devices: []*DeviceKind{
+					{Name: "test-device"},
+				},
+			},
+		},
+	})
+
+	assert.NoError(t, err)
+	assert.True(t, ctx.IsDeviceConfig())
+	cfg := ctx.Config.(*DeviceConfig)
+	assert.Equal(t, 1, len(cfg.Devices))
+	assert.Equal(t, 1, len(cfg.Locations))
+}
+
+// TestUnifyDeviceConfigs2 tests unifying configs when there are multiple
+// configs to unify.
+func TestUnifyDeviceConfigs2(t *testing.T) {
+	ctx, err := UnifyDeviceConfigs([]*ConfigContext{
+		{
+			Source: "test",
+			Config: &DeviceConfig{
+				ConfigVersion: ConfigVersion{Version: "1.0"},
+				Locations: []*Location{
+					{
+						Name:  "loc-1",
+						Rack:  &LocationData{Name: "rack"},
+						Board: &LocationData{Name: "board"},
+					},
+				},
+				Devices: []*DeviceKind{
+					{Name: "test-device-1"},
+				},
+			},
+		},
+		{
+			Source: "test",
+			Config: &DeviceConfig{
+				ConfigVersion: ConfigVersion{Version: "1.0"},
+				Locations: []*Location{
+					{
+						Name:  "loc-2",
+						Rack:  &LocationData{Name: "rack"},
+						Board: &LocationData{Name: "board"},
+					},
+					{
+						Name:  "loc-3",
+						Rack:  &LocationData{Name: "rack"},
+						Board: &LocationData{Name: "board"},
+					},
+				},
+				Devices: []*DeviceKind{
+					{Name: "test-device-2"},
+				},
+			},
+		},
+		{
+			Source: "test",
+			Config: &DeviceConfig{
+				ConfigVersion: ConfigVersion{Version: "1.0"},
+				Locations: []*Location{
+					{
+						Name:  "loc-4",
+						Rack:  &LocationData{Name: "rack"},
+						Board: &LocationData{Name: "board"},
+					},
+				},
+				Devices: []*DeviceKind{
+					{Name: "test-device-3"},
+					{Name: "test-device-4"},
+				},
+			},
+		},
+	})
+
+	assert.NoError(t, err)
+	assert.True(t, ctx.IsDeviceConfig())
+	cfg := ctx.Config.(*DeviceConfig)
+	assert.Equal(t, 4, len(cfg.Devices))
+	assert.Equal(t, 4, len(cfg.Locations))
+}

--- a/sdk/config/validation_test.go
+++ b/sdk/config/validation_test.go
@@ -15,7 +15,7 @@ import (
 // and ConfigComponent interface. It is used to test simple validation
 // cases.
 type simpleTestConfig struct {
-	ConfigVersion
+	SchemeVersion
 
 	TestField string `addedIn:"1.0" deprecatedIn:"1.5" removedIn:"2.0"`
 
@@ -25,7 +25,7 @@ type simpleTestConfig struct {
 }
 
 func (config simpleTestConfig) Validate(multiErr *errors.MultiError) {
-	_, err := config.GetSchemeVersion()
+	_, err := config.GetVersion()
 	if err != nil {
 		multiErr.Add(errors.NewValidationError(multiErr.Context["source"], err.Error()))
 	}
@@ -39,7 +39,7 @@ func (config simpleTestConfig) Validate(multiErr *errors.MultiError) {
 // and ConfigComponent interface. It is used to test complex validation
 // cases where there are nested and grouped components.
 type complexTestConfig struct {
-	ConfigVersion
+	SchemeVersion
 
 	Foo      bool               `addedIn:"1.0" removedIn:"1.5"`
 	Simples  []simpleTestConfig `addedIn:"1.5"`
@@ -52,7 +52,7 @@ type complexTestConfig struct {
 }
 
 func (config complexTestConfig) Validate(multiErr *errors.MultiError) {
-	_, err := config.GetSchemeVersion()
+	_, err := config.GetVersion()
 	if err != nil {
 		multiErr.Add(errors.NewValidationError(multiErr.Context["source"], err.Error()))
 	}
@@ -96,10 +96,10 @@ func checkValidationCleanup(t *testing.T) {
 
 // TestSchemeValidator_Validate_Simple_Ok tests validating a simple struct where everything is ok.
 func TestSchemeValidator_Validate_Simple_Ok(t *testing.T) {
-	toValidate := &ConfigContext{
+	toValidate := &Context{
 		Source: "<simple test config>",
 		Config: &simpleTestConfig{
-			ConfigVersion: ConfigVersion{Version: "1.0"},
+			SchemeVersion: SchemeVersion{Version: "1.0"},
 			TestField:     "foo",
 		},
 	}
@@ -112,12 +112,12 @@ func TestSchemeValidator_Validate_Simple_Ok(t *testing.T) {
 }
 
 // TestSchemeValidator_Validate_Simple_UnsupportedVersion tests validating a simple struct where
-// the ConfigVersion of the struct is less than that of a specified field.
+// the SchemeVersion of the struct is less than that of a specified field.
 func TestSchemeValidator_Validate_Simple_UnsupportedVersion(t *testing.T) {
-	toValidate := &ConfigContext{
+	toValidate := &Context{
 		Source: "<simple test config>",
 		Config: &simpleTestConfig{
-			ConfigVersion: ConfigVersion{Version: "0.5"}, // config version less than addedIn tag for both fields
+			SchemeVersion: SchemeVersion{Version: "0.5"}, // config version less than addedIn tag for both fields
 			TestField:     "foo",
 		},
 	}
@@ -131,12 +131,12 @@ func TestSchemeValidator_Validate_Simple_UnsupportedVersion(t *testing.T) {
 }
 
 // TestSchemeValidator_Validate_Simple_DeprecatedVersion1 tests validating a simple struct where
-// the ConfigVersion of the struct is equal to the deprecatedIn tag of a field.
+// the SchemeVersion of the struct is equal to the deprecatedIn tag of a field.
 func TestSchemeValidator_Validate_Simple_DeprecatedVersion1(t *testing.T) {
-	toValidate := &ConfigContext{
+	toValidate := &Context{
 		Source: "<simple test config>",
 		Config: &simpleTestConfig{
-			ConfigVersion: ConfigVersion{Version: "1.5"}, // equal to deprecatedIn tag for TestField
+			SchemeVersion: SchemeVersion{Version: "1.5"}, // equal to deprecatedIn tag for TestField
 			TestField:     "foo",
 		},
 	}
@@ -149,12 +149,12 @@ func TestSchemeValidator_Validate_Simple_DeprecatedVersion1(t *testing.T) {
 }
 
 // TestSchemeValidator_Validate_Simple_DeprecatedVersion2 tests validating a simple struct where
-// the ConfigVersion of the struct is greater than the deprecatedIn tag of a field.
+// the SchemeVersion of the struct is greater than the deprecatedIn tag of a field.
 func TestSchemeValidator_Validate_Simple_DeprecatedVersion2(t *testing.T) {
-	toValidate := &ConfigContext{
+	toValidate := &Context{
 		Source: "<simple test config>",
 		Config: &simpleTestConfig{
-			ConfigVersion: ConfigVersion{Version: "1.8"}, // greater than deprecatedIn tag for TestField
+			SchemeVersion: SchemeVersion{Version: "1.8"}, // greater than deprecatedIn tag for TestField
 			TestField:     "foo",
 		},
 	}
@@ -167,12 +167,12 @@ func TestSchemeValidator_Validate_Simple_DeprecatedVersion2(t *testing.T) {
 }
 
 // TestSchemeValidator_Validate_Simple_RemovedVersion1 tests validating a simple struct where
-// the ConfigVersion of the struct is equal to the removedIn tag of a field.
+// the SchemeVersion of the struct is equal to the removedIn tag of a field.
 func TestSchemeValidator_Validate_Simple_RemovedVersion1(t *testing.T) {
-	toValidate := &ConfigContext{
+	toValidate := &Context{
 		Source: "<simple test config>",
 		Config: &simpleTestConfig{
-			ConfigVersion: ConfigVersion{Version: "2.0"}, // equal to removedIn tag for TestField
+			SchemeVersion: SchemeVersion{Version: "2.0"}, // equal to removedIn tag for TestField
 			TestField:     "foo",
 		},
 	}
@@ -186,12 +186,12 @@ func TestSchemeValidator_Validate_Simple_RemovedVersion1(t *testing.T) {
 }
 
 // TestSchemeValidator_Validate_Simple_RemovedVersion2 tests validating a simple struct where
-// the ConfigVersion of the struct is greater than the removedIn tag of a field.
+// the SchemeVersion of the struct is greater than the removedIn tag of a field.
 func TestSchemeValidator_Validate_Simple_RemovedVersion2(t *testing.T) {
-	toValidate := &ConfigContext{
+	toValidate := &Context{
 		Source: "<simple test config>",
 		Config: &simpleTestConfig{
-			ConfigVersion: ConfigVersion{Version: "2.1"}, // greater than removedIn tag for TestField
+			SchemeVersion: SchemeVersion{Version: "2.1"}, // greater than removedIn tag for TestField
 			TestField:     "foo",
 		},
 	}
@@ -207,10 +207,10 @@ func TestSchemeValidator_Validate_Simple_RemovedVersion2(t *testing.T) {
 // TestSchemeValidator_Validate_Error tests validating a simple struct where
 // the versions resolve, but the Validate function fails for one field.
 func TestSchemeValidator_Validate_Error(t *testing.T) {
-	toValidate := &ConfigContext{
+	toValidate := &Context{
 		Source: "<simple test config>",
 		Config: &simpleTestConfig{
-			ConfigVersion: ConfigVersion{Version: "1.0"},
+			SchemeVersion: SchemeVersion{Version: "1.0"},
 			TestField:     "", // TestField required, will fail Validate()
 		},
 	}
@@ -229,10 +229,10 @@ func TestSchemeValidator_Validate_Error(t *testing.T) {
 // of bounds of the version. If a field is not set, we won't validate its version,
 // so it should only result in one of those errors being captured.
 func TestSchemeValidator_Validate_Error2(t *testing.T) {
-	toValidate := &ConfigContext{
+	toValidate := &Context{
 		Source: "<simple test config>",
 		Config: &simpleTestConfig{
-			ConfigVersion: ConfigVersion{Version: "3.0"},
+			SchemeVersion: SchemeVersion{Version: "3.0"},
 			TestField:     "", // TestField required, will fail Validate()
 		},
 	}
@@ -246,12 +246,12 @@ func TestSchemeValidator_Validate_Error2(t *testing.T) {
 }
 
 // TestSchemeValidator_Validate_Simple_BadConfigScheme tests validating a simple struct where
-// the ConfigVersion specified a bad scheme version.
+// the SchemeVersion specified a bad scheme version.
 func TestSchemeValidator_Validate_Simple_BadConfigScheme(t *testing.T) {
-	toValidate := &ConfigContext{
+	toValidate := &Context{
 		Source: "<simple test config>",
 		Config: &simpleTestConfig{
-			ConfigVersion: ConfigVersion{Version: "xyz.xyz"}, // bad scheme version
+			SchemeVersion: SchemeVersion{Version: "xyz.xyz"}, // bad scheme version
 			TestField:     "foo",
 		},
 	}
@@ -267,10 +267,10 @@ func TestSchemeValidator_Validate_Simple_BadConfigScheme(t *testing.T) {
 // TestSchemeValidator_Validate_Simple_BadAddedInTag tests validating a simple struct where
 // a field specifies a bad "addedIn" tag.
 func TestSchemeValidator_Validate_Simple_BadAddedInTag(t *testing.T) {
-	toValidate := &ConfigContext{
+	toValidate := &Context{
 		Source: "<simple test config>",
 		Config: &simpleTestConfig{
-			ConfigVersion: ConfigVersion{Version: "1.0"},
+			SchemeVersion: SchemeVersion{Version: "1.0"},
 			TestField:     "foo",
 			BadAddedInTag: "bar", // this field has a bad addedIn tag in the struct definition
 		},
@@ -287,10 +287,10 @@ func TestSchemeValidator_Validate_Simple_BadAddedInTag(t *testing.T) {
 // TestSchemeValidator_Validate_Simple_BadDeprecatedInTag tests validating a simple struct where
 // a field specifies a bad "deprecatedIn" tag.
 func TestSchemeValidator_Validate_Simple_BadDeprecatedInTag(t *testing.T) {
-	toValidate := &ConfigContext{
+	toValidate := &Context{
 		Source: "<simple test config>",
 		Config: &simpleTestConfig{
-			ConfigVersion:      ConfigVersion{Version: "1.0"},
+			SchemeVersion:      SchemeVersion{Version: "1.0"},
 			TestField:          "foo",
 			BadDeprecatedInTag: "bar", // this field has a bad deprecatedIn tag in the struct definition
 		},
@@ -307,10 +307,10 @@ func TestSchemeValidator_Validate_Simple_BadDeprecatedInTag(t *testing.T) {
 // TestSchemeValidator_Validate_Simple_BadRemovedInTag tests validating a simple struct where
 // a field specifies a bad "removedIn" tag.
 func TestSchemeValidator_Validate_Simple_BadRemovedInTag(t *testing.T) {
-	toValidate := &ConfigContext{
+	toValidate := &Context{
 		Source: "<simple test config>",
 		Config: &simpleTestConfig{
-			ConfigVersion:   ConfigVersion{Version: "1.0"},
+			SchemeVersion:   SchemeVersion{Version: "1.0"},
 			TestField:       "foo",
 			BadRemovedInTag: "bar", // this field has a bad removedIn tag in the struct definition
 		},
@@ -348,10 +348,10 @@ func TestSchemeValidator_validate(t *testing.T) {
 
 // TestSchemeValidator_Validate_Complex_Ok tests validating a complex struct where everything is ok.
 func TestSchemeValidator_Validate_Complex_Ok(t *testing.T) {
-	toValidate := &ConfigContext{
+	toValidate := &Context{
 		Source: "<complex test config>",
 		Config: &complexTestConfig{
-			ConfigVersion: ConfigVersion{Version: "1.0"},
+			SchemeVersion: SchemeVersion{Version: "1.0"},
 			Foo:           true,
 			FloatVal:      20,
 			IntVal:        3,
@@ -373,10 +373,10 @@ func TestSchemeValidator_Validate_Complex_Ok(t *testing.T) {
 // TestSchemeValidator_Validate_Complex_Ok2 tests validating a complex struct where everything is ok,
 // but some values are specified as the zero value for that type.
 func TestSchemeValidator_Validate_Complex_Ok2(t *testing.T) {
-	toValidate := &ConfigContext{
+	toValidate := &Context{
 		Source: "<complex test config>",
 		Config: &complexTestConfig{
-			ConfigVersion: ConfigVersion{Version: "1.0"},
+			SchemeVersion: SchemeVersion{Version: "1.0"},
 			Foo:           false,
 			FloatVal:      0,
 			IntVal:        0,
@@ -399,13 +399,13 @@ func TestSchemeValidator_Validate_Complex_Ok2(t *testing.T) {
 // there are errors due to SchemeVersion mismatches. In this case, it is for fields
 // specified in a version before they are supported.
 func TestSchemeValidator_Validate_Complex_Error(t *testing.T) {
-	toValidate := &ConfigContext{
+	toValidate := &Context{
 		Source: "<complex test config>",
 		Config: &complexTestConfig{
-			ConfigVersion: ConfigVersion{Version: "1.0"},
+			SchemeVersion: SchemeVersion{Version: "1.0"},
 			Simples: []simpleTestConfig{
 				{
-					ConfigVersion: ConfigVersion{Version: "1.0"},
+					SchemeVersion: SchemeVersion{Version: "1.0"},
 					TestField:     "foo",
 				},
 			},
@@ -438,13 +438,13 @@ func TestSchemeValidator_Validate_Complex_Error(t *testing.T) {
 // there are errors due to SchemeVersion mismatches. In this case, it is for fields
 // specified in a version after they were removed.
 func TestSchemeValidator_Validate_Complex_Error2(t *testing.T) {
-	toValidate := &ConfigContext{
+	toValidate := &Context{
 		Source: "<complex test config>",
 		Config: &complexTestConfig{
-			ConfigVersion: ConfigVersion{Version: "3.0"},
+			SchemeVersion: SchemeVersion{Version: "3.0"},
 			Simples: []simpleTestConfig{
 				{
-					ConfigVersion: ConfigVersion{Version: "3.0"},
+					SchemeVersion: SchemeVersion{Version: "3.0"},
 					TestField:     "foo",
 				},
 			},
@@ -477,13 +477,13 @@ func TestSchemeValidator_Validate_Complex_Error2(t *testing.T) {
 // there are errors due to SchemeVersion mismatches. In this case, it is for ConfigComponent
 // validation errors.
 func TestSchemeValidator_Validate_Complex_Error3(t *testing.T) {
-	toValidate := &ConfigContext{
+	toValidate := &Context{
 		Source: "<complex test config>",
 		Config: &complexTestConfig{
-			ConfigVersion: ConfigVersion{Version: "1.5"},
+			SchemeVersion: SchemeVersion{Version: "1.5"},
 			Simples: []simpleTestConfig{
 				{
-					ConfigVersion: ConfigVersion{Version: "1.0"},
+					SchemeVersion: SchemeVersion{Version: "1.0"},
 					TestField:     "", // error #1
 				},
 			},

--- a/sdk/config/versioning.go
+++ b/sdk/config/versioning.go
@@ -12,15 +12,15 @@ const (
 	tagRemovedIn    = "removedIn"
 )
 
-// SchemeVersion is a representation of a configuration scheme version
+// Version is a representation of a configuration scheme version
 // that can be compared to other SchemeVersions.
-type SchemeVersion struct {
+type Version struct {
 	Major int
 	Minor int
 }
 
-// NewSchemeVersion creates a new instance of a SchemeVersion.
-func NewSchemeVersion(versionString string) (*SchemeVersion, error) {
+// NewVersion creates a new instance of a Version.
+func NewVersion(versionString string) (*Version, error) {
 	var min, maj int
 	var err error
 
@@ -49,75 +49,75 @@ func NewSchemeVersion(versionString string) (*SchemeVersion, error) {
 		return nil, fmt.Errorf("too many version components - should only have MAJOR[.MINOR]")
 	}
 
-	return &SchemeVersion{
+	return &Version{
 		Major: maj,
 		Minor: min,
 	}, nil
 }
 
 // String returns a string representation of the scheme version.
-func (schemeVersion *SchemeVersion) String() string {
-	return fmt.Sprintf("%d.%d", schemeVersion.Major, schemeVersion.Minor)
+func (version *Version) String() string {
+	return fmt.Sprintf("%d.%d", version.Major, version.Minor)
 }
 
-// IsLessThan returns true if the SchemeVersion is less than the SchemeVersion
+// IsLessThan returns true if the Version is less than the Version
 // provided as a parameter.
-func (schemeVersion *SchemeVersion) IsLessThan(other *SchemeVersion) bool {
-	if schemeVersion.Major < other.Major {
+func (version *Version) IsLessThan(other *Version) bool {
+	if version.Major < other.Major {
 		return true
 	}
-	if schemeVersion.Major == other.Major && schemeVersion.Minor < other.Minor {
-		return true
-	}
-	return false
-}
-
-// IsGreaterOrEqualTo returns true if the SchemeVersion is greater than or equal to
-// the SchemeVersion provided as a parameter.
-func (schemeVersion *SchemeVersion) IsGreaterOrEqualTo(other *SchemeVersion) bool {
-	if schemeVersion.Major > other.Major {
-		return true
-	}
-	if schemeVersion.Major == other.Major && schemeVersion.Minor >= other.Minor {
+	if version.Major == other.Major && version.Minor < other.Minor {
 		return true
 	}
 	return false
 }
 
-// IsEqual returns true if the SchemeVersion is equal to the SchemeVersion provided
+// IsGreaterOrEqualTo returns true if the Version is greater than or equal to
+// the Version provided as a parameter.
+func (version *Version) IsGreaterOrEqualTo(other *Version) bool {
+	if version.Major > other.Major {
+		return true
+	}
+	if version.Major == other.Major && version.Minor >= other.Minor {
+		return true
+	}
+	return false
+}
+
+// IsEqual returns true if the Version is equal to the Version provided
 // as a parameter.
-func (schemeVersion *SchemeVersion) IsEqual(other *SchemeVersion) bool {
-	return schemeVersion.Major == other.Major && schemeVersion.Minor == other.Minor
+func (version *Version) IsEqual(other *Version) bool {
+	return version.Major == other.Major && version.Minor == other.Minor
 }
 
-// ConfigVersion is a struct that is used to extract the configuration
+// SchemeVersion is a struct that is used to extract the configuration
 // scheme version from any config file.
-type ConfigVersion struct {
+type SchemeVersion struct {
 	// Version is the config version scheme specified in the config file.
 	Version string `yaml:"version,omitempty" addedIn:"1.0"`
 
-	// scheme is the SchemeVersion that represents the ConfigVersion's Version.
-	scheme *SchemeVersion
+	// scheme is the Version that represents the SchemeVersion's Version.
+	scheme *Version
 }
 
-// parseScheme parses the Version field into a SchemeVersion.
-func (configVersion *ConfigVersion) parseScheme() error {
-	scheme, err := NewSchemeVersion(configVersion.Version)
+// parse parses the Version field into a Version.
+func (schemeVersion *SchemeVersion) parse() error {
+	scheme, err := NewVersion(schemeVersion.Version)
 	if err != nil {
 		return err
 	}
-	configVersion.scheme = scheme
+	schemeVersion.scheme = scheme
 	return nil
 }
 
-// GetSchemeVersion gets the SchemeVersion associated with the version specified
+// GetVersion gets the Version associated with the version specified
 // in the configuration.
-func (configVersion *ConfigVersion) GetSchemeVersion() (*SchemeVersion, error) {
-	if configVersion.scheme == nil {
-		err := configVersion.parseScheme()
+func (schemeVersion *SchemeVersion) GetVersion() (*Version, error) {
+	if schemeVersion.scheme == nil {
+		err := schemeVersion.parse()
 		if err != nil {
 			return nil, err
 		}
 	}
-	return configVersion.scheme, nil
+	return schemeVersion.scheme, nil
 }

--- a/sdk/config/versioning_test.go
+++ b/sdk/config/versioning_test.go
@@ -6,61 +6,61 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestNewSchemeVersion_Ok tests creating a new SchemeVersion with no errors.
+// TestNewSchemeVersion_Ok tests creating a new Version with no errors.
 func TestNewSchemeVersion_Ok(t *testing.T) {
 	var testTable = []struct {
 		desc     string
 		in       string
-		expected SchemeVersion
+		expected Version
 	}{
 		{
 			desc:     "Version with only major specified",
 			in:       "1",
-			expected: SchemeVersion{1, 0},
+			expected: Version{1, 0},
 		},
 		{
 			desc:     "Version with major and 0-valued minor",
 			in:       "1.0",
-			expected: SchemeVersion{1, 0},
+			expected: Version{1, 0},
 		},
 		{
 			desc:     "Version with 0-valued major and minor",
 			in:       "0.1",
-			expected: SchemeVersion{0, 1},
+			expected: Version{0, 1},
 		},
 		{
 			desc:     "Version with non-0 major and minor",
 			in:       "2.5",
-			expected: SchemeVersion{2, 5},
+			expected: Version{2, 5},
 		},
 		{
 			desc:     "Version with large major/minor",
 			in:       "12345.12345",
-			expected: SchemeVersion{12345, 12345},
+			expected: Version{12345, 12345},
 		},
 		{
 			desc:     "Version with double zero major",
 			in:       "00.1",
-			expected: SchemeVersion{0, 1},
+			expected: Version{0, 1},
 		},
 		{
 			desc:     "Version with double zero minor",
 			in:       "1.00",
-			expected: SchemeVersion{1, 0},
+			expected: Version{1, 0},
 		},
 	}
 
 	for _, testCase := range testTable {
-		sv, err := NewSchemeVersion(testCase.in)
+		sv, err := NewVersion(testCase.in)
 		assert.NoError(t, err, testCase.desc)
 		assert.NotNil(t, sv, testCase.desc)
-		assert.IsType(t, &SchemeVersion{}, sv, testCase.desc)
+		assert.IsType(t, &Version{}, sv, testCase.desc)
 		assert.Equal(t, testCase.expected.Major, sv.Major, testCase.desc)
 		assert.Equal(t, testCase.expected.Minor, sv.Minor, testCase.desc)
 	}
 }
 
-// TestNewSchemeVersion_Error tests creating a new SchemeVersion with errors.
+// TestNewSchemeVersion_Error tests creating a new Version with errors.
 func TestNewSchemeVersion_Error(t *testing.T) {
 	var testTable = []struct {
 		desc string
@@ -93,32 +93,32 @@ func TestNewSchemeVersion_Error(t *testing.T) {
 	}
 
 	for _, testCase := range testTable {
-		sv, err := NewSchemeVersion(testCase.in)
+		sv, err := NewVersion(testCase.in)
 		assert.Nil(t, sv, testCase.desc)
 		assert.Error(t, err, testCase.desc)
 	}
 }
 
-// TestSchemeVersion_String tests converting a SchemeVersion to a string
+// TestSchemeVersion_String tests converting a Version to a string
 func TestSchemeVersion_String(t *testing.T) {
 	var testTable = []struct {
-		scheme   SchemeVersion
+		scheme   Version
 		expected string
 	}{
 		{
-			scheme:   SchemeVersion{0, 1},
+			scheme:   Version{0, 1},
 			expected: "0.1",
 		},
 		{
-			scheme:   SchemeVersion{1, 0},
+			scheme:   Version{1, 0},
 			expected: "1.0",
 		},
 		{
-			scheme:   SchemeVersion{1, 1},
+			scheme:   Version{1, 1},
 			expected: "1.1",
 		},
 		{
-			scheme:   SchemeVersion{1234, 4321},
+			scheme:   Version{1234, 4321},
 			expected: "1234.4321",
 		},
 	}
@@ -132,33 +132,33 @@ func TestSchemeVersion_String(t *testing.T) {
 // TestSchemeVersion_IsEqual test equality of SchemeVersions
 func TestSchemeVersion_IsEqual(t *testing.T) {
 	var testTable = []struct {
-		scheme1 *SchemeVersion
-		scheme2 *SchemeVersion
+		scheme1 *Version
+		scheme2 *Version
 		equal   bool
 	}{
 		{
-			scheme1: &SchemeVersion{1, 0},
-			scheme2: &SchemeVersion{1, 0},
+			scheme1: &Version{1, 0},
+			scheme2: &Version{1, 0},
 			equal:   true,
 		},
 		{
-			scheme1: &SchemeVersion{0, 1},
-			scheme2: &SchemeVersion{0, 1},
+			scheme1: &Version{0, 1},
+			scheme2: &Version{0, 1},
 			equal:   true,
 		},
 		{
-			scheme1: &SchemeVersion{4, 51},
-			scheme2: &SchemeVersion{4, 51},
+			scheme1: &Version{4, 51},
+			scheme2: &Version{4, 51},
 			equal:   true,
 		},
 		{
-			scheme1: &SchemeVersion{1, 0},
-			scheme2: &SchemeVersion{2, 0},
+			scheme1: &Version{1, 0},
+			scheme2: &Version{2, 0},
 			equal:   false,
 		},
 		{
-			scheme1: &SchemeVersion{1, 1},
-			scheme2: &SchemeVersion{1, 2},
+			scheme1: &Version{1, 1},
+			scheme2: &Version{1, 2},
 			equal:   false,
 		},
 	}
@@ -169,41 +169,41 @@ func TestSchemeVersion_IsEqual(t *testing.T) {
 	}
 }
 
-// TestSchemeVersion_IsLessThan tests if one SchemeVersion is less than another
+// TestSchemeVersion_IsLessThan tests if one Version is less than another
 func TestSchemeVersion_IsLessThan(t *testing.T) {
 	var testTable = []struct {
-		scheme1  *SchemeVersion
-		scheme2  *SchemeVersion
+		scheme1  *Version
+		scheme2  *Version
 		lessThan bool
 	}{
 		{
-			scheme1:  &SchemeVersion{1, 0},
-			scheme2:  &SchemeVersion{1, 0},
+			scheme1:  &Version{1, 0},
+			scheme2:  &Version{1, 0},
 			lessThan: false,
 		},
 		{
-			scheme1:  &SchemeVersion{0, 1},
-			scheme2:  &SchemeVersion{0, 1},
+			scheme1:  &Version{0, 1},
+			scheme2:  &Version{0, 1},
 			lessThan: false,
 		},
 		{
-			scheme1:  &SchemeVersion{4, 51},
-			scheme2:  &SchemeVersion{4, 51},
+			scheme1:  &Version{4, 51},
+			scheme2:  &Version{4, 51},
 			lessThan: false,
 		},
 		{
-			scheme1:  &SchemeVersion{1, 0},
-			scheme2:  &SchemeVersion{2, 0},
+			scheme1:  &Version{1, 0},
+			scheme2:  &Version{2, 0},
 			lessThan: true,
 		},
 		{
-			scheme1:  &SchemeVersion{1, 1},
-			scheme2:  &SchemeVersion{1, 2},
+			scheme1:  &Version{1, 1},
+			scheme2:  &Version{1, 2},
 			lessThan: true,
 		},
 		{
-			scheme1:  &SchemeVersion{1, 2},
-			scheme2:  &SchemeVersion{1, 1},
+			scheme1:  &Version{1, 2},
+			scheme2:  &Version{1, 1},
 			lessThan: false,
 		},
 	}
@@ -214,47 +214,47 @@ func TestSchemeVersion_IsLessThan(t *testing.T) {
 	}
 }
 
-// TestSchemeVersion_IsGreaterOrEqualTo tests if one SchemeVersion is greater than
+// TestSchemeVersion_IsGreaterOrEqualTo tests if one Version is greater than
 // or qual to another
 func TestSchemeVersion_IsGreaterOrEqualTo(t *testing.T) {
 	var testTable = []struct {
-		scheme1 *SchemeVersion
-		scheme2 *SchemeVersion
+		scheme1 *Version
+		scheme2 *Version
 		gte     bool
 	}{
 		{
-			scheme1: &SchemeVersion{1, 0},
-			scheme2: &SchemeVersion{1, 0},
+			scheme1: &Version{1, 0},
+			scheme2: &Version{1, 0},
 			gte:     true,
 		},
 		{
-			scheme1: &SchemeVersion{0, 1},
-			scheme2: &SchemeVersion{0, 1},
+			scheme1: &Version{0, 1},
+			scheme2: &Version{0, 1},
 			gte:     true,
 		},
 		{
-			scheme1: &SchemeVersion{4, 51},
-			scheme2: &SchemeVersion{4, 51},
+			scheme1: &Version{4, 51},
+			scheme2: &Version{4, 51},
 			gte:     true,
 		},
 		{
-			scheme1: &SchemeVersion{1, 0},
-			scheme2: &SchemeVersion{2, 0},
+			scheme1: &Version{1, 0},
+			scheme2: &Version{2, 0},
 			gte:     false,
 		},
 		{
-			scheme1: &SchemeVersion{1, 1},
-			scheme2: &SchemeVersion{1, 2},
+			scheme1: &Version{1, 1},
+			scheme2: &Version{1, 2},
 			gte:     false,
 		},
 		{
-			scheme1: &SchemeVersion{1, 2},
-			scheme2: &SchemeVersion{1, 1},
+			scheme1: &Version{1, 2},
+			scheme2: &Version{1, 1},
 			gte:     true,
 		},
 		{
-			scheme1: &SchemeVersion{2, 1},
-			scheme2: &SchemeVersion{1, 2},
+			scheme1: &Version{2, 1},
+			scheme2: &Version{1, 2},
 			gte:     true,
 		},
 	}
@@ -265,60 +265,60 @@ func TestSchemeVersion_IsGreaterOrEqualTo(t *testing.T) {
 	}
 }
 
-// TestConfigVersion_GetSchemeVersion_Ok tests getting the scheme version from a ConfigVersion
+// TestConfigVersion_GetSchemeVersion_Ok tests getting the scheme version from a SchemeVersion
 func TestConfigVersion_GetSchemeVersion_Ok(t *testing.T) {
 	var testTable = []struct {
 		desc    string
 		version string
-		scheme  SchemeVersion
+		scheme  Version
 	}{
 		{
 			desc:    "Version with only major specified",
 			version: "1",
-			scheme:  SchemeVersion{1, 0},
+			scheme:  Version{1, 0},
 		},
 		{
 			desc:    "Version with major and 0-valued minor",
 			version: "1.0",
-			scheme:  SchemeVersion{1, 0},
+			scheme:  Version{1, 0},
 		},
 		{
 			desc:    "Version with 0-valued major and minor",
 			version: "0.1",
-			scheme:  SchemeVersion{0, 1},
+			scheme:  Version{0, 1},
 		},
 		{
 			desc:    "Version with non-0 major and minor",
 			version: "2.5",
-			scheme:  SchemeVersion{2, 5},
+			scheme:  Version{2, 5},
 		},
 		{
 			desc:    "Version with large major/minor",
 			version: "12345.12345",
-			scheme:  SchemeVersion{12345, 12345},
+			scheme:  Version{12345, 12345},
 		},
 		{
 			desc:    "Version with double zero major",
 			version: "00.1",
-			scheme:  SchemeVersion{0, 1},
+			scheme:  Version{0, 1},
 		},
 		{
 			desc:    "Version with double zero minor",
 			version: "1.00",
-			scheme:  SchemeVersion{1, 0},
+			scheme:  Version{1, 0},
 		},
 	}
 
 	for _, testCase := range testTable {
-		cfgVer := ConfigVersion{Version: testCase.version}
-		sv, err := cfgVer.GetSchemeVersion()
+		cfgVer := SchemeVersion{Version: testCase.version}
+		sv, err := cfgVer.GetVersion()
 		assert.NoError(t, err, testCase.desc)
 		assert.Equal(t, testCase.scheme.Major, sv.Major, testCase.desc)
 		assert.Equal(t, testCase.scheme.Minor, sv.Minor, testCase.desc)
 	}
 }
 
-// TestConfigVersion_GetSchemeVersion_Error tests getting the scheme version from a ConfigVersion
+// TestConfigVersion_GetSchemeVersion_Error tests getting the scheme version from a SchemeVersion
 // which results in error
 func TestConfigVersion_GetSchemeVersion_Error(t *testing.T) {
 	var testTable = []struct {
@@ -352,8 +352,8 @@ func TestConfigVersion_GetSchemeVersion_Error(t *testing.T) {
 	}
 
 	for _, testCase := range testTable {
-		cfgVer := ConfigVersion{Version: testCase.version}
-		sv, err := cfgVer.GetSchemeVersion()
+		cfgVer := SchemeVersion{Version: testCase.version}
+		sv, err := cfgVer.GetVersion()
 		assert.Error(t, err, testCase.desc)
 		assert.Nil(t, sv, testCase.desc)
 	}

--- a/sdk/context.go
+++ b/sdk/context.go
@@ -4,7 +4,7 @@ package sdk
 // including handler functions for customizable plugin functionality.
 var Context = newPluginContext()
 
-// pluginContext holds context information for the plugin. Having the context
+// PluginContext holds context information for the plugin. Having the context
 // global allows simpler access, without having to pass references to the plugin
 // through many of our functions.
 type PluginContext struct {

--- a/sdk/context_test.go
+++ b/sdk/context_test.go
@@ -1,1 +1,20 @@
 package sdk
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Test_newPluginContext tests creating a new instance of a plugin context.
+func Test_newPluginContext(t *testing.T) {
+	ctx := newPluginContext()
+
+	assert.NotNil(t, ctx)
+	assert.IsType(t, &PluginContext{}, ctx)
+
+	// Can't compare function pointers, so just make sure its not nil for noe
+	assert.NotNil(t, ctx.deviceIdentifier)
+	assert.NotNil(t, ctx.dynamicDeviceRegistrar)
+	assert.NotNil(t, ctx.dynamicDeviceConfigRegistrar)
+}

--- a/sdk/data_manager.go
+++ b/sdk/data_manager.go
@@ -97,7 +97,7 @@ func (manager *dataManager) setup() error {
 	if PluginConfig.Limiter != nil && PluginConfig.Limiter != (&config.LimiterSettings{}) {
 		manager.limiter = rate.NewLimiter(
 			rate.Limit(PluginConfig.Limiter.Rate),
-			int(PluginConfig.Limiter.Burst),
+			PluginConfig.Limiter.Burst,
 		)
 	}
 	return nil

--- a/sdk/data_manager.go
+++ b/sdk/data_manager.go
@@ -342,14 +342,14 @@ func (manager *dataManager) write(w *WriteContext) {
 		msg := "no device found with ID " + w.ID()
 		w.transaction.message = msg
 		logger.Error(msg)
-	}
-
-	data := decodeWriteData(w.data)
-	err := device.Write(data)
-	if err != nil {
-		w.transaction.setStateError()
-		w.transaction.message = err.Error()
-		logger.Errorf("failed to write to device %v: %v", w.device, err)
+	} else {
+		data := decodeWriteData(w.data)
+		err := device.Write(data)
+		if err != nil {
+			w.transaction.setStateError()
+			w.transaction.message = err.Error()
+			logger.Errorf("failed to write to device %v: %v", w.device, err)
+		}
 	}
 	w.transaction.setStatusDone()
 }

--- a/sdk/data_manager_test.go
+++ b/sdk/data_manager_test.go
@@ -1,13 +1,12 @@
 package sdk
 
-//"testing"
-//
-//"github.com/stretchr/testify/assert"
-//
-//"fmt"
-//
-//"github.com/vapor-ware/synse-sdk/sdk/config"
-//"golang.org/x/time/rate"
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vapor-ware/synse-sdk/sdk/config"
+)
 
 // DeviceID gets the unique identifiers out of the plugin-specific
 // configuration to be used in UID generation. Required to construct Handlers.
@@ -15,297 +14,310 @@ func DeviceID(data map[string]string) string {
 	return data["id"]
 }
 
-//
-//// TestNewDataManager tests creating a new dataManager instance successfully.
-//func TestNewDataManager(t *testing.T) {
-//	// Create handlers.
-//	h, err := NewHandlers(DeviceID, nil)
-//	assert.NoError(t, err)
-//
-//	c := config.PluginConfig{
-//		Version: "test",
-//		Network: config.NetworkSettings{
-//			Type:    "tcp",
-//			Address: "test",
-//		},
-//		Settings: config.Settings{
-//			Read:        config.ReadSettings{Buffer: 200},
-//			Write:       config.WriteSettings{Buffer: 200},
-//			Transaction: config.TransactionSettings{TTL: "2s"},
-//		},
-//	}
-//	p := Plugin{handlers: h}
-//	err = p.SetConfig(&c)
-//	assert.NoError(t, err)
-//
-//	d, err := newDataManager(&p)
-//	assert.NoError(t, err)
-//
-//	assert.Equal(t, 200, cap(d.writeChannel))
-//	assert.Equal(t, 200, cap(d.readChannel))
-//	assert.Equal(t, h, d.handlers)
-//}
-//
-//// TestNewDataManager2 tests creating a new dataManager instance successfully with
-//// a different configuration.
-//func TestNewDataManager2(t *testing.T) {
-//	// Create handlers.
-//	h, err := NewHandlers(DeviceID, nil)
-//	assert.NoError(t, err)
-//
-//	c := &config.PluginConfig{
-//		Version: "test",
-//		Network: config.NetworkSettings{
-//			Type:    "tcp",
-//			Address: "test",
-//		},
-//		Settings: config.Settings{
-//			Read:        config.ReadSettings{Buffer: 500},
-//			Write:       config.WriteSettings{Buffer: 500},
-//			Transaction: config.TransactionSettings{TTL: "2s"},
-//		},
-//	}
-//	p := Plugin{handlers: h}
-//	err = p.SetConfig(c)
-//	assert.NoError(t, err)
-//
-//	// Create the dataManager
-//	d, err := newDataManager(&p)
-//	assert.NoError(t, err)
-//
-//	assert.Equal(t, 500, cap(d.writeChannel))
-//	assert.Equal(t, 500, cap(d.readChannel))
-//	assert.Equal(t, h, d.handlers)
-//}
-//
-//// TestNewDataManager_NilPlugin tests creating a new dataManager instance, passing
-//// in a nil Plugin to the constructor.
-//func TestNewDataManager_NilPlugin(t *testing.T) {
-//	d, err := newDataManager(nil)
-//	assert.Nil(t, d)
-//	assert.Error(t, err)
-//}
-//
-//// TestNewDataManager_NilPluginHandlers tests creating a new dataManager instance,
-//// passing in a Plugin with nil handlers to the constructor.
-//func TestNewDataManager_NilPluginHandlers(t *testing.T) {
-//	p := Plugin{
-//		handlers: nil,
-//	}
-//
-//	d, err := newDataManager(&p)
-//	assert.Nil(t, d)
-//	assert.Error(t, err)
-//}
-//
-//// TestNewDataManager_NilPluginConfig tests creating a new dataManager instance,
-//// passing in a Plugin with nil config to the constructor.
-//func TestNewDataManager_NilPluginConfig(t *testing.T) {
-//	p := Plugin{
-//		handlers: &Handlers{DeviceID, nil},
-//	}
-//
-//	d, err := newDataManager(&p)
-//	assert.Nil(t, d)
-//	assert.Error(t, err)
-//}
-//
-//// TestDataManager_WritesEnabled tests that writes are enabled in the dataManager
-//// when they are enabled in the config.
-//func TestDataManager_WritesEnabled(t *testing.T) {
-//	// Create the plugin
-//	c := config.PluginConfig{
-//		Version: "test",
-//		Network: config.NetworkSettings{
-//			Type:    "tcp",
-//			Address: "test",
-//		},
-//		Settings: config.Settings{
-//			Read: config.ReadSettings{Buffer: 200},
-//			Write: config.WriteSettings{
-//				Enabled: true,
-//				Buffer:  200,
-//			},
-//			Transaction: config.TransactionSettings{TTL: "2s"},
-//		},
-//	}
-//	p := Plugin{
-//		Config:   &c,
-//		handlers: &Handlers{DeviceID, nil},
-//	}
-//
-//	// Create the dataManager
-//	d, err := newDataManager(&p)
-//	assert.NoError(t, err)
-//
-//	assert.True(t, d.writesEnabled())
-//}
-//
-//// TestDataManager_readNoLimiter tests reading a device when a limiter is
-//// not configured.
-//func TestDataManager_readOneOkNoLimiter(t *testing.T) {
-//	// Create the plugin
-//	p := Plugin{
-//		Config: &config.PluginConfig{
-//			Version: "test",
-//			Network: config.NetworkSettings{
-//				Type:    "tcp",
-//				Address: "test",
-//			},
-//			Settings: config.Settings{
-//				Read:        config.ReadSettings{Buffer: 200},
-//				Write:       config.WriteSettings{Buffer: 200},
-//				Transaction: config.TransactionSettings{TTL: "2s"},
-//			},
-//		},
-//		handlers: &Handlers{DeviceID, nil},
-//	}
-//
-//	// Create the device to read
-//	device := makeTestDevice()
-//	device.Handler = &DeviceHandler{
-//		Read: func(d *Device) ([]*Reading, error) {
-//			return []*Reading{NewReading("test", "ok")}, nil
-//		},
-//	}
-//
-//	// Create the dataManager
-//	d, err := newDataManager(&p)
-//	assert.NoError(t, err)
-//
-//	assert.Equal(t, 0, len(d.readChannel))
-//	d.readOne(device)
-//	assert.Equal(t, 1, len(d.readChannel))
-//
-//	reading := <-d.readChannel
-//	assert.Equal(t, 1, len(reading.Reading))
-//	assert.Equal(t, "test", reading.Reading[0].Type)
-//	assert.Equal(t, "ok", reading.Reading[0].Value)
-//}
-//
-//// TestDataManager_readOkWithLimiter tests reading a device when a limiter is
-//// configured.
-//func TestDataManager_readOneOkWithLimiter(t *testing.T) {
-//	// Create the plugin
-//	p := Plugin{
-//		Config: &config.PluginConfig{
-//			Version: "test",
-//			Network: config.NetworkSettings{
-//				Type:    "tcp",
-//				Address: "test",
-//			},
-//			Settings: config.Settings{
-//				Read:        config.ReadSettings{Buffer: 200},
-//				Write:       config.WriteSettings{Buffer: 200},
-//				Transaction: config.TransactionSettings{TTL: "2s"},
-//			},
-//			Limiter: rate.NewLimiter(200, 200),
-//		},
-//		handlers: &Handlers{DeviceID, nil},
-//	}
-//
-//	// Create the device to read
-//	device := makeTestDevice()
-//	device.Handler = &DeviceHandler{
-//		Read: func(d *Device) ([]*Reading, error) {
-//			return []*Reading{NewReading("test", "ok")}, nil
-//		},
-//	}
-//
-//	// Create the dataManager
-//	d, err := newDataManager(&p)
-//	assert.NoError(t, err)
-//
-//	assert.Equal(t, 0, len(d.readChannel))
-//	d.readOne(device)
-//	assert.Equal(t, 1, len(d.readChannel))
-//
-//	reading := <-d.readChannel
-//	assert.Equal(t, 1, len(reading.Reading))
-//	assert.Equal(t, "test", reading.Reading[0].Type)
-//	assert.Equal(t, "ok", reading.Reading[0].Value)
-//}
-//
-//// TestDataManager_readErr tests reading a device that results in error.
-//func TestDataManager_readOneErr(t *testing.T) {
-//	// Create the plugin
-//	p := Plugin{
-//		Config: &config.PluginConfig{
-//			Version: "test",
-//			Network: config.NetworkSettings{
-//				Type:    "tcp",
-//				Address: "test",
-//			},
-//			Settings: config.Settings{
-//				Read:        config.ReadSettings{Buffer: 200},
-//				Write:       config.WriteSettings{Buffer: 200},
-//				Transaction: config.TransactionSettings{TTL: "2s"},
-//			},
-//		},
-//		handlers: &Handlers{DeviceID, nil},
-//	}
-//
-//	// Create the device to read
-//	device := makeTestDevice()
-//	device.Handler = &DeviceHandler{
-//		Read: func(d *Device) ([]*Reading, error) {
-//			return nil, fmt.Errorf("test read error")
-//		},
-//	}
-//
-//	// Create the dataManager
-//	d, err := newDataManager(&p)
-//	assert.NoError(t, err)
-//
-//	assert.Equal(t, 0, len(d.readChannel))
-//	d.readOne(device)
-//	assert.Equal(t, 0, len(d.readChannel))
-//}
-//
-//// TestDataManager_serialReadSingle tests reading a single device serially.
-//func TestDataManager_serialReadSingle(t *testing.T) {
-//	// Create the plugin
-//	p := Plugin{
-//		Config: &config.PluginConfig{
-//			Version: "test",
-//			Network: config.NetworkSettings{
-//				Type:    "tcp",
-//				Address: "test",
-//			},
-//			Settings: config.Settings{
-//				Read:        config.ReadSettings{Buffer: 200},
-//				Write:       config.WriteSettings{Buffer: 200},
-//				Transaction: config.TransactionSettings{TTL: "2s"},
-//			},
-//		},
-//		handlers: &Handlers{DeviceID, nil},
-//	}
-//
-//	// Create the device to read
-//	device := makeTestDevice()
-//	device.Handler = &DeviceHandler{
-//		Read: func(d *Device) ([]*Reading, error) {
-//			return []*Reading{NewReading("test", "ok")}, nil
-//		},
-//	}
-//
-//	// Clear the global device map then add the device to it
-//	deviceMap = make(map[string]*Device)
-//	deviceMap["test-id-1"] = device
-//
-//	// Create the dataManager
-//	d, err := newDataManager(&p)
-//	assert.NoError(t, err)
-//
-//	assert.Equal(t, 0, len(d.readChannel))
-//	d.serialRead()
-//	assert.Equal(t, 1, len(d.readChannel))
-//
-//	reading := <-d.readChannel
-//	assert.Equal(t, 1, len(reading.Reading))
-//	assert.Equal(t, "test", reading.Reading[0].Type)
-//	assert.Equal(t, "ok", reading.Reading[0].Value)
-//}
+// TestNewDataManager tests creating a new dataManager instance successfully.
+func TestNewDataManager(t *testing.T) {
+	d := newDataManager()
+	assert.Nil(t, d.readChannel)
+	assert.Nil(t, d.writeChannel)
+	assert.Nil(t, d.limiter)
+	assert.NotNil(t, d.dataLock)
+	assert.NotNil(t, d.rwLock)
+	assert.Empty(t, d.readings)
+}
+
+// TestDataManager_WritesEnabled tests that writes are enabled in the dataManager
+// when they are enabled in the config.
+func TestDataManager_WritesEnabled(t *testing.T) {
+	PluginConfig = &config.PluginConfig{
+		ConfigVersion: config.ConfigVersion{Version: "test"},
+		Network: &config.NetworkSettings{
+			Type:    "tcp",
+			Address: "test",
+		},
+		Settings: &config.PluginSettings{
+			Read: &config.ReadSettings{
+				Buffer: 200,
+			},
+			Write: &config.WriteSettings{
+				Enabled: true,
+				Buffer:  200,
+			},
+			Transaction: &config.TransactionSettings{
+				TTL: "2s",
+			},
+		},
+	}
+	defer func() {
+		// reset the plugin config
+		PluginConfig = &config.PluginConfig{}
+	}()
+
+	assert.True(t, DataManager.writesEnabled())
+}
+
+// TestDataManager_readNoLimiter tests reading a device when a limiter is
+// not configured.
+func TestDataManager_readOneOkNoLimiter(t *testing.T) {
+	PluginConfig = &config.PluginConfig{
+		ConfigVersion: config.ConfigVersion{Version: "test"},
+		Network: &config.NetworkSettings{
+			Type:    "tcp",
+			Address: "test",
+		},
+		Settings: &config.PluginSettings{
+			Read:        &config.ReadSettings{Buffer: 200},
+			Write:       &config.WriteSettings{Buffer: 200},
+			Transaction: &config.TransactionSettings{TTL: "2s"},
+		},
+	}
+	defer func() {
+		// reset the plugin config
+		PluginConfig = &config.PluginConfig{}
+	}()
+
+	// Create the device to read
+	device := &Device{
+		Kind:     "test.state",
+		Location: &Location{Rack: "rack", Board: "board"},
+		Outputs: []*Output{
+			{
+				OutputType: config.OutputType{
+					Name: "foo",
+				},
+			},
+		},
+		Handler: &DeviceHandler{
+			Read: func(d *Device) ([]*Reading, error) {
+				return []*Reading{d.GetOutput("foo").MakeReading("ok")}, nil
+			},
+		},
+	}
+
+	d := newDataManager()
+	d.setup()
+
+	// Pass a reading in
+	assert.Equal(t, 0, len(d.readChannel))
+	d.readOne(device)
+	assert.Equal(t, 1, len(d.readChannel))
+
+	// Get the reading out
+	reading := <-d.readChannel
+	assert.Equal(t, 1, len(reading.Reading))
+	assert.Equal(t, "foo", reading.Reading[0].Type)
+	assert.Equal(t, "ok", reading.Reading[0].Value)
+}
+
+// TestDataManager_readOkWithLimiter tests reading a device when a limiter is
+// configured.
+func TestDataManager_readOneOkWithLimiter(t *testing.T) {
+	PluginConfig = &config.PluginConfig{
+		ConfigVersion: config.ConfigVersion{Version: "test"},
+		Network: &config.NetworkSettings{
+			Type:    "tcp",
+			Address: "test",
+		},
+		Settings: &config.PluginSettings{
+			Read:        &config.ReadSettings{Buffer: 200},
+			Write:       &config.WriteSettings{Buffer: 200},
+			Transaction: &config.TransactionSettings{TTL: "2s"},
+		},
+		Limiter: &config.LimiterSettings{Rate: 200, Burst: 200},
+	}
+	defer func() {
+		// reset the plugin config
+		PluginConfig = &config.PluginConfig{}
+	}()
+
+	// Create the device to read
+	device := &Device{
+		Kind:     "test.state",
+		Location: &Location{Rack: "rack", Board: "board"},
+		Outputs: []*Output{
+			{
+				OutputType: config.OutputType{
+					Name: "foo",
+				},
+			},
+		},
+		Handler: &DeviceHandler{
+			Read: func(d *Device) ([]*Reading, error) {
+				return []*Reading{d.GetOutput("foo").MakeReading("ok")}, nil
+			},
+		},
+	}
+
+	d := newDataManager()
+	d.setup()
+
+	// Pass a reading in
+	assert.Equal(t, 0, len(d.readChannel))
+	d.readOne(device)
+	assert.Equal(t, 1, len(d.readChannel))
+
+	// Get the reading out
+	reading := <-d.readChannel
+	assert.Equal(t, 1, len(reading.Reading))
+	assert.Equal(t, "foo", reading.Reading[0].Type)
+	assert.Equal(t, "ok", reading.Reading[0].Value)
+}
+
+// TestDataManager_readErr tests reading a device that results in error.
+func TestDataManager_readOneErr(t *testing.T) {
+	PluginConfig = &config.PluginConfig{
+		ConfigVersion: config.ConfigVersion{Version: "test"},
+		Network: &config.NetworkSettings{
+			Type:    "tcp",
+			Address: "test",
+		},
+		Settings: &config.PluginSettings{
+			Read:        &config.ReadSettings{Buffer: 200},
+			Write:       &config.WriteSettings{Buffer: 200},
+			Transaction: &config.TransactionSettings{TTL: "2s"},
+		},
+	}
+	defer func() {
+		// reset the plugin config
+		PluginConfig = &config.PluginConfig{}
+	}()
+
+	// Create the device to read
+	device := &Device{
+		Kind:     "test.state",
+		Location: &Location{Rack: "rack", Board: "board"},
+		Outputs: []*Output{
+			{
+				OutputType: config.OutputType{
+					Name: "foo",
+				},
+			},
+		},
+		Handler: &DeviceHandler{
+			Read: func(d *Device) ([]*Reading, error) {
+				return nil, fmt.Errorf("test read error")
+			},
+		},
+	}
+
+	d := newDataManager()
+	d.setup()
+
+	assert.Equal(t, 0, len(d.readChannel))
+	d.readOne(device)
+	assert.Equal(t, 0, len(d.readChannel))
+}
+
+// TestDataManager_serialReadSingle tests reading a single device serially.
+func TestDataManager_serialReadSingle(t *testing.T) {
+	PluginConfig = &config.PluginConfig{
+		ConfigVersion: config.ConfigVersion{Version: "test"},
+		Network: &config.NetworkSettings{
+			Type:    "tcp",
+			Address: "test",
+		},
+		Settings: &config.PluginSettings{
+			Read:        &config.ReadSettings{Buffer: 200},
+			Write:       &config.WriteSettings{Buffer: 200},
+			Transaction: &config.TransactionSettings{TTL: "2s"},
+		},
+	}
+	defer func() {
+		// reset the plugin config
+		PluginConfig = &config.PluginConfig{}
+	}()
+
+	// Create the device to read
+	device := &Device{
+		Kind:     "test.state",
+		Location: &Location{Rack: "rack", Board: "board"},
+		Outputs: []*Output{
+			{
+				OutputType: config.OutputType{
+					Name: "foo",
+				},
+			},
+		},
+		Handler: &DeviceHandler{
+			Read: func(d *Device) ([]*Reading, error) {
+				return []*Reading{d.GetOutput("foo").MakeReading("ok")}, nil
+			},
+		},
+	}
+
+	// Clear the global device map then add the device to it
+	deviceMap = make(map[string]*Device)
+	deviceMap["test-id-1"] = device
+
+	d := newDataManager()
+	d.setup()
+
+	// Pass a reading in
+	assert.Equal(t, 0, len(d.readChannel))
+	d.serialRead()
+	assert.Equal(t, 1, len(d.readChannel))
+
+	// Get the reading out
+	reading := <-d.readChannel
+	assert.Equal(t, 1, len(reading.Reading))
+	assert.Equal(t, "foo", reading.Reading[0].Type)
+	assert.Equal(t, "ok", reading.Reading[0].Value)
+}
+
+// TestDataManager_parallelReadSingle tests reading a single device in parallel.
+func TestDataManager_parallelReadSingle(t *testing.T) {
+	PluginConfig = &config.PluginConfig{
+		ConfigVersion: config.ConfigVersion{Version: "test"},
+		Network: &config.NetworkSettings{
+			Type:    "tcp",
+			Address: "test",
+		},
+		Settings: &config.PluginSettings{
+			Read:        &config.ReadSettings{Buffer: 200},
+			Write:       &config.WriteSettings{Buffer: 200},
+			Transaction: &config.TransactionSettings{TTL: "2s"},
+		},
+	}
+	defer func() {
+		// reset the plugin config
+		PluginConfig = &config.PluginConfig{}
+	}()
+
+	// Create the device to read
+	device := &Device{
+		Kind:     "test.state",
+		Location: &Location{Rack: "rack", Board: "board"},
+		Outputs: []*Output{
+			{
+				OutputType: config.OutputType{
+					Name: "foo",
+				},
+			},
+		},
+		Handler: &DeviceHandler{
+			Read: func(d *Device) ([]*Reading, error) {
+				return []*Reading{d.GetOutput("foo").MakeReading("ok")}, nil
+			},
+		},
+	}
+
+	// Clear the global device map then add the device to it
+	deviceMap = make(map[string]*Device)
+	deviceMap["test-id-1"] = device
+
+	d := newDataManager()
+	d.setup()
+
+	// Pass a reading in
+	assert.Equal(t, 0, len(d.readChannel))
+	d.parallelRead()
+	assert.Equal(t, 1, len(d.readChannel))
+
+	// Get the reading out
+	reading := <-d.readChannel
+	assert.Equal(t, 1, len(reading.Reading))
+	assert.Equal(t, "foo", reading.Reading[0].Type)
+	assert.Equal(t, "ok", reading.Reading[0].Value)
+}
 
 // FIXME - race condition, likely because the deviceMap is global and used by other tests..
 //// TestDataManager_serialReadMultiple tests reading multiple devices serially.
@@ -375,51 +387,6 @@ func DeviceID(data map[string]string) string {
 //		assert.Equal(t, "test", r.Type)
 //		assert.Equal(t, "ok", r.Value)
 //	}
-//}
-//
-//// TestDataManager_parallelReadSingle tests reading a single device in parallel.
-//func TestDataManager_parallelReadSingle(t *testing.T) {
-//	// Create the plugin
-//	p := Plugin{
-//		Config: &config.PluginConfig{
-//			Version: "test",
-//			Network: config.NetworkSettings{
-//				Type:    "tcp",
-//				Address: "test",
-//			},
-//			Settings: config.Settings{
-//				Read:        config.ReadSettings{Buffer: 200},
-//				Write:       config.WriteSettings{Buffer: 200},
-//				Transaction: config.TransactionSettings{TTL: "2s"},
-//			},
-//		},
-//		handlers: &Handlers{DeviceID, nil},
-//	}
-//
-//	// Create the device to read
-//	device := makeTestDevice()
-//	device.Handler = &DeviceHandler{
-//		Read: func(d *Device) ([]*Reading, error) {
-//			return []*Reading{NewReading("test", "ok")}, nil
-//		},
-//	}
-//
-//	// Clear the global device map then add the device to it
-//	deviceMap = make(map[string]*Device)
-//	deviceMap["test-id-1"] = device
-//
-//	// Create the dataManager
-//	d, err := newDataManager(&p)
-//	assert.NoError(t, err)
-//
-//	assert.Equal(t, 0, len(d.readChannel))
-//	d.parallelRead()
-//	assert.Equal(t, 1, len(d.readChannel))
-//
-//	reading := <-d.readChannel
-//	assert.Equal(t, 1, len(reading.Reading))
-//	assert.Equal(t, "test", reading.Reading[0].Type)
-//	assert.Equal(t, "ok", reading.Reading[0].Value)
 //}
 
 // FIXME - race condition, likely because the deviceMap is global and used by other tests..

--- a/sdk/data_manager_test.go
+++ b/sdk/data_manager_test.go
@@ -8,12 +8,6 @@ import (
 	"github.com/vapor-ware/synse-sdk/sdk/config"
 )
 
-// DeviceID gets the unique identifiers out of the plugin-specific
-// configuration to be used in UID generation. Required to construct Handlers.
-func DeviceID(data map[string]string) string {
-	return data["id"]
-}
-
 // TestNewDataManager tests creating a new dataManager instance successfully.
 func TestNewDataManager(t *testing.T) {
 	d := newDataManager()
@@ -29,7 +23,7 @@ func TestNewDataManager(t *testing.T) {
 // when they are enabled in the config.
 func TestDataManager_WritesEnabled(t *testing.T) {
 	PluginConfig = &config.PluginConfig{
-		ConfigVersion: config.ConfigVersion{Version: "test"},
+		SchemeVersion: config.SchemeVersion{Version: "test"},
 		Network: &config.NetworkSettings{
 			Type:    "tcp",
 			Address: "test",
@@ -59,7 +53,7 @@ func TestDataManager_WritesEnabled(t *testing.T) {
 // not configured.
 func TestDataManager_readOneOkNoLimiter(t *testing.T) {
 	PluginConfig = &config.PluginConfig{
-		ConfigVersion: config.ConfigVersion{Version: "test"},
+		SchemeVersion: config.SchemeVersion{Version: "test"},
 		Network: &config.NetworkSettings{
 			Type:    "tcp",
 			Address: "test",
@@ -94,7 +88,8 @@ func TestDataManager_readOneOkNoLimiter(t *testing.T) {
 	}
 
 	d := newDataManager()
-	d.setup()
+	err := d.setup()
+	assert.NoError(t, err)
 
 	// Pass a reading in
 	assert.Equal(t, 0, len(d.readChannel))
@@ -112,7 +107,7 @@ func TestDataManager_readOneOkNoLimiter(t *testing.T) {
 // configured.
 func TestDataManager_readOneOkWithLimiter(t *testing.T) {
 	PluginConfig = &config.PluginConfig{
-		ConfigVersion: config.ConfigVersion{Version: "test"},
+		SchemeVersion: config.SchemeVersion{Version: "test"},
 		Network: &config.NetworkSettings{
 			Type:    "tcp",
 			Address: "test",
@@ -148,7 +143,8 @@ func TestDataManager_readOneOkWithLimiter(t *testing.T) {
 	}
 
 	d := newDataManager()
-	d.setup()
+	err := d.setup()
+	assert.NoError(t, err)
 
 	// Pass a reading in
 	assert.Equal(t, 0, len(d.readChannel))
@@ -165,7 +161,7 @@ func TestDataManager_readOneOkWithLimiter(t *testing.T) {
 // TestDataManager_readErr tests reading a device that results in error.
 func TestDataManager_readOneErr(t *testing.T) {
 	PluginConfig = &config.PluginConfig{
-		ConfigVersion: config.ConfigVersion{Version: "test"},
+		SchemeVersion: config.SchemeVersion{Version: "test"},
 		Network: &config.NetworkSettings{
 			Type:    "tcp",
 			Address: "test",
@@ -200,7 +196,8 @@ func TestDataManager_readOneErr(t *testing.T) {
 	}
 
 	d := newDataManager()
-	d.setup()
+	err := d.setup()
+	assert.NoError(t, err)
 
 	assert.Equal(t, 0, len(d.readChannel))
 	d.readOne(device)
@@ -210,7 +207,7 @@ func TestDataManager_readOneErr(t *testing.T) {
 // TestDataManager_serialReadSingle tests reading a single device serially.
 func TestDataManager_serialReadSingle(t *testing.T) {
 	PluginConfig = &config.PluginConfig{
-		ConfigVersion: config.ConfigVersion{Version: "test"},
+		SchemeVersion: config.SchemeVersion{Version: "test"},
 		Network: &config.NetworkSettings{
 			Type:    "tcp",
 			Address: "test",
@@ -249,7 +246,8 @@ func TestDataManager_serialReadSingle(t *testing.T) {
 	deviceMap["test-id-1"] = device
 
 	d := newDataManager()
-	d.setup()
+	err := d.setup()
+	assert.NoError(t, err)
 
 	// Pass a reading in
 	assert.Equal(t, 0, len(d.readChannel))
@@ -266,7 +264,7 @@ func TestDataManager_serialReadSingle(t *testing.T) {
 // TestDataManager_parallelReadSingle tests reading a single device in parallel.
 func TestDataManager_parallelReadSingle(t *testing.T) {
 	PluginConfig = &config.PluginConfig{
-		ConfigVersion: config.ConfigVersion{Version: "test"},
+		SchemeVersion: config.SchemeVersion{Version: "test"},
 		Network: &config.NetworkSettings{
 			Type:    "tcp",
 			Address: "test",
@@ -305,7 +303,8 @@ func TestDataManager_parallelReadSingle(t *testing.T) {
 	deviceMap["test-id-1"] = device
 
 	d := newDataManager()
-	d.setup()
+	err := d.setup()
+	assert.NoError(t, err)
 
 	// Pass a reading in
 	assert.Equal(t, 0, len(d.readChannel))

--- a/sdk/data_manager_test.go
+++ b/sdk/data_manager_test.go
@@ -241,9 +241,8 @@ func TestDataManager_serialReadSingle(t *testing.T) {
 		},
 	}
 
-	// Clear the global device map then add the device to it
-	deviceMap = make(map[string]*Device)
 	deviceMap["test-id-1"] = device
+	defer delete(deviceMap, "test-id-1")
 
 	d := newDataManager()
 	err := d.setup()
@@ -299,8 +298,8 @@ func TestDataManager_parallelReadSingle(t *testing.T) {
 	}
 
 	// Clear the global device map then add the device to it
-	deviceMap = make(map[string]*Device)
 	deviceMap["test-id-1"] = device
+	defer delete(deviceMap, "test-id-1")
 
 	d := newDataManager()
 	err := d.setup()

--- a/sdk/defaults.go
+++ b/sdk/defaults.go
@@ -2,6 +2,7 @@ package sdk
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/vapor-ware/synse-sdk/sdk/config"
 )
@@ -13,13 +14,22 @@ import (
 // device data map. Non-string values in the map are cast to a string.
 func defaultDeviceIdentifier(data map[string]interface{}) string {
 	var identifier string
-	for _, value := range data {
+
+	// To ensure that we get the same identifier reliably, we want to make sure
+	// we append the components reliably, so we will sort the keys.
+	var keys []string
+	for k := range data {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
 		// Instead of implementing our own type checking and casting, just
 		// use Sprint. Note that this may be meaningless for complex types.
 		// TODO: write tests/check to see how this behaves with things like
 		//  maps/lists. I have a feeling that maps will not produce a deterministic
 		//  string because they are unordered, so we may need custom handling for that.
-		identifier += fmt.Sprint(value)
+		identifier += fmt.Sprint(data[key])
 	}
 	return identifier
 }
@@ -29,7 +39,7 @@ func defaultDeviceIdentifier(data map[string]interface{}) string {
 //
 // This implementation simply returns an empty slice. A plugin will not do any dynamic
 // registration by default.
-func defaultDynamicDeviceRegistration(data map[string]interface{}) ([]*Device, error) {
+func defaultDynamicDeviceRegistration(_ map[string]interface{}) ([]*Device, error) {
 	return []*Device{}, nil
 }
 
@@ -38,6 +48,6 @@ func defaultDynamicDeviceRegistration(data map[string]interface{}) ([]*Device, e
 //
 // This implementation simply returns an empty slice. A plugin will not do any dynamic
 // registration by default.
-func defaultDynamicDeviceConfigRegistration(data map[string]interface{}) ([]*config.DeviceConfig, error) {
+func defaultDynamicDeviceConfigRegistration(_ map[string]interface{}) ([]*config.DeviceConfig, error) {
 	return []*config.DeviceConfig{}, nil
 }

--- a/sdk/defaults_test.go
+++ b/sdk/defaults_test.go
@@ -1,1 +1,35 @@
 package sdk
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var testData = map[string]interface{}{
+	"foo":  "bar",
+	"baz":  1,
+	"bool": true,
+}
+
+// Test_defaultDeviceIdentifier tests the default device identifier functionality.
+func Test_defaultDeviceIdentifier(t *testing.T) {
+	idComponent := defaultDeviceIdentifier(testData)
+	assert.Equal(t, "1truebar", idComponent)
+}
+
+// Test_defaultDynamicDeviceRegistration tests the default dynamic device registration
+// functionality.
+func Test_defaultDynamicDeviceRegistration(t *testing.T) {
+	devices, err := defaultDynamicDeviceRegistration(testData)
+	assert.NoError(t, err)
+	assert.Empty(t, devices)
+}
+
+// Test_defaultDynamicDeviceConfigRegistration tests the default dynamic device config
+// functionality.
+func Test_defaultDynamicDeviceConfigRegistration(t *testing.T) {
+	cfgs, err := defaultDynamicDeviceConfigRegistration(testData)
+	assert.NoError(t, err)
+	assert.Empty(t, cfgs)
+}

--- a/sdk/devices.go
+++ b/sdk/devices.go
@@ -61,6 +61,16 @@ type DeviceHandler struct {
 	BulkRead func([]*Device) ([]*ReadContext, error)
 }
 
+// supportsBulkRead checks if the handler supports bulk reading for its Devices.
+//
+// If BulkRead is set for the device handler and Read is not, then the handler
+// supports bulk reading. If both BulkRead and Read are defined, bulk reading
+// will not be considered supported and the handler will default to individual
+// reads.
+func (deviceHandler *DeviceHandler) supportsBulkRead() bool {
+	return deviceHandler.Read == nil && deviceHandler.BulkRead != nil
+}
+
 // getDevicesForHandler gets a list of all the devices which use the DeviceHandler.
 func (deviceHandler *DeviceHandler) getDevicesForHandler() []*Device {
 	var devices []*Device
@@ -81,16 +91,6 @@ func getHandlerForDevice(handlerName string) (*DeviceHandler, error) {
 		}
 	}
 	return nil, fmt.Errorf("no handler found with name: %s", handlerName)
-}
-
-// supportsBulkRead checks if the handler supports bulk reading for its Devices.
-//
-// If BulkRead is set for the device handler and Read is not, then the handler
-// supports bulk reading. If both BulkRead and Read are defined, bulk reading
-// will not be considered supported and the handler will default to individual
-// reads.
-func (deviceHandler *DeviceHandler) supportsBulkRead() bool {
-	return deviceHandler.Read == nil && deviceHandler.BulkRead != nil
 }
 
 // Device is the internal model for a single device (physical or virtual) that
@@ -140,6 +140,17 @@ func (device *Device) GetType() string {
 		return nameSpace[len(nameSpace)-1]
 	}
 	return device.Kind
+}
+
+// GetOutput gets the named Output from the Device's output list. If the Output
+// is not found, nil is returned.
+func (device *Device) GetOutput(name string) *Output {
+	for _, output := range device.Outputs {
+		if output.Name == name {
+			return output
+		}
+	}
+	return nil
 }
 
 // makeDevices creates Device instances from a DeviceConfig. The DeviceConfig
@@ -278,17 +289,6 @@ func NewLocationFromConfig(config *config.Location) (*Location, error) {
 		Rack:  rack,
 		Board: board,
 	}, nil
-}
-
-// GetOutput gets the named Output from the Device's output list. If the Output
-// is not found, nil is returned.
-func (device *Device) GetOutput(name string) *Output {
-	for _, output := range device.Outputs {
-		if output.Name == name {
-			return output
-		}
-	}
-	return nil
 }
 
 // Output defines a single output that a device can support. It is the DeviceConfig's

--- a/sdk/devices.go
+++ b/sdk/devices.go
@@ -3,6 +3,8 @@ package sdk
 import (
 	"fmt"
 
+	"strings"
+
 	"github.com/vapor-ware/synse-sdk/sdk/config"
 	"github.com/vapor-ware/synse-sdk/sdk/errors"
 	"github.com/vapor-ware/synse-sdk/sdk/logger"
@@ -127,6 +129,17 @@ type Device struct {
 	// bulkRead is a flag that determines whether or not the device should be
 	// read in bulk, i.e. in a batch with other devices of the same kind.
 	bulkRead bool
+}
+
+// GetType gets the type of the device. The type of the device is the last
+// element in its Kind namespace. For example, with the Kind "foo.bar.temperature",
+// the type would be "temperature".
+func (device *Device) GetType() string {
+	if strings.Contains(device.Kind, ".") {
+		nameSpace := strings.Split(device.Kind, ".")
+		return nameSpace[len(nameSpace)-1]
+	}
+	return device.Kind
 }
 
 // makeDevices creates Device instances from a DeviceConfig. The DeviceConfig

--- a/sdk/devices.go
+++ b/sdk/devices.go
@@ -344,7 +344,7 @@ func (device *Device) Read() (*ReadContext, error) {
 			return nil, err
 		}
 
-		return NewReadContext(device, readings)
+		return NewReadContext(device, readings), nil
 	}
 	return nil, &errors.UnsupportedCommandError{}
 }

--- a/sdk/devices.go
+++ b/sdk/devices.go
@@ -156,6 +156,9 @@ func makeDevices(config *config.DeviceConfig) ([]*Device, error) {
 
 			// Get the outputs for the instance.
 			instanceOutputs, err := getInstanceOutputs(kind, instance)
+			if err != nil {
+				return nil, err
+			}
 
 			// Get the location
 			l, err := config.GetLocation(instance.Location)

--- a/sdk/devices_test.go
+++ b/sdk/devices_test.go
@@ -1,617 +1,1022 @@
 package sdk
 
-//
-//import (
-//	"fmt"
-//	"testing"
-//
-//	"github.com/stretchr/testify/assert"
-//
-//	"github.com/vapor-ware/synse-sdk/sdk/config"
-//)
+import (
+	"fmt"
+	"testing"
 
-//
-//// TestMakeDevices tests making devices where two instances match one prototype.
-//func TestMakeDevices(t *testing.T) {
-//	inst := []*config.DeviceConfig{&testDeviceConfig1, &testDeviceConfig2}
-//	proto := []*config.PrototypeConfig{&testPrototypeConfig1}
-//
-//	devices, err := makeDevices(inst, proto, &testPlugin)
-//	assert.NoError(t, err)
-//	assert.Equal(t, 2, len(devices))
-//}
-//
-//// TestMakeDevices2 tests making devices when no instances match the prototype.
-//func TestMakeDevices2(t *testing.T) {
-//	inst := []*config.DeviceConfig{&testDeviceConfig1, &testDeviceConfig2}
-//	proto := []*config.PrototypeConfig{&testPrototypeConfig2}
-//
-//	devices, err := makeDevices(inst, proto, &testPlugin)
-//	assert.NoError(t, err)
-//	assert.Equal(t, 0, len(devices))
-//}
-//
-//// TestMakeDevices3 tests making devices when one instance matches one of two prototypes.
-//func TestMakeDevices3(t *testing.T) {
-//	inst := []*config.DeviceConfig{&testDeviceConfig1}
-//	proto := []*config.PrototypeConfig{&testPrototypeConfig1, &testPrototypeConfig2}
-//
-//	devices, err := makeDevices(inst, proto, &testPlugin)
-//	assert.NoError(t, err)
-//	assert.Equal(t, 1, len(devices))
-//}
-//
-//// TestMakeDevices4 tests making devices when no prototypes exist for instances to
-//// match with.
-//func TestMakeDevices4(t *testing.T) {
-//	inst := []*config.DeviceConfig{&testDeviceConfig1, &testDeviceConfig2}
-//	var proto []*config.PrototypeConfig
-//
-//	devices, err := makeDevices(inst, proto, &testPlugin)
-//	assert.NoError(t, err)
-//	assert.Equal(t, 0, len(devices))
-//}
-//
-//// TestMakeDevices5 tests making devices when no instances exist for protocols to
-//// be matched with.
-//func TestMakeDevices5(t *testing.T) {
-//	var inst []*config.DeviceConfig
-//	proto := []*config.PrototypeConfig{&testPrototypeConfig1, &testPrototypeConfig2}
-//
-//	devices, err := makeDevices(inst, proto, &testPlugin)
-//	assert.NoError(t, err)
-//	assert.Equal(t, 0, len(devices))
-//}
-//
-//// TestMakeDevices6 tests making devices when the plugin is incorrectly configured
-//// (no device identifier handler), which should prohibit devices from being created.
-//func TestMakeDevices6(t *testing.T) {
-//	inst := []*config.DeviceConfig{&testDeviceConfig1, &testDeviceConfig2}
-//	proto := []*config.PrototypeConfig{&testPrototypeConfig1}
-//
-//	plugin := makeTestPlugin()
-//	plugin.handlers.DeviceIdentifier = nil
-//
-//	_, err := makeDevices(inst, proto, plugin)
-//	assert.Error(t, err)
-//}
-//
-//// TestMakeDevices7 tests making devices when the plugin is incorrectly configured
-//// (no device handlers), which should prohibit devices from being created.
-//func TestMakeDevices7(t *testing.T) {
-//	inst := []*config.DeviceConfig{&testDeviceConfig1, &testDeviceConfig2}
-//	proto := []*config.PrototypeConfig{&testPrototypeConfig1}
-//
-//	plugin := makeTestPlugin()
-//	plugin.deviceHandlers = []*DeviceHandler{}
-//
-//	_, err := makeDevices(inst, proto, plugin)
-//	assert.Error(t, err)
-//}
+	"github.com/stretchr/testify/assert"
 
-//
-//// testDeviceFields is a test helper function to check the Device
-//// fields against the specified prototype and device configs.
-//func testDeviceFields(t *testing.T, dev *Device, proto *config.PrototypeConfig, deviceConfig *config.DeviceConfig) {
-//	assert.Equal(t, proto.Type, dev.Type)
-//	assert.Equal(t, proto.Model, dev.Model)
-//	assert.Equal(t, proto.Manufacturer, dev.Manufacturer)
-//	assert.Equal(t, proto.Protocol, dev.Protocol)
-//
-//	assert.Equal(t, deviceConfig.Location, dev.Location)
-//
-//	assert.Equal(t, len(proto.Output), len(dev.Output))
-//	for i := 0; i < len(dev.Output); i++ {
-//		assert.Equal(t, proto.Output[i], dev.Output[i])
-//	}
-//
-//	assert.Equal(t, deviceConfig.Data, dev.Data)
-//	for k, v := range dev.Data {
-//		assert.Equal(t, deviceConfig.Data[k], v)
-//	}
-//}
-//
-//// TestDeviceFields tests that the Device instance fields match up with
-//// the expected configuration fields from which they should originate.
-//func TestDeviceFields(t *testing.T) {
-//	testDevice := makeTestDevice()
-//
-//	testDeviceFields(t, testDevice, testDevice.pconfig, testDevice.dconfig)
-//	assert.Equal(t, "664f6cfa51c9bef163682bd2a766613b", testDevice.ID())
-//	assert.Equal(t, "TestRack-TestBoard-664f6cfa51c9bef163682bd2a766613b", testDevice.GUID())
-//}
-//
-//// TestEncodeDevice tests encoding the SDK Device to the gRPC MetainfoResponse model.
-//func TestEncodeDevice(t *testing.T) {
-//	testDevice := makeTestDevice()
-//	encoded := testDevice.encode()
-//
-//	assert.Equal(t, testDevice.ID(), encoded.Uid)
-//	assert.Equal(t, testDevice.Type, encoded.Type)
-//	assert.Equal(t, testDevice.Model, encoded.Model)
-//	assert.Equal(t, testDevice.Manufacturer, encoded.Manufacturer)
-//	assert.Equal(t, testDevice.Protocol, encoded.Protocol)
-//	assert.Equal(t, "", encoded.Info)
-//	assert.Equal(t, "", encoded.Comment)
-//	assert.Equal(t, testDevice.Location.Rack, encoded.Location.Rack)
-//	assert.Equal(t, testDevice.Location.Board, encoded.Location.Board)
-//}
-//
-//// TestNewDevice tests creating a new device and validating its fields.
-//func TestNewDevice(t *testing.T) {
-//	// Create Handlers.
-//	handlers, err := NewHandlers(testDeviceIdentifier, nil)
-//	assert.NoError(t, err)
-//
-//	// Initialize Plugin with handlers.
-//	p := Plugin{
-//		handlers: handlers,
-//	}
-//
-//	protoConfig := makePrototypeConfig()
-//	deviceConfig := makeDeviceConfig()
-//
-//	d, err := NewDevice(protoConfig, deviceConfig, &testDeviceHandler, &p)
-//	assert.NoError(t, err)
-//
-//	testDeviceFields(t, d, protoConfig, deviceConfig)
-//	assert.Equal(t, &testDeviceHandler, d.Handler)
-//	assert.Equal(t, deviceConfig, d.dconfig)
-//	assert.Equal(t, protoConfig, d.pconfig)
-//}
-//
-//// TestNewDevice2 tests creating a new device and getting a error on validation
-//// of the device (invalid handlers).
-//func TestNewDevice2(t *testing.T) {
-//	p := Plugin{
-//		handlers: &Handlers{},
-//	}
-//
-//	protoConfig := makePrototypeConfig()
-//	deviceConfig := makeDeviceConfig()
-//
-//	_, err := NewDevice(protoConfig, deviceConfig, &testDeviceHandler, &p)
-//	assert.Error(t, err)
-//}
-//
-//// TestNewDevice3 tests creating a new device and getting an error on validation
-//// of the device (instance-protocol mismatch on type).
-//func TestNewDevice3(t *testing.T) {
-//	// Create handlers.
-//	handlers, err := NewHandlers(testDeviceIdentifier, nil)
-//	assert.NoError(t, err)
-//
-//	// Initialize plugin with handlers.
-//	p := Plugin{
-//		handlers: handlers,
-//	}
-//
-//	protoConfig := makePrototypeConfig()
-//	deviceConfig := makeDeviceConfig()
-//	deviceConfig.Type = "foo"
-//
-//	_, err = NewDevice(protoConfig, deviceConfig, &testDeviceHandler, &p)
-//	assert.Error(t, err)
-//}
-//
-//// TestNewDevice3 tests creating a new device and getting an error on validation
-//// of the device (instance-protocol mismatch on model).
-//func TestNewDevice4(t *testing.T) {
-//	// Create handlers.
-//	handlers, err := NewHandlers(testDeviceIdentifier, nil)
-//	assert.NoError(t, err)
-//
-//	// Initialize plugin with handlers.
-//	p := Plugin{
-//		handlers: handlers,
-//	}
-//
-//	protoConfig := makePrototypeConfig()
-//	deviceConfig := makeDeviceConfig()
-//	deviceConfig.Model = "foo"
-//
-//	_, err = NewDevice(protoConfig, deviceConfig, &testDeviceHandler, &p)
-//	assert.Error(t, err)
-//}
-//
-//// TestDeviceIsReadable tests whether a device is readable in the case
-//// when it is readable.
-//func TestDeviceIsReadable(t *testing.T) {
-//	device := Device{
-//		Handler: &DeviceHandler{
-//			Read: func(device *Device) ([]*Reading, error) {
-//				return []*Reading{}, nil
-//			},
-//		},
-//	}
-//
-//	readable := device.IsReadable()
-//	assert.True(t, readable)
-//}
-//
-//// TestDeviceIsNotReadable tests whether a device is readable in the case
-//// when it is not readable.
-//func TestDeviceIsNotReadable(t *testing.T) {
-//	device := Device{
-//		Handler: &DeviceHandler{},
-//	}
-//
-//	readable := device.IsReadable()
-//	assert.False(t, readable)
-//}
-//
-//// TestDeviceIsWritable tests whether a device is writable in the case
-//// when it is writable.
-//func TestDeviceIsWritable(t *testing.T) {
-//	device := Device{
-//		Handler: &DeviceHandler{
-//			Write: func(device *Device, data *WriteData) error {
-//				return nil
-//			},
-//		},
-//	}
-//
-//	writable := device.IsWritable()
-//	assert.True(t, writable)
-//}
-//
-//// TestDeviceIsNotWritable tests whether a device is writable in the case
-//// when it is not writable.
-//func TestDeviceIsNotWritable(t *testing.T) {
-//	device := Device{
-//		Handler: &DeviceHandler{},
-//	}
-//
-//	writable := device.IsWritable()
-//	assert.False(t, writable)
-//}
-//
-//// TestDeviceReadNotReadable tests reading from a device when it is not
-//// a readable device.
-//func TestDeviceReadNotReadable(t *testing.T) {
-//	device := makeTestDevice()
-//
-//	ctx, err := device.Read()
-//	assert.Nil(t, ctx)
-//	assert.Error(t, err)
-//	assert.IsType(t, &UnsupportedCommandError{}, err)
-//}
-//
-//// TestDeviceReadErr tests reading from a device when the device is readable,
-//// but reading from it will return an error.
-//func TestDeviceReadErr(t *testing.T) {
-//	device := makeTestDevice()
-//	device.Handler.Read = func(device *Device) ([]*Reading, error) {
-//		return nil, fmt.Errorf("test error")
-//	}
-//
-//	ctx, err := device.Read()
-//	assert.Nil(t, ctx)
-//	assert.Error(t, err)
-//	assert.Equal(t, "test error", err.Error())
-//}
-//
-//// TestDeviceReadErr2 tests reading from a device when the device is readable,
-//// but the device rack specification is invalid.
-//func TestDeviceReadErr2(t *testing.T) {
-//	device := makeTestDevice()
-//	device.Location = config.Location{
-//		Rack:  map[string]string{"invalid-key": "invalid-value"},
-//		Board: "TestBoard",
-//	}
-//	device.Handler.Read = func(device *Device) ([]*Reading, error) {
-//		return []*Reading{NewReading("test", "value")}, nil
-//	}
-//
-//	ctx, err := device.Read()
-//	assert.Nil(t, ctx)
-//	assert.Error(t, err)
-//}
-//
-//// TestDeviceReadOk tests reading from a device when the device is readable,
-//// and the device config is correct, so we get back a good reading.
-//func TestDeviceReadOk(t *testing.T) {
-//	device := makeTestDevice()
-//	device.Handler.Read = func(device *Device) ([]*Reading, error) {
-//		return []*Reading{NewReading("test", "value")}, nil
-//	}
-//
-//	ctx, err := device.Read()
-//
-//	assert.NotNil(t, ctx)
-//	assert.NoError(t, err)
-//	assert.Equal(t, device.Location.Rack, ctx.Rack)
-//	assert.Equal(t, device.Location.Board, ctx.Board)
-//	assert.Equal(t, device.ID(), ctx.Device)
-//	assert.Equal(t, 1, len(ctx.Reading))
-//	assert.Equal(t, "test", ctx.Reading[0].Type)
-//	assert.Equal(t, "value", ctx.Reading[0].Value)
-//}
-//
-//// TestDeviceWriteNotWritable tests writing to a device when it is not
-//// a writable device.
-//func TestDeviceWriteNotWritable(t *testing.T) {
-//	device := makeTestDevice()
-//
-//	err := device.Write(&WriteData{Action: "test"})
-//	assert.Error(t, err)
-//	assert.IsType(t, &UnsupportedCommandError{}, err)
-//}
-//
-//// TestDeviceWriteErr tests writing to a device when it is
-//// a writable device, but the write returns an error.
-//func TestDeviceWriteErr(t *testing.T) {
-//	device := makeTestDevice()
-//	device.Handler.Write = func(device *Device, data *WriteData) error {
-//		return fmt.Errorf("test error")
-//	}
-//
-//	err := device.Write(&WriteData{Action: "test"})
-//	assert.Error(t, err)
-//	assert.Equal(t, "test error", err.Error())
-//}
-//
-//// TestDeviceWriteOk tests writing to a device when it is
-//// a writable device.
-//func TestDeviceWriteOk(t *testing.T) {
-//	device := makeTestDevice()
-//	device.Handler.Write = func(device *Device, data *WriteData) error {
-//		return nil
-//	}
-//
-//	err := device.Write(&WriteData{Action: "test"})
-//	assert.NoError(t, err)
-//}
-//
-//// TestDevicesFromAutoEnum_noConfig tests dynamically registering devices
-//// when there is no config specified for auto-enumeration.
-//func TestDevicesFromAutoEnum_noConfig(t *testing.T) {
-//	// Create handlers.
-//	handlers, err := NewHandlers(testDeviceIdentifier, nil)
-//	assert.NoError(t, err)
-//
-//	// Initialize plugin with handlers.
-//	p := Plugin{
-//		Config:   &config.PluginConfig{},
-//		handlers: handlers,
-//	}
-//
-//	devices, err := devicesFromAutoEnum(&p)
-//	assert.NoError(t, err)
-//	assert.Equal(t, 0, len(devices))
-//}
-//
-//// TestDevicesFromAutoEnum_noHandler tests dynamically registering devices
-//// when there is config specified for auto-enumeration, but no enumeration handler.
-//func TestDevicesFromAutoEnum_noHandler(t *testing.T) {
-//	// Create handlers.
-//	handlers, err := NewHandlers(testDeviceIdentifier, nil)
-//	assert.NoError(t, err)
-//
-//	// Initialize plugin with handlers.
-//	p := Plugin{
-//		Config: &config.PluginConfig{
-//			AutoEnumerate: []map[string]interface{}{
-//				{
-//					"foo": "bar",
-//				},
-//			},
-//		},
-//		handlers: handlers,
-//	}
-//
-//	devices, err := devicesFromAutoEnum(&p)
-//	assert.Error(t, err)
-//	assert.Nil(t, devices)
-//}
-//
-//// TestDevicesFromAutoEnum_errHandler tests dynamically registering devices
-//// when there is config specified for auto-enumeration and the enumeration
-//// handler always returns an error.
-//func TestDevicesFromAutoEnum_errHandler(t *testing.T) {
-//	// Create handlers.
-//	handlers, err := NewHandlers(
-//		testDeviceIdentifier,
-//		func(i map[string]interface{}) ([]*config.DeviceConfig, error) {
-//			// returns an error always
-//			return nil, fmt.Errorf("enumerator error")
-//		},
-//	)
-//	assert.NoError(t, err)
-//
-//	// Initialize plugin with handlers.
-//	p := Plugin{
-//		Config: &config.PluginConfig{
-//			AutoEnumerate: []map[string]interface{}{
-//				{
-//					"foo": "bar",
-//				},
-//			},
-//		},
-//		handlers: handlers,
-//	}
-//
-//	devices, err := devicesFromAutoEnum(&p)
-//	assert.NoError(t, err)
-//	assert.Equal(t, 0, len(devices))
-//}
-//
-//// TestDevicesFromAutoEnum_errHandler tests dynamically registering devices
-//// when there are multiple configs specified for auto-enumeration and the
-//// enumeration handler always returns an error.
-//func TestDevicesFromAutoEnum_errHandler2(t *testing.T) {
-//	// Create handlers.
-//	handlers, err := NewHandlers(
-//		testDeviceIdentifier,
-//		func(i map[string]interface{}) ([]*config.DeviceConfig, error) {
-//			// returns an error always
-//			return nil, fmt.Errorf("enumerator error")
-//		},
-//	)
-//	assert.NoError(t, err)
-//
-//	// Initialize plugin with handlers.
-//	p := Plugin{
-//		Config: &config.PluginConfig{
-//			AutoEnumerate: []map[string]interface{}{
-//				{
-//					"foo": "bar",
-//				},
-//				{
-//					"bar": "baz",
-//				},
-//				{
-//					"baz": "foo",
-//				},
-//			},
-//		},
-//		handlers: handlers,
-//	}
-//
-//	devices, err := devicesFromAutoEnum(&p)
-//	assert.NoError(t, err)
-//	assert.Equal(t, 0, len(devices))
-//}
-//
-//// TestDevicesFromAutoEnum_okHandler tests dynamically registering devices
-//// when there is config specified for auto-enumeration and the enumeration
-//// handler returns successfully.
-//func TestDevicesFromAutoEnum_okHandler(t *testing.T) {
-//	// Create handlers.
-//	handlers, err := NewHandlers(
-//		testDeviceIdentifier,
-//		func(i map[string]interface{}) ([]*config.DeviceConfig, error) {
-//			// returns a single device config
-//			return []*config.DeviceConfig{{}}, nil
-//		},
-//	)
-//	assert.NoError(t, err)
-//
-//	// Initialize plugin with handlers.
-//	p := Plugin{
-//		Config: &config.PluginConfig{
-//			AutoEnumerate: []map[string]interface{}{
-//				{
-//					"foo": "bar",
-//				},
-//			},
-//		},
-//		handlers: handlers,
-//	}
-//
-//	devices, err := devicesFromAutoEnum(&p)
-//	assert.NoError(t, err)
-//	assert.Equal(t, 1, len(devices))
-//}
-//
-//// TestDevicesFromAutoEnum_okHandler tests dynamically registering devices
-//// when there are multiple configs specified for auto-enumeration and the
-//// enumeration handler returns successfully.
-//func TestDevicesFromAutoEnum_okHandler2(t *testing.T) {
-//	// Create handlers.
-//	handlers, err := NewHandlers(
-//		testDeviceIdentifier,
-//		func(i map[string]interface{}) ([]*config.DeviceConfig, error) {
-//			// returns a single device config
-//			return []*config.DeviceConfig{{}}, nil
-//		},
-//	)
-//	assert.NoError(t, err)
-//
-//	// Initialize plugin with handlers.
-//	p := Plugin{
-//		Config: &config.PluginConfig{
-//			AutoEnumerate: []map[string]interface{}{
-//				{
-//					"foo": "bar",
-//				},
-//				{
-//					"bar": "baz",
-//				},
-//				{
-//					"baz": "foo",
-//				},
-//			},
-//		},
-//		handlers: handlers,
-//	}
-//
-//	devices, err := devicesFromAutoEnum(&p)
-//	assert.NoError(t, err)
-//	assert.Equal(t, 3, len(devices))
-//}
-//
-//// ----------
-//// Examples
-//// ----------
-//
-//// A device with a Read function defined in its DeviceHandler should
-//// be readable.
-//func ExampleDevice_IsReadable_true() {
-//	device := Device{
-//		Handler: &DeviceHandler{
-//			Read: func(device *Device) ([]*Reading, error) {
-//				return []*Reading{}, nil
-//			},
-//		},
-//	}
-//
-//	readable := device.IsReadable()
-//	fmt.Println(readable)
-//	// Output: true
-//}
-//
-//// A device without a Read function defined in its DeviceHandler should
-//// not be readable.
-//func ExampleDevice_IsReadable_false() {
-//	device := Device{
-//		Handler: &DeviceHandler{},
-//	}
-//
-//	readable := device.IsReadable()
-//	fmt.Println(readable)
-//	// Output: false
-//}
-//
-//// A device with a Write function defined in its DeviceHandler should
-//// be writable.
-//func ExampleDevice_IsWritable_true() {
-//	device := Device{
-//		Handler: &DeviceHandler{
-//			Write: func(device *Device, data *WriteData) error {
-//				return nil
-//			},
-//		},
-//	}
-//
-//	writable := device.IsWritable()
-//	fmt.Println(writable)
-//	// Output: true
-//}
-//
-//// A device without a Write function defined in its DeviceHandler should
-//// not be writable.
-//func ExampleDevice_IsWritable_false() {
-//	device := Device{
-//		Handler: &DeviceHandler{},
-//	}
-//
-//	writable := device.IsWritable()
-//	fmt.Println(writable)
-//	// Output: false
-//}
-//
-//// Get the GUID of the device.
-//func ExampleDevice_GUID() {
-//	device := Device{
-//		id: "baz",
-//		Location: config.Location{
-//			Rack:  "foo",
-//			Board: "bar",
-//		},
-//	}
-//
-//	guid := device.GUID()
-//	fmt.Println(guid)
-//	// Output: foo-bar-baz
-//}
+	"github.com/vapor-ware/synse-sdk/sdk/config"
+	"github.com/vapor-ware/synse-sdk/sdk/errors"
+)
+
+// TestDevicesInit tests that the devices data structures were properly initialized
+func TestDevicesInit(t *testing.T) {
+	assert.NotNil(t, deviceMap)
+	assert.NotNil(t, deviceHandlers)
+}
+
+// TestDeviceHandler_supportsBulkRead tests whether a DeviceHandler supports bulk reads
+func TestDeviceHandler_supportsBulkRead(t *testing.T) {
+	var testTable = []struct {
+		desc         string
+		supportsBulk bool
+		handler      DeviceHandler
+	}{
+		{
+			desc:         "empty handler, does not support reads",
+			supportsBulk: false,
+			handler:      DeviceHandler{},
+		},
+		{
+			desc:         "supports only writes",
+			supportsBulk: false,
+			handler: DeviceHandler{
+				Write: func(device *Device, data *WriteData) error {
+					return nil
+				},
+			},
+		},
+		{
+			desc:         "supports individual reads",
+			supportsBulk: false,
+			handler: DeviceHandler{
+				Read: func(device *Device) ([]*Reading, error) {
+					return nil, nil
+				},
+			},
+		},
+		{
+			desc:         "supports individual read and bulk read",
+			supportsBulk: false,
+			handler: DeviceHandler{
+				Read: func(device *Device) ([]*Reading, error) {
+					return nil, nil
+				},
+				BulkRead: func(devices []*Device) ([]*ReadContext, error) {
+					return nil, nil
+				},
+			},
+		},
+		{
+			desc:         "supports bulk reads",
+			supportsBulk: true,
+			handler: DeviceHandler{
+				BulkRead: func(devices []*Device) ([]*ReadContext, error) {
+					return nil, nil
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testTable {
+		actual := testCase.handler.supportsBulkRead()
+		assert.Equal(t, testCase.supportsBulk, actual, testCase.desc)
+	}
+}
+
+// TestDeviceHandler_getDevicesForHandler tests getting devices for the handler,
+// when none exist.
+func TestDeviceHandler_getDevicesForHandler(t *testing.T) {
+	handler := DeviceHandler{Name: "test"}
+	devices := handler.getDevicesForHandler()
+	assert.Equal(t, 0, len(devices))
+}
+
+// TestDeviceHandler_getDevicesForHandler2 tests getting devices for the handler,
+// when one exists.
+func TestDeviceHandler_getDevicesForHandler2(t *testing.T) {
+	handler := DeviceHandler{Name: "test"}
+	deviceMap["123"] = &Device{
+		Handler: &handler,
+	}
+	defer delete(deviceMap, "123")
+
+	devices := handler.getDevicesForHandler()
+	assert.Equal(t, 1, len(devices))
+}
+
+// Test_getHandlerForDevice tests getting the handler for a Device when a handler
+// with the given name doesn't exist.
+func Test_getHandlerForDevice(t *testing.T) {
+	handler, err := getHandlerForDevice("bar")
+	assert.Error(t, err)
+	assert.Nil(t, handler)
+}
+
+// Test_getHandlerForDevice2 tests getting the handler for a Device when a handler
+// with the given name exists.
+func Test_getHandlerForDevice2(t *testing.T) {
+	deviceHandlers = []*DeviceHandler{
+		{Name: "foo"},
+	}
+	defer func() {
+		deviceHandlers = []*DeviceHandler{}
+	}()
+
+	handler, err := getHandlerForDevice("foo")
+	assert.NoError(t, err)
+	assert.Equal(t, "foo", handler.Name)
+}
+
+// TestDevice_GetType tests getting the type of the device.
+func TestDevice_GetType(t *testing.T) {
+	var testTable = []struct {
+		desc     string
+		expected string
+		device   Device
+	}{
+		{
+			desc:     "empty kind",
+			expected: "",
+			device:   Device{},
+		},
+		{
+			desc:     "single name for kind",
+			expected: "foo",
+			device: Device{
+				Kind: "foo",
+			},
+		},
+		{
+			desc:     "namespaced name for kind",
+			expected: "foo",
+			device: Device{
+				Kind: "test.foo",
+			},
+		},
+		{
+			desc:     "deep namespaced name for kind",
+			expected: "foo",
+			device: Device{
+				Kind: "test.example.sample.something.foo",
+			},
+		},
+	}
+
+	for _, testCase := range testTable {
+		actual := testCase.device.GetType()
+		assert.Equal(t, testCase.expected, actual, testCase.desc)
+	}
+}
+
+// TestDevice_GetOutputNil tests getting an output when it doesn't exist.
+func TestDevice_GetOutputNil(t *testing.T) {
+	device := &Device{
+		Outputs: []*Output{},
+	}
+	output := device.GetOutput("foo")
+	assert.Nil(t, output)
+}
+
+// TestDevice_GetOutput tests getting an output when it does exist.
+func TestDevice_GetOutput(t *testing.T) {
+	device := &Device{
+		Outputs: []*Output{
+			{
+				OutputType: config.OutputType{Name: "foo"},
+			},
+		},
+	}
+	output := device.GetOutput("foo")
+	assert.NotNil(t, output)
+	assert.Equal(t, "foo", output.Name)
+}
+
+// TestMakeDevices tests making a single device.
+func TestMakeDevices(t *testing.T) {
+	// Add an output to the output map
+	outputTypeMap["something"] = &config.OutputType{
+		Name: "something",
+	}
+	defer delete(outputTypeMap, "something")
+
+	// Add a handler to the handler list
+	deviceHandlers = []*DeviceHandler{
+		{Name: "test"},
+	}
+	defer func() {
+		deviceHandlers = []*DeviceHandler{}
+	}()
+
+	// Create the device config from which Devices will be made
+	cfg := &config.DeviceConfig{
+		Locations: []*config.Location{
+			{
+				Name:  "foo",
+				Rack:  &config.LocationData{Name: "rack"},
+				Board: &config.LocationData{Name: "board"},
+			},
+		},
+		Devices: []*config.DeviceKind{
+			{
+				Name: "test",
+				Outputs: []*config.DeviceOutput{
+					{
+						Type: "something",
+					},
+				},
+				Instances: []*config.DeviceInstance{
+					{
+						Info:     "test info",
+						Location: "foo",
+					},
+				},
+			},
+		},
+	}
+
+	devices, err := makeDevices(cfg)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(devices))
+}
+
+// TestMakeDevices2 tests making devices when no device kinds are specified
+func TestMakeDevices2(t *testing.T) {
+	cfg := &config.DeviceConfig{
+		Locations: []*config.Location{
+			{
+				Name:  "foo",
+				Rack:  &config.LocationData{Name: "rack"},
+				Board: &config.LocationData{Name: "board"},
+			},
+		},
+		Devices: []*config.DeviceKind{},
+	}
+
+	devices, err := makeDevices(cfg)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(devices))
+}
+
+// TestMakeDevices3 tests making devices when no device instances are specified
+func TestMakeDevices3(t *testing.T) {
+	cfg := &config.DeviceConfig{
+		Locations: []*config.Location{
+			{
+				Name:  "foo",
+				Rack:  &config.LocationData{Name: "rack"},
+				Board: &config.LocationData{Name: "board"},
+			},
+		},
+		Devices: []*config.DeviceKind{
+			{
+				Name: "test",
+				Outputs: []*config.DeviceOutput{
+					{
+						Type: "something",
+					},
+				},
+				Instances: []*config.DeviceInstance{},
+			},
+		},
+	}
+
+	devices, err := makeDevices(cfg)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(devices))
+}
+
+// TestMakeDevices4 tests making a single device, when the instance output is invalid.
+func TestMakeDevices4(t *testing.T) {
+	// Create the device config from which Devices will be made
+	cfg := &config.DeviceConfig{
+		Locations: []*config.Location{
+			{
+				Name:  "foo",
+				Rack:  &config.LocationData{Name: "rack"},
+				Board: &config.LocationData{Name: "board"},
+			},
+		},
+		Devices: []*config.DeviceKind{
+			{
+				Name: "test",
+				Instances: []*config.DeviceInstance{
+					{
+						Info:     "test info",
+						Location: "foo",
+						Outputs: []*config.DeviceOutput{
+							{
+								Type: "something",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	devices, err := makeDevices(cfg)
+	assert.Error(t, err)
+	assert.Nil(t, devices)
+}
+
+// TestMakeDevices5 tests making a single device, when there is no associated handler
+// defined.
+func TestMakeDevices5(t *testing.T) {
+	// Add an output to the output map
+	outputTypeMap["something"] = &config.OutputType{
+		Name: "something",
+	}
+	defer delete(outputTypeMap, "something")
+
+	// Create the device config from which Devices will be made
+	cfg := &config.DeviceConfig{
+		Locations: []*config.Location{
+			{
+				Name:  "foo",
+				Rack:  &config.LocationData{Name: "rack"},
+				Board: &config.LocationData{Name: "board"},
+			},
+		},
+		Devices: []*config.DeviceKind{
+			{
+				Name: "test",
+				Outputs: []*config.DeviceOutput{
+					{
+						Type: "something",
+					},
+				},
+				Instances: []*config.DeviceInstance{
+					{
+						Info:     "test info",
+						Location: "foo",
+					},
+				},
+			},
+		},
+	}
+
+	devices, err := makeDevices(cfg)
+	assert.Error(t, err)
+	assert.Nil(t, devices)
+}
+
+// TestMakeDevices6 tests making a single device, when the locations do not
+// match up.
+func TestMakeDevices6(t *testing.T) {
+	// Add an output to the output map
+	outputTypeMap["something"] = &config.OutputType{
+		Name: "something",
+	}
+	defer delete(outputTypeMap, "something")
+
+	// Create the device config from which Devices will be made
+	cfg := &config.DeviceConfig{
+		Locations: []*config.Location{
+			{
+				Name:  "foo",
+				Rack:  &config.LocationData{Name: "rack"},
+				Board: &config.LocationData{Name: "board"},
+			},
+		},
+		Devices: []*config.DeviceKind{
+			{
+				Name: "test",
+				Outputs: []*config.DeviceOutput{
+					{
+						Type: "something",
+					},
+				},
+				Instances: []*config.DeviceInstance{
+					{
+						Info:     "test info",
+						Location: "baz",
+					},
+				},
+			},
+		},
+	}
+
+	devices, err := makeDevices(cfg)
+	assert.Error(t, err)
+	assert.Nil(t, devices)
+}
+
+// TestMakeDevices7 tests making a single device when the kind specifies
+// an override handler.
+func TestMakeDevices7(t *testing.T) {
+	// Add an output to the output map
+	outputTypeMap["something"] = &config.OutputType{
+		Name: "something",
+	}
+	defer delete(outputTypeMap, "something")
+
+	// Add a handler to the handler list
+	deviceHandlers = []*DeviceHandler{
+		{Name: "override"},
+	}
+	defer func() {
+		deviceHandlers = []*DeviceHandler{}
+	}()
+
+	// Create the device config from which Devices will be made
+	cfg := &config.DeviceConfig{
+		Locations: []*config.Location{
+			{
+				Name:  "foo",
+				Rack:  &config.LocationData{Name: "rack"},
+				Board: &config.LocationData{Name: "board"},
+			},
+		},
+		Devices: []*config.DeviceKind{
+			{
+				Name:        "test",
+				HandlerName: "override",
+				Outputs: []*config.DeviceOutput{
+					{
+						Type: "something",
+					},
+				},
+				Instances: []*config.DeviceInstance{
+					{
+						Info:     "test info",
+						Location: "foo",
+					},
+				},
+			},
+		},
+	}
+
+	devices, err := makeDevices(cfg)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(devices))
+}
+
+// TestMakeDevices8 tests making a single device when the instances specifies
+// an override handler.
+func TestMakeDevices8(t *testing.T) {
+	// Add an output to the output map
+	outputTypeMap["something"] = &config.OutputType{
+		Name: "something",
+	}
+	defer delete(outputTypeMap, "something")
+
+	// Add a handler to the handler list
+	deviceHandlers = []*DeviceHandler{
+		{Name: "override"},
+	}
+	defer func() {
+		deviceHandlers = []*DeviceHandler{}
+	}()
+
+	// Create the device config from which Devices will be made
+	cfg := &config.DeviceConfig{
+		Locations: []*config.Location{
+			{
+				Name:  "foo",
+				Rack:  &config.LocationData{Name: "rack"},
+				Board: &config.LocationData{Name: "board"},
+			},
+		},
+		Devices: []*config.DeviceKind{
+			{
+				Name: "test",
+				Outputs: []*config.DeviceOutput{
+					{
+						Type: "something",
+					},
+				},
+				Instances: []*config.DeviceInstance{
+					{
+						Info:        "test info",
+						Location:    "foo",
+						HandlerName: "override",
+					},
+				},
+			},
+		},
+	}
+
+	devices, err := makeDevices(cfg)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(devices))
+}
+
+// TestDeviceIsReadable tests whether a device is readable in the case
+// when it is readable.
+func TestDeviceIsReadable(t *testing.T) {
+	device := Device{
+		Handler: &DeviceHandler{
+			Read: func(device *Device) ([]*Reading, error) {
+				return []*Reading{}, nil
+			},
+		},
+	}
+
+	readable := device.IsReadable()
+	assert.True(t, readable)
+}
+
+// TestDeviceIsNotReadable tests whether a device is readable in the case
+// when it is not readable.
+func TestDeviceIsNotReadable(t *testing.T) {
+	device := Device{
+		Handler: &DeviceHandler{},
+	}
+
+	readable := device.IsReadable()
+	assert.False(t, readable)
+}
+
+// TestDeviceIsWritable tests whether a device is writable in the case
+// when it is writable.
+func TestDeviceIsWritable(t *testing.T) {
+	device := Device{
+		Handler: &DeviceHandler{
+			Write: func(device *Device, data *WriteData) error {
+				return nil
+			},
+		},
+	}
+
+	writable := device.IsWritable()
+	assert.True(t, writable)
+}
+
+// TestDeviceIsNotWritable tests whether a device is writable in the case
+// when it is not writable.
+func TestDeviceIsNotWritable(t *testing.T) {
+	device := Device{
+		Handler: &DeviceHandler{},
+	}
+
+	writable := device.IsWritable()
+	assert.False(t, writable)
+}
+
+// TestDeviceReadNotReadable tests reading from a device when it is not
+// a readable device.
+func TestDeviceReadNotReadable(t *testing.T) {
+	device := Device{
+		Handler: &DeviceHandler{},
+	}
+
+	ctx, err := device.Read()
+	assert.Nil(t, ctx)
+	assert.Error(t, err)
+	assert.IsType(t, &errors.UnsupportedCommandError{}, err)
+}
+
+// TestDeviceReadErr tests reading from a device when the device is readable,
+// but reading from it will return an error.
+func TestDeviceReadErr(t *testing.T) {
+	device := Device{
+		Handler: &DeviceHandler{
+			Read: func(device *Device) ([]*Reading, error) {
+				return nil, fmt.Errorf("test error")
+			},
+		},
+	}
+
+	ctx, err := device.Read()
+	assert.Nil(t, ctx)
+	assert.Error(t, err)
+	assert.Equal(t, "test error", err.Error())
+}
+
+// TestDeviceReadOk tests reading from a device when the device is readable,
+// and the device config is correct, so we get back a good reading.
+func TestDeviceReadOk(t *testing.T) {
+	device := Device{
+		Outputs: []*Output{
+			{
+				OutputType: config.OutputType{Name: "foo"},
+			},
+		},
+		Location: &Location{
+			Rack:  "rack",
+			Board: "board",
+		},
+		Handler: &DeviceHandler{
+			Read: func(device *Device) ([]*Reading, error) {
+				return []*Reading{
+					device.GetOutput("foo").MakeReading("value"),
+				}, nil
+			},
+		},
+	}
+
+	ctx, err := device.Read()
+
+	assert.NotNil(t, ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, device.Location.Rack, ctx.Rack)
+	assert.Equal(t, device.Location.Board, ctx.Board)
+	assert.Equal(t, device.ID(), ctx.Device)
+	assert.Equal(t, 1, len(ctx.Reading))
+	assert.Equal(t, "foo", ctx.Reading[0].Type)
+	assert.Equal(t, "value", ctx.Reading[0].Value)
+}
+
+// TestDeviceWriteNotWritable tests writing to a device when it is not
+// a writable device.
+func TestDeviceWriteNotWritable(t *testing.T) {
+	device := Device{
+		Handler: &DeviceHandler{},
+	}
+
+	err := device.Write(&WriteData{Action: "test"})
+	assert.Error(t, err)
+	assert.IsType(t, &errors.UnsupportedCommandError{}, err)
+}
+
+// TestDeviceWriteErr tests writing to a device when it is
+// a writable device, but the write returns an error.
+func TestDeviceWriteErr(t *testing.T) {
+	device := Device{
+		Handler: &DeviceHandler{
+			Write: func(device *Device, data *WriteData) error {
+				return fmt.Errorf("test error")
+			},
+		},
+	}
+
+	err := device.Write(&WriteData{Action: "test"})
+	assert.Error(t, err)
+	assert.Equal(t, "test error", err.Error())
+}
+
+// TestDeviceWriteOk tests writing to a device when it is
+// a writable device.
+func TestDeviceWriteOk(t *testing.T) {
+	device := Device{
+		Handler: &DeviceHandler{
+			Write: func(device *Device, data *WriteData) error {
+				return nil
+			},
+		},
+	}
+
+	err := device.Write(&WriteData{Action: "test"})
+	assert.NoError(t, err)
+}
+
+// TestLocation_encode tests encoding a Location to the grpc message
+func TestLocation_encode(t *testing.T) {
+	location := Location{
+		Rack:  "foo",
+		Board: "bar",
+	}
+	out := location.encode()
+	assert.Equal(t, "foo", out.GetRack())
+	assert.Equal(t, "bar", out.GetBoard())
+}
+
+// TestNewLocationFromConfig tests successfully getting a Location from config
+func TestNewLocationFromConfig(t *testing.T) {
+	cfg := &config.Location{
+		Name:  "test",
+		Rack:  &config.LocationData{Name: "rack"},
+		Board: &config.LocationData{Name: "board"},
+	}
+
+	loc, err := NewLocationFromConfig(cfg)
+	assert.NoError(t, err)
+	assert.Equal(t, "rack", loc.Rack)
+	assert.Equal(t, "board", loc.Board)
+}
+
+// TestNewLocationFromConfig2 tests getting a Location from config with bad rack
+func TestNewLocationFromConfig2(t *testing.T) {
+	cfg := &config.Location{
+		Name:  "test",
+		Rack:  &config.LocationData{FromEnv: "NOT_AN_ENV"},
+		Board: &config.LocationData{Name: "board"},
+	}
+
+	loc, err := NewLocationFromConfig(cfg)
+	assert.Error(t, err)
+	assert.Nil(t, loc)
+}
+
+// TestNewLocationFromConfig3 tests getting a Location from config with bad board
+func TestNewLocationFromConfig3(t *testing.T) {
+	cfg := &config.Location{
+		Name:  "test",
+		Rack:  &config.LocationData{Name: "rack"},
+		Board: &config.LocationData{FromEnv: "NOT_AN_ENV"},
+	}
+
+	loc, err := NewLocationFromConfig(cfg)
+	assert.Error(t, err)
+	assert.Nil(t, loc)
+}
+
+// TestOutput_encode tests successfully converting an output to its grpc message.
+func TestOutput_encode(t *testing.T) {
+	output := Output{
+		OutputType: config.OutputType{
+			Name:      "foo",
+			Precision: 2,
+		},
+	}
+	out := output.encode()
+	assert.Equal(t, "foo", out.Name)
+	assert.Equal(t, int32(2), out.Precision)
+}
+
+// TestOutput_encode2 tests successfully converting an output to its grpc message
+// with bad scaling factor.
+func TestOutput_encode2(t *testing.T) {
+	output := Output{
+		OutputType: config.OutputType{
+			Name:          "foo",
+			Precision:     2,
+			ScalingFactor: "abc",
+		},
+	}
+	out := output.encode()
+	assert.Equal(t, "foo", out.Name)
+	assert.Equal(t, int32(2), out.Precision)
+	assert.Equal(t, float64(0), out.ScalingFactor)
+}
+
+// TestDevice_encode tests encoding a Device to its grpc message.
+func TestDevice_encode(t *testing.T) {
+	device := &Device{
+		Kind:   "test",
+		Plugin: "foo",
+		Info:   "bar",
+		Location: &Location{
+			Rack:  "rack",
+			Board: "board",
+		},
+		Outputs: []*Output{
+			{
+				OutputType: config.OutputType{
+					Name: "output",
+					Unit: config.Unit{
+						Name:   "x",
+						Symbol: "X",
+					},
+				},
+				Info: "out info",
+			},
+		},
+	}
+	out := device.encode()
+	assert.Equal(t, "test", out.GetKind())
+	assert.Equal(t, "foo", out.GetPlugin())
+	assert.Equal(t, "bar", out.GetInfo())
+	assert.Equal(t, "rack", out.GetLocation().GetRack())
+	assert.Equal(t, "board", out.GetLocation().GetBoard())
+	assert.Equal(t, "output", out.GetOutput()[0].GetName())
+	assert.Equal(t, "x", out.GetOutput()[0].GetUnit().GetName())
+	assert.Equal(t, "X", out.GetOutput()[0].GetUnit().GetSymbol())
+}
+
+// Test_updateDeviceMap tests updating the device map.
+func Test_updateDeviceMap(t *testing.T) {
+	device := &Device{
+		Kind: "test",
+		Location: &Location{
+			Rack:  "rack",
+			Board: "board",
+		},
+	}
+
+	assert.Equal(t, 0, len(deviceMap))
+	updateDeviceMap([]*Device{device})
+	assert.Equal(t, 1, len(deviceMap))
+
+	delete(deviceMap, device.GUID())
+}
+
+// Test_getInstanceOutputs tests getting instance output when none are defined.
+func Test_getInstanceOutputs(t *testing.T) {
+	kind := &config.DeviceKind{}
+	instance := &config.DeviceInstance{}
+
+	outputs, err := getInstanceOutputs(kind, instance)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(outputs))
+}
+
+// Test_getInstanceOutputs2 tests getting instance output when the Kind defines them.
+func Test_getInstanceOutputs2(t *testing.T) {
+	outputTypeMap["test"] = &config.OutputType{Name: "test"}
+	defer delete(outputTypeMap, "test")
+
+	kind := &config.DeviceKind{
+		Outputs: []*config.DeviceOutput{
+			{
+				Type: "test",
+			},
+		},
+	}
+	instance := &config.DeviceInstance{}
+
+	outputs, err := getInstanceOutputs(kind, instance)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(outputs))
+}
+
+// Test_getInstanceOutputs3 tests getting instance output when the Instance defines them.
+func Test_getInstanceOutputs3(t *testing.T) {
+	outputTypeMap["test"] = &config.OutputType{Name: "test"}
+	defer delete(outputTypeMap, "test")
+
+	kind := &config.DeviceKind{}
+	instance := &config.DeviceInstance{
+		Outputs: []*config.DeviceOutput{
+			{
+				Type: "test",
+			},
+		},
+	}
+
+	outputs, err := getInstanceOutputs(kind, instance)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(outputs))
+}
+
+// Test_getInstanceOutputs4 tests getting instance output when the Kind and Instance defines them.
+func Test_getInstanceOutputs4(t *testing.T) {
+	outputTypeMap["foo"] = &config.OutputType{Name: "foo"}
+	outputTypeMap["bar"] = &config.OutputType{Name: "bar"}
+	defer delete(outputTypeMap, "foo")
+	defer delete(outputTypeMap, "bar")
+
+	kind := &config.DeviceKind{
+		Outputs: []*config.DeviceOutput{
+			{
+				Type: "foo",
+			},
+		},
+	}
+	instance := &config.DeviceInstance{
+		Outputs: []*config.DeviceOutput{
+			{
+				Type: "bar",
+			},
+		},
+	}
+
+	outputs, err := getInstanceOutputs(kind, instance)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(outputs))
+}
+
+// Test_getInstanceOutputs5 tests getting instance output when duplicates are defined.
+func Test_getInstanceOutputs5(t *testing.T) {
+	outputTypeMap["test"] = &config.OutputType{Name: "test"}
+	defer delete(outputTypeMap, "test")
+
+	kind := &config.DeviceKind{
+		Outputs: []*config.DeviceOutput{
+			{
+				Type: "test",
+			},
+		},
+	}
+	instance := &config.DeviceInstance{
+		Outputs: []*config.DeviceOutput{
+			{
+				Type: "test",
+			},
+		},
+	}
+
+	outputs, err := getInstanceOutputs(kind, instance)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(outputs))
+}
+
+// Test_getInstanceOutputs6 tests getting instance output when the Kind and Instance defines them,
+// but the instance should not inherit from the kind..
+func Test_getInstanceOutputs6(t *testing.T) {
+	outputTypeMap["foo"] = &config.OutputType{Name: "foo"}
+	outputTypeMap["bar"] = &config.OutputType{Name: "bar"}
+	defer delete(outputTypeMap, "foo")
+	defer delete(outputTypeMap, "bar")
+
+	kind := &config.DeviceKind{
+		Outputs: []*config.DeviceOutput{
+			{
+				Type: "foo",
+			},
+		},
+	}
+	instance := &config.DeviceInstance{
+		DisableOutputInheritance: true,
+		Outputs: []*config.DeviceOutput{
+			{
+				Type: "bar",
+			},
+		},
+	}
+
+	outputs, err := getInstanceOutputs(kind, instance)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(outputs))
+}
+
+// Test_getInstanceOutputs7 tests getting instance output when the Kind defines them,
+// but there is no corresponding type.
+func Test_getInstanceOutputs7(t *testing.T) {
+	kind := &config.DeviceKind{
+		Outputs: []*config.DeviceOutput{
+			{
+				Type: "test",
+			},
+		},
+	}
+	instance := &config.DeviceInstance{}
+
+	outputs, err := getInstanceOutputs(kind, instance)
+	assert.Error(t, err)
+	assert.Nil(t, outputs)
+}
+
+// Test_getInstanceOutputs8 tests getting instance output when the Instance defines them,
+// but there is no corresponding type.
+func Test_getInstanceOutputs8(t *testing.T) {
+	kind := &config.DeviceKind{}
+	instance := &config.DeviceInstance{
+		Outputs: []*config.DeviceOutput{
+			{
+				Type: "test",
+			},
+		},
+	}
+
+	outputs, err := getInstanceOutputs(kind, instance)
+	assert.Error(t, err)
+	assert.Nil(t, outputs)
+}
+
+// ----------
+// Examples
+// ----------
+
+// A device with a Read function defined in its DeviceHandler should
+// be readable.
+func ExampleDevice_IsReadable_true() {
+	device := Device{
+		Handler: &DeviceHandler{
+			Read: func(device *Device) ([]*Reading, error) {
+				return []*Reading{}, nil
+			},
+		},
+	}
+
+	readable := device.IsReadable()
+	fmt.Println(readable)
+	// Output: true
+}
+
+// A device without a Read function defined in its DeviceHandler should
+// not be readable.
+func ExampleDevice_IsReadable_false() {
+	device := Device{
+		Handler: &DeviceHandler{},
+	}
+
+	readable := device.IsReadable()
+	fmt.Println(readable)
+	// Output: false
+}
+
+// A device with a Write function defined in its DeviceHandler should
+// be writable.
+func ExampleDevice_IsWritable_true() {
+	device := Device{
+		Handler: &DeviceHandler{
+			Write: func(device *Device, data *WriteData) error {
+				return nil
+			},
+		},
+	}
+
+	writable := device.IsWritable()
+	fmt.Println(writable)
+	// Output: true
+}
+
+// A device without a Write function defined in its DeviceHandler should
+// not be writable.
+func ExampleDevice_IsWritable_false() {
+	device := Device{
+		Handler: &DeviceHandler{},
+	}
+
+	writable := device.IsWritable()
+	fmt.Println(writable)
+	// Output: false
+}
+
+// Get the GUID of the device.
+func ExampleDevice_GUID() {
+	device := Device{
+		id: "baz",
+		Location: &Location{
+			Rack:  "foo",
+			Board: "bar",
+		},
+	}
+
+	guid := device.GUID()
+	fmt.Println(guid)
+	// Output: foo-bar-baz
+}

--- a/sdk/devices_test.go
+++ b/sdk/devices_test.go
@@ -9,6 +9,86 @@ package sdk
 //
 //	"github.com/vapor-ware/synse-sdk/sdk/config"
 //)
+
+//
+//// TestMakeDevices tests making devices where two instances match one prototype.
+//func TestMakeDevices(t *testing.T) {
+//	inst := []*config.DeviceConfig{&testDeviceConfig1, &testDeviceConfig2}
+//	proto := []*config.PrototypeConfig{&testPrototypeConfig1}
+//
+//	devices, err := makeDevices(inst, proto, &testPlugin)
+//	assert.NoError(t, err)
+//	assert.Equal(t, 2, len(devices))
+//}
+//
+//// TestMakeDevices2 tests making devices when no instances match the prototype.
+//func TestMakeDevices2(t *testing.T) {
+//	inst := []*config.DeviceConfig{&testDeviceConfig1, &testDeviceConfig2}
+//	proto := []*config.PrototypeConfig{&testPrototypeConfig2}
+//
+//	devices, err := makeDevices(inst, proto, &testPlugin)
+//	assert.NoError(t, err)
+//	assert.Equal(t, 0, len(devices))
+//}
+//
+//// TestMakeDevices3 tests making devices when one instance matches one of two prototypes.
+//func TestMakeDevices3(t *testing.T) {
+//	inst := []*config.DeviceConfig{&testDeviceConfig1}
+//	proto := []*config.PrototypeConfig{&testPrototypeConfig1, &testPrototypeConfig2}
+//
+//	devices, err := makeDevices(inst, proto, &testPlugin)
+//	assert.NoError(t, err)
+//	assert.Equal(t, 1, len(devices))
+//}
+//
+//// TestMakeDevices4 tests making devices when no prototypes exist for instances to
+//// match with.
+//func TestMakeDevices4(t *testing.T) {
+//	inst := []*config.DeviceConfig{&testDeviceConfig1, &testDeviceConfig2}
+//	var proto []*config.PrototypeConfig
+//
+//	devices, err := makeDevices(inst, proto, &testPlugin)
+//	assert.NoError(t, err)
+//	assert.Equal(t, 0, len(devices))
+//}
+//
+//// TestMakeDevices5 tests making devices when no instances exist for protocols to
+//// be matched with.
+//func TestMakeDevices5(t *testing.T) {
+//	var inst []*config.DeviceConfig
+//	proto := []*config.PrototypeConfig{&testPrototypeConfig1, &testPrototypeConfig2}
+//
+//	devices, err := makeDevices(inst, proto, &testPlugin)
+//	assert.NoError(t, err)
+//	assert.Equal(t, 0, len(devices))
+//}
+//
+//// TestMakeDevices6 tests making devices when the plugin is incorrectly configured
+//// (no device identifier handler), which should prohibit devices from being created.
+//func TestMakeDevices6(t *testing.T) {
+//	inst := []*config.DeviceConfig{&testDeviceConfig1, &testDeviceConfig2}
+//	proto := []*config.PrototypeConfig{&testPrototypeConfig1}
+//
+//	plugin := makeTestPlugin()
+//	plugin.handlers.DeviceIdentifier = nil
+//
+//	_, err := makeDevices(inst, proto, plugin)
+//	assert.Error(t, err)
+//}
+//
+//// TestMakeDevices7 tests making devices when the plugin is incorrectly configured
+//// (no device handlers), which should prohibit devices from being created.
+//func TestMakeDevices7(t *testing.T) {
+//	inst := []*config.DeviceConfig{&testDeviceConfig1, &testDeviceConfig2}
+//	proto := []*config.PrototypeConfig{&testPrototypeConfig1}
+//
+//	plugin := makeTestPlugin()
+//	plugin.deviceHandlers = []*DeviceHandler{}
+//
+//	_, err := makeDevices(inst, proto, plugin)
+//	assert.Error(t, err)
+//}
+
 //
 //// testDeviceFields is a test helper function to check the Device
 //// fields against the specified prototype and device configs.

--- a/sdk/errors/errors_test.go
+++ b/sdk/errors/errors_test.go
@@ -56,7 +56,7 @@ func TestMultiError_Error(t *testing.T) {
 			errs: []error{
 				fmt.Errorf("error 1"),
 			},
-			expected: "MultiError has 1 error(s) for source: unspecified\nerror 1\n",
+			expected: "1 error(s) for: unspecified\nerror 1\n",
 		},
 		{
 			desc:   "MultiError has 1 error, with source",
@@ -64,7 +64,7 @@ func TestMultiError_Error(t *testing.T) {
 			errs: []error{
 				fmt.Errorf("error 1"),
 			},
-			expected: "MultiError has 1 error(s) for source: test\nerror 1\n",
+			expected: "1 error(s) for: test\nerror 1\n",
 		},
 		{
 			desc:   "MultiError has multiple errors, no source",
@@ -74,7 +74,7 @@ func TestMultiError_Error(t *testing.T) {
 				fmt.Errorf("error 2"),
 				fmt.Errorf("error 3"),
 			},
-			expected: "MultiError has 3 error(s) for source: unspecified\nerror 1\nerror 2\nerror 3\n",
+			expected: "3 error(s) for: unspecified\nerror 1\nerror 2\nerror 3\n",
 		},
 		{
 			desc:   "MultiError has multiple errors, with source",
@@ -84,7 +84,7 @@ func TestMultiError_Error(t *testing.T) {
 				fmt.Errorf("error 2"),
 				fmt.Errorf("error 3"),
 			},
-			expected: "MultiError has 3 error(s) for source: test\nerror 1\nerror 2\nerror 3\n",
+			expected: "3 error(s) for: test\nerror 1\nerror 2\nerror 3\n",
 		},
 	}
 

--- a/sdk/globals.go
+++ b/sdk/globals.go
@@ -8,5 +8,8 @@ import (
 // for now, this is fine since it gets things moving, but it needs
 // to be improved/fixed before v1.0 is considered done.
 
+// DeviceConfig is the global SDK unified DeviceConfig
 var DeviceConfig *config.DeviceConfig
+
+// PluginConfig is the global SDK PluginConfig
 var PluginConfig *config.PluginConfig

--- a/sdk/meta_test.go
+++ b/sdk/meta_test.go
@@ -25,3 +25,8 @@ func TestSetPluginMeta(t *testing.T) {
 	assert.Equal(t, "desc", metainfo.Description)
 	assert.Equal(t, "vcs", metainfo.VCS)
 }
+
+// TestMetaLog tests logging out the metadata.
+func TestMetaLog(t *testing.T) {
+	metainfo.log()
+}

--- a/sdk/models.go
+++ b/sdk/models.go
@@ -39,7 +39,7 @@ func NewReading(output *Output, value interface{}) *Reading {
 }
 
 // encode translates the Reading type to the corresponding gRPC Reading message.
-func (reading *Reading) encode() *synse.Reading {
+func (reading *Reading) encode() *synse.Reading { // nolint: gocyclo
 	r := synse.Reading{
 		Timestamp: reading.Timestamp,
 		Type:      reading.Type,
@@ -49,35 +49,35 @@ func (reading *Reading) encode() *synse.Reading {
 
 	switch t := reading.Value.(type) {
 	case string:
-		r.Value = &synse.Reading_StringValue{t}
+		r.Value = &synse.Reading_StringValue{StringValue: t}
 	case bool:
-		r.Value = &synse.Reading_BoolValue{t}
+		r.Value = &synse.Reading_BoolValue{BoolValue: t}
 	case float64:
-		r.Value = &synse.Reading_Float64Value{t}
+		r.Value = &synse.Reading_Float64Value{Float64Value: t}
 	case float32:
-		r.Value = &synse.Reading_Float32Value{t}
+		r.Value = &synse.Reading_Float32Value{Float32Value: t}
 	case int64:
-		r.Value = &synse.Reading_Int64Value{t}
+		r.Value = &synse.Reading_Int64Value{Int64Value: t}
 	case int32:
-		r.Value = &synse.Reading_Int32Value{t}
+		r.Value = &synse.Reading_Int32Value{Int32Value: t}
 	case int16:
-		r.Value = &synse.Reading_Int32Value{int32(t)}
+		r.Value = &synse.Reading_Int32Value{Int32Value: int32(t)}
 	case int8:
-		r.Value = &synse.Reading_Int32Value{int32(t)}
+		r.Value = &synse.Reading_Int32Value{Int32Value: int32(t)}
 	case int:
-		r.Value = &synse.Reading_Int64Value{int64(t)}
+		r.Value = &synse.Reading_Int64Value{Int64Value: int64(t)}
 	case []byte:
-		r.Value = &synse.Reading_BytesValue{t}
+		r.Value = &synse.Reading_BytesValue{BytesValue: t}
 	case uint64:
-		r.Value = &synse.Reading_Uint64Value{t}
+		r.Value = &synse.Reading_Uint64Value{Uint64Value: t}
 	case uint32:
-		r.Value = &synse.Reading_Uint32Value{t}
+		r.Value = &synse.Reading_Uint32Value{Uint32Value: t}
 	case uint16:
-		r.Value = &synse.Reading_Uint32Value{uint32(t)}
+		r.Value = &synse.Reading_Uint32Value{Uint32Value: uint32(t)}
 	case uint8:
-		r.Value = &synse.Reading_Uint32Value{uint32(t)}
+		r.Value = &synse.Reading_Uint32Value{Uint32Value: uint32(t)}
 	case uint:
-		r.Value = &synse.Reading_Uint64Value{uint64(t)}
+		r.Value = &synse.Reading_Uint64Value{Uint64Value: uint64(t)}
 	case nil:
 		r.Value = nil
 	default:

--- a/sdk/models.go
+++ b/sdk/models.go
@@ -106,13 +106,13 @@ type ReadContext struct {
 
 // NewReadContext creates a new instance of a ReadContext from the given
 // device and corresponding readings.
-func NewReadContext(device *Device, readings []*Reading) (*ReadContext, error) {
+func NewReadContext(device *Device, readings []*Reading) *ReadContext {
 	return &ReadContext{
 		Device:  device.ID(),
 		Board:   device.Location.Board,
 		Rack:    device.Location.Rack,
 		Reading: readings,
-	}, nil
+	}
 }
 
 // ID returns a compound string that can identify the resource by its

--- a/sdk/models_test.go
+++ b/sdk/models_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/vapor-ware/synse-sdk/sdk/config"
 	"github.com/vapor-ware/synse-server-grpc/go"
 )
 
@@ -73,13 +74,215 @@ func TestDecodeWriteData(t *testing.T) {
 	}
 }
 
-//
-//// TestNewReading tests creating a new Reading from the NewReading constructor.
-//func TestNewReading(t *testing.T) {
-//	r := NewReading("test", "value")
-//
-//	assert.IsType(t, Reading{}, *r)
-//	assert.NotEqual(t, "", r.Timestamp)
-//	assert.Equal(t, "test", r.Type)
-//	assert.Equal(t, "value", r.Value)
-//}
+// TestNewReading tests creating a new Reading.
+func TestNewReading(t *testing.T) {
+	output := &Output{
+		OutputType: config.OutputType{
+			Name: "test",
+			Unit: config.Unit{
+				Name:   "abc",
+				Symbol: "A",
+			},
+		},
+		Info: "foobar",
+	}
+
+	reading := NewReading(output, 42)
+	assert.Equal(t, "test", reading.Type)
+	assert.Equal(t, "foobar", reading.Info)
+	assert.Equal(t, "abc", reading.Unit.Name)
+	assert.Equal(t, "A", reading.Unit.Symbol)
+	assert.Equal(t, 42, reading.Value)
+}
+
+// TestNewReadContext tests creating a new ReadContext.
+func TestNewReadContext(t *testing.T) {
+	device := &Device{
+		Location: &Location{
+			Rack:  "rack",
+			Board: "board",
+		},
+	}
+	ctx := NewReadContext(device, []*Reading{{Type: "test", Value: 2}})
+
+	assert.Equal(t, "d41d8cd98f00b204e9800998ecf8427e", ctx.Device)
+	assert.Equal(t, "board", ctx.Board)
+	assert.Equal(t, "rack", ctx.Rack)
+	assert.Equal(t, 1, len(ctx.Reading))
+}
+
+// TestReading_encode_string tests encoding a Reading when the value is a string.
+func TestReading_encode_string(t *testing.T) {
+	reading := Reading{
+		Type:  "test",
+		Value: "foo",
+	}
+	out := reading.encode()
+	assert.Equal(t, "test", out.Type)
+	assert.Equal(t, "foo", out.GetStringValue())
+}
+
+// TestReading_encode_bool tests encoding a Reading when the value is a bool.
+func TestReading_encode_bool(t *testing.T) {
+	reading := Reading{
+		Type:  "test",
+		Value: true,
+	}
+	out := reading.encode()
+	assert.Equal(t, "test", out.Type)
+	assert.Equal(t, true, out.GetBoolValue())
+}
+
+// TestReading_encode_float64 tests encoding a Reading when the value is a float64.
+func TestReading_encode_float64(t *testing.T) {
+	reading := Reading{
+		Type:  "test",
+		Value: float64(7),
+	}
+	out := reading.encode()
+	assert.Equal(t, "test", out.Type)
+	assert.Equal(t, float64(7), out.GetFloat64Value())
+}
+
+// TestReading_encode_float32 tests encoding a Reading when the value is a float32.
+func TestReading_encode_float32(t *testing.T) {
+	reading := Reading{
+		Type:  "test",
+		Value: float32(7),
+	}
+	out := reading.encode()
+	assert.Equal(t, "test", out.Type)
+	assert.Equal(t, float32(7), out.GetFloat32Value())
+}
+
+// TestReading_encode_int64 tests encoding a Reading when the value is an int64.
+func TestReading_encode_int64(t *testing.T) {
+	reading := Reading{
+		Type:  "test",
+		Value: int64(7),
+	}
+	out := reading.encode()
+	assert.Equal(t, "test", out.Type)
+	assert.Equal(t, int64(7), out.GetInt64Value())
+}
+
+// TestReading_encode_int32 tests encoding a Reading when the value is an int32.
+func TestReading_encode_int32(t *testing.T) {
+	reading := Reading{
+		Type:  "test",
+		Value: int32(7),
+	}
+	out := reading.encode()
+	assert.Equal(t, "test", out.Type)
+	assert.Equal(t, int32(7), out.GetInt32Value())
+}
+
+// TestReading_encode_int16 tests encoding a Reading when the value is an int16.
+func TestReading_encode_int16(t *testing.T) {
+	reading := Reading{
+		Type:  "test",
+		Value: int16(7),
+	}
+	out := reading.encode()
+	assert.Equal(t, "test", out.Type)
+	assert.Equal(t, int32(7), out.GetInt32Value())
+}
+
+// TestReading_encode_int8 tests encoding a Reading when the value is an int8.
+func TestReading_encode_int8(t *testing.T) {
+	reading := Reading{
+		Type:  "test",
+		Value: int8(7),
+	}
+	out := reading.encode()
+	assert.Equal(t, "test", out.Type)
+	assert.Equal(t, int32(7), out.GetInt32Value())
+}
+
+// TestReading_encode_int tests encoding a Reading when the value is an int.
+func TestReading_encode_int(t *testing.T) {
+	reading := Reading{
+		Type:  "test",
+		Value: int(7),
+	}
+	out := reading.encode()
+	assert.Equal(t, "test", out.Type)
+	assert.Equal(t, int64(7), out.GetInt64Value())
+}
+
+// TestReading_encode_uint64 tests encoding a Reading when the value is a uint64.
+func TestReading_encode_uint64(t *testing.T) {
+	reading := Reading{
+		Type:  "test",
+		Value: uint64(7),
+	}
+	out := reading.encode()
+	assert.Equal(t, "test", out.Type)
+	assert.Equal(t, uint64(7), out.GetUint64Value())
+}
+
+// TestReading_encode_uint32 tests encoding a Reading when the value is a uint32.
+func TestReading_encode_uint32(t *testing.T) {
+	reading := Reading{
+		Type:  "test",
+		Value: uint32(7),
+	}
+	out := reading.encode()
+	assert.Equal(t, "test", out.Type)
+	assert.Equal(t, uint32(7), out.GetUint32Value())
+}
+
+// TestReading_encode_uint16 tests encoding a Reading when the value is a uint16.
+func TestReading_encode_uint16(t *testing.T) {
+	reading := Reading{
+		Type:  "test",
+		Value: uint16(7),
+	}
+	out := reading.encode()
+	assert.Equal(t, "test", out.Type)
+	assert.Equal(t, uint32(7), out.GetUint32Value())
+}
+
+// TestReading_encode_uint8 tests encoding a Reading when the value is a uint8.
+func TestReading_encode_uint8(t *testing.T) {
+	reading := Reading{
+		Type:  "test",
+		Value: uint8(7),
+	}
+	out := reading.encode()
+	assert.Equal(t, "test", out.Type)
+	assert.Equal(t, uint32(7), out.GetUint32Value())
+}
+
+// TestReading_encode_uint tests encoding a Reading when the value is a uint.
+func TestReading_encode_uint(t *testing.T) {
+	reading := Reading{
+		Type:  "test",
+		Value: uint(7),
+	}
+	out := reading.encode()
+	assert.Equal(t, "test", out.Type)
+	assert.Equal(t, uint64(7), out.GetUint64Value())
+}
+
+// TestReading_encode_bytes tests encoding a Reading when the value is a slice of bytes.
+func TestReading_encode_bytes(t *testing.T) {
+	reading := Reading{
+		Type:  "test",
+		Value: []byte("test"),
+	}
+	out := reading.encode()
+	assert.Equal(t, "test", out.Type)
+	assert.Equal(t, []byte("test"), out.GetBytesValue())
+}
+
+// TestReading_encode_nil tests encoding a Reading when the value is nil.
+func TestReading_encode_nil(t *testing.T) {
+	reading := Reading{
+		Type:  "test",
+		Value: nil,
+	}
+	out := reading.encode()
+	assert.Equal(t, "test", out.Type)
+	assert.Equal(t, nil, out.GetValue())
+}

--- a/sdk/options_test.go
+++ b/sdk/options_test.go
@@ -1,1 +1,53 @@
 package sdk
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vapor-ware/synse-sdk/sdk/config"
+)
+
+// TestCustomDeviceIdentifier tests creating a PluginOption for a custom
+// device identifier.
+func TestCustomDeviceIdentifier(t *testing.T) {
+	opt := CustomDeviceIdentifier(
+		func(data map[string]interface{}) string {
+			return "foo"
+		},
+	)
+	ctx := PluginContext{}
+	assert.Nil(t, ctx.deviceIdentifier)
+
+	opt(&ctx)
+	assert.NotNil(t, ctx.deviceIdentifier)
+}
+
+// TestCustomDynamicDeviceRegistration tests creating a PluginOption for
+// a custom device registration function.
+func TestCustomDynamicDeviceRegistration(t *testing.T) {
+	opt := CustomDynamicDeviceRegistration(
+		func(data map[string]interface{}) ([]*Device, error) {
+			return []*Device{}, nil
+		},
+	)
+	ctx := PluginContext{}
+	assert.Nil(t, ctx.dynamicDeviceRegistrar)
+
+	opt(&ctx)
+	assert.NotNil(t, ctx.dynamicDeviceRegistrar)
+}
+
+// TestCustomDynamicDeviceConfigRegistration tests creating a PluginOption
+// for a custom device config registration function.
+func TestCustomDynamicDeviceConfigRegistration(t *testing.T) {
+	opt := CustomDynamicDeviceConfigRegistration(
+		func(data map[string]interface{}) ([]*config.DeviceConfig, error) {
+			return []*config.DeviceConfig{}, nil
+		},
+	)
+	ctx := PluginContext{}
+	assert.Nil(t, ctx.dynamicDeviceConfigRegistrar)
+
+	opt(&ctx)
+	assert.NotNil(t, ctx.dynamicDeviceConfigRegistrar)
+}

--- a/sdk/plugin.go
+++ b/sdk/plugin.go
@@ -220,7 +220,10 @@ func (plugin *Plugin) Run() (err error) {
 	// "Starting" steps **
 
 	// startDataManager
-	DataManager.init()
+	err = DataManager.run()
+	if err != nil {
+		return
+	}
 
 	// startServer
 	return plugin.server.Serve()

--- a/sdk/plugin_test.go
+++ b/sdk/plugin_test.go
@@ -1,357 +1,211 @@
 package sdk
 
-// File level global test configuration.
-//var testConfig = config.PluginConfig{
-//	SchemeVersion: config.SchemeVersion{
-//		Version: "1.0",
-//	},
-//	Network: &config.NetworkSettings{
-//		Type:    "tcp",
-//		Address: "test_config",
-//	},
-//	Settings: &config.PluginSettings{
-//		Read:        &config.ReadSettings{Buffer: 1024},
-//		Write:       &config.WriteSettings{Buffer: 1024},
-//		Transaction: &config.TransactionSettings{TTL: "2s"},
-//	},
-//}
+import (
+	"testing"
 
-//// TestNewPluginNilHandlers tests creating a new Plugin with nil handlers
-//func TestNewPluginNilHandlers(t *testing.T) {
-//	_, err := NewPlugin(nil, &testConfig)
-//	assert.Error(t, err)
-//}
-//
-//// TestNewPlugin tests creating a new Plugin with the required handlers defined.
-//func TestNewPlugin(t *testing.T) {
-//	// Create valid handlers for the Plugin.
-//	h, err := NewHandlers(testDeviceIdentifier, nil)
-//	assert.NoError(t, err)
-//
-//	// Create the plugin.
-//	p, err := NewPlugin(h, &testConfig)
-//	assert.NoError(t, err)
-//
-//	assert.Nil(t, p.server, "server should not be initialized with new plugin")
-//	assert.Nil(t, p.dataManager, "data manager should not be initialized with new plugin")
-//	assert.Nil(t, p.handlers.DeviceEnumerator)
-//
-//	assert.Equal(t, &h.DeviceIdentifier, &p.handlers.DeviceIdentifier)
-//	assert.NotNil(t, p.Config, "plugin should be configured on init")
-//}
-//
-//// TestNewPluginWithConfig tests creating a new Plugin and passing a valid
-//// config in as an argument.
-//func TestNewPluginWithConfig(t *testing.T) {
-//	// Create valid handlers for the Plugin.
-//	h, err := NewHandlers(testDeviceIdentifier, nil)
-//	assert.NoError(t, err)
-//
-//	// Create a configuration for the Plugin.
-//	c := config.PluginConfig{
-//		Version: "1.0",
-//		Network: config.NetworkSettings{
-//			Type:    "tcp",
-//			Address: ":666",
-//		},
-//	}
-//
-//	// Create the plugin.
-//	p, err := NewPlugin(h, &c)
-//	assert.NoError(t, err)
-//	assert.NotNil(t, p.Config, "plugin should be configured")
-//}
-//
-//// TestNewPluginWithIncompleteConfig tests creating a new Plugin and passing in
-//// an incomplete PluginConfig instance as an argument. The constructor should not
-//// return an error with a bad/incomplete config.
-//func TestNewPluginWithIncompleteConfig(t *testing.T) {
-//	// Create valid handlers for the Plugin.
-//	h, err := NewHandlers(testDeviceIdentifier, nil)
-//	assert.NoError(t, err)
-//
-//	// network spec missing but required
-//	c := config.PluginConfig{
-//		Version: "1.0",
-//	}
-//
-//	// Create the plugin.
-//	_, err = NewPlugin(h, &c)
-//	assert.NoError(t, err)
-//}
-//
-//// TestNewPluginNilConfig tests creating a new Plugin, passing in nil as the
-//// configuration. This should cause the plugin to search for plugin configuration
-//// files to load config from. Here we expect it to error out because it should
-//// not find a config file.
-//func TestNewPluginNilConfig(t *testing.T) {
-//	h, err := NewHandlers(testDeviceIdentifier, nil)
-//	assert.NoError(t, err)
-//
-//	// Create the plugin
-//	plugin, err := NewPlugin(h, nil)
-//	assert.Nil(t, plugin)
-//	assert.Error(t, err)
-//}
-//
-//// TestPlugin_RegisterDeviceHandlers tests registering device handlers when
-//// none are already registered.
-//func TestPlugin_RegisterDeviceHandlers(t *testing.T) {
-//	devHandler1 := DeviceHandler{Type: "test", Model: "model1"}
-//	devHandler2 := DeviceHandler{Type: "test", Model: "model2"}
-//
-//	plugin := Plugin{}
-//	assert.Nil(t, plugin.deviceHandlers)
-//
-//	plugin.RegisterDeviceHandlers(&devHandler1, &devHandler2)
-//
-//	assert.NotNil(t, plugin.deviceHandlers)
-//	assert.Equal(t, 2, len(plugin.deviceHandlers))
-//}
-//
-//// TestPlugin_RegisterDeviceHandlers tests registering device handlers when
-//// some are already registered.
-//func TestPlugin_RegisterDeviceHandlers2(t *testing.T) {
-//	devHandler1 := DeviceHandler{Type: "test", Model: "model1"}
-//	devHandler2 := DeviceHandler{Type: "test", Model: "model2"}
-//
-//	plugin := Plugin{}
-//	plugin.deviceHandlers = []*DeviceHandler{&devHandler1}
-//	assert.Equal(t, 1, len(plugin.deviceHandlers))
-//
-//	plugin.RegisterDeviceHandlers(&devHandler2)
-//
-//	assert.NotNil(t, plugin.deviceHandlers)
-//	assert.Equal(t, 2, len(plugin.deviceHandlers))
-//}
-//
-//// TestPlugin_RegisterDeviceSetupActions tests registering device setup actions for a filter
-//// when the device setup actions map doesn't exist.
-//func TestPlugin_RegisterDeviceSetupActions(t *testing.T) {
-//	plugin := Plugin{}
-//	setupFn := func(p *Plugin, d *Device) error { return nil }
-//
-//	assert.Nil(t, plugin.deviceSetupActions)
-//
-//	plugin.RegisterDeviceSetupActions("type=test", setupFn)
-//
-//	assert.NotNil(t, plugin.deviceSetupActions)
-//	assert.Equal(t, 1, len(plugin.deviceSetupActions))
-//	assert.Equal(t, 1, len(plugin.deviceSetupActions["type=test"]))
-//}
-//
-//// TestPlugin_RegisterDeviceSetupActions2 tests registering device setup actions for a filter
-//// when the device setup actions map does exist, but the filter does not already exist.
-//func TestPlugin_RegisterDeviceSetupActions2(t *testing.T) {
-//	plugin := Plugin{}
-//	plugin.deviceSetupActions = make(map[string][]deviceAction)
-//	setupFn := func(p *Plugin, d *Device) error { return nil }
-//
-//	assert.NotNil(t, plugin.deviceSetupActions)
-//
-//	plugin.RegisterDeviceSetupActions("type=test", setupFn)
-//
-//	assert.NotNil(t, plugin.deviceSetupActions)
-//	assert.Equal(t, 1, len(plugin.deviceSetupActions))
-//	assert.Equal(t, 1, len(plugin.deviceSetupActions["type=test"]))
-//}
-//
-//// TestPlugin_RegisterDeviceSetupActions3 tests registering device setup actions for a filter
-//// when the device setup actions map exists and the filter already exists in the map.
-//func TestPlugin_RegisterDeviceSetupActions3(t *testing.T) {
-//	plugin := Plugin{}
-//	setupFn1 := func(p *Plugin, d *Device) error { return nil }
-//	setupFn2 := func(p *Plugin, d *Device) error { return nil }
-//	plugin.deviceSetupActions = make(map[string][]deviceAction)
-//	plugin.deviceSetupActions["type=test"] = []deviceAction{setupFn1}
-//
-//	assert.NotNil(t, plugin.deviceSetupActions)
-//	assert.Equal(t, 1, len(plugin.deviceSetupActions))
-//	assert.Equal(t, 1, len(plugin.deviceSetupActions["type=test"]))
-//
-//	plugin.RegisterDeviceSetupActions("type=test", setupFn2)
-//
-//	assert.NotNil(t, plugin.deviceSetupActions)
-//	assert.Equal(t, 1, len(plugin.deviceSetupActions))
-//	assert.Equal(t, 2, len(plugin.deviceSetupActions["type=test"]))
-//}
-//
-//// TestPlugin_RegisterPostRunActions tests registering post run actions
-//// when none are already defined.
-//func TestPlugin_RegisterPostRunActions(t *testing.T) {
-//	action := func(p *Plugin) error { return nil }
-//	plugin := Plugin{}
-//	assert.Nil(t, plugin.postRunActions)
-//
-//	plugin.RegisterPostRunActions(action)
-//
-//	assert.NotNil(t, plugin.postRunActions)
-//	assert.Equal(t, 1, len(plugin.postRunActions))
-//}
-//
-//// TestPlugin_RegisterPostRunActions2 tests registering post run actions
-//// when some are already defined.
-//func TestPlugin_RegisterPostRunActions2(t *testing.T) {
-//	action1 := func(p *Plugin) error { return nil }
-//	action2 := func(p *Plugin) error { return nil }
-//	plugin := Plugin{}
-//
-//	plugin.postRunActions = []pluginAction{action1}
-//	assert.NotNil(t, plugin.postRunActions)
-//	assert.Equal(t, 1, len(plugin.postRunActions))
-//
-//	plugin.RegisterPostRunActions(action2)
-//
-//	assert.NotNil(t, plugin.postRunActions)
-//	assert.Equal(t, 2, len(plugin.postRunActions))
-//}
-//
-//// TestPlugin_RegisterPreRunActions tests registering pre run actions
-//// when none are already defined.
-//func TestPlugin_RegisterPreRunActions(t *testing.T) {
-//	action := func(p *Plugin) error { return nil }
-//	plugin := Plugin{}
-//	assert.Nil(t, plugin.preRunActions)
-//
-//	plugin.RegisterPreRunActions(action)
-//
-//	assert.NotNil(t, plugin.preRunActions)
-//	assert.Equal(t, 1, len(plugin.preRunActions))
-//}
-//
-//// TestPlugin_RegisterPreRunActions2 tests registering pre run actions
-//// when some are already defined.
-//func TestPlugin_RegisterPreRunActions2(t *testing.T) {
-//	action1 := func(p *Plugin) error { return nil }
-//	action2 := func(p *Plugin) error { return nil }
-//	plugin := Plugin{}
-//
-//	plugin.preRunActions = []pluginAction{action1}
-//	assert.NotNil(t, plugin.preRunActions)
-//	assert.Equal(t, 1, len(plugin.preRunActions))
-//
-//	plugin.RegisterPreRunActions(action2)
-//
-//	assert.NotNil(t, plugin.preRunActions)
-//	assert.Equal(t, 2, len(plugin.preRunActions))
-//
-//}
-//
-//// TestPlugin_logInfo tests logging out the plugin info.
-//func TestPlugin_logInfo(t *testing.T) {
-//	h, err := NewHandlers(testDeviceIdentifier, nil)
-//	assert.NoError(t, err)
-//
-//	// Create the plugin.
-//	p, err := NewPlugin(h, &testConfig)
-//	assert.NoError(t, err)
-//	assert.NotNil(t, p)
-//
-//	// Should not cause any kind of error
-//	p.logInfo()
-//}
-//
-//// TestPlugin_Configure tests configuring a Plugin using a config file
-//// specified via environment variable.
-//func TestPlugin_Configure(t *testing.T) {
-//	cfgFilePath := "tmp/config.yml"
-//	cfg := `
-//version: 1.0.0
-//debug: true
-//network:
-//  type: tcp
-//  address: ":50051"
-//settings:
-//  loop_delay: 100
-//  read:
-//    buffer_size: 150
-//  write:
-//    buffer_size: 150
-//    per_loop: 4
-//  transaction:
-//    ttl: 600s`
-//
-//	err := writeConfigFile(cfgFilePath, cfg)
-//	assert.NoError(t, err)
-//
-//	defer func() {
-//		err = os.RemoveAll("tmp")
-//		assert.NoError(t, err)
-//	}()
-//
-//	test.CheckErr(t, os.Setenv("PLUGIN_CONFIG", "tmp"))
-//
-//	// Create valid handlers for the Plugin.
-//	h, err := NewHandlers(testDeviceIdentifier, nil)
-//	assert.NoError(t, err)
-//
-//	// Create the plugin.
-//	p, err := NewPlugin(h, nil)
-//	assert.NoError(t, err)
-//
-//	assert.NotNil(t, p.Config, "plugin is not configured, but should be")
-//	assert.Equal(t, "1.0.0", p.Config.Version)
-//}
-//
-//// TestPlugin_setup tests setting up a Plugin successfully. This means that
-//// the state is validated, the devices are registered, and the Plugin components
-//// (server, data manager) are created.
-//func TestPlugin_setup(t *testing.T) {
-//	// Create valid handlers for the Plugin.
-//	h, err := NewHandlers(testDeviceIdentifier, testDeviceEnumerator)
-//	assert.NoError(t, err)
-//
-//	// Create the plugin.
-//	p, err := NewPlugin(h, &testConfig)
-//	assert.NoError(t, err)
-//
-//	// CONSIDER: Can we move setup functionality to the constructor?
-//	err = p.setup()
-//	assert.NoError(t, err)
-//
-//	assert.NotNil(t, p.server, "server should be initialized on setup")
-//	assert.NotNil(t, p.dataManager, "data manager should be initialized on setup")
-//}
-//
-//// TestPlugin_setup2 tests setting up a Plugin unsuccessfully. This means that
-//// the state is validated, the devices are registered, and the Plugin components
-//// (server, data manager) are created. In this case, handler validation should fail.
-//func TestPlugin_setup2(t *testing.T) {
-//	// Create invalid handlers for the plugin.
-//	h := Handlers{}
-//	p, err := NewPlugin(&h, &testConfig)
-//	assert.NoError(t, err)
-//
-//	err = p.setup()
-//	assert.Error(t, err)
-//}
-//
-//// TestPlugin_setup3 tests setting up a plugin unsuccessfully. It should fail
-//// setup validation due to a nil config.
-//func TestPlugin_setup3(t *testing.T) {
-//	h, err := NewHandlers(testDeviceIdentifier, testDeviceEnumerator)
-//	assert.NoError(t, err)
-//
-//	p := Plugin{
-//		handlers: h,
-//	}
-//
-//	err = p.setup()
-//	assert.Error(t, err)
-//}
-//
-//// TestPlugin_setup4 tests setting up a plugin unsuccessfully. It should fail
-//// setup validation due to a bad configuration.
-//func TestPlugin_setup4(t *testing.T) {
-//	h, err := NewHandlers(testDeviceIdentifier, testDeviceEnumerator)
-//	assert.NoError(t, err)
-//
-//	p, err := NewPlugin(h, &testConfig)
-//	assert.NoError(t, err)
-//
-//	// make the plugin config bad
-//	p.Config.Settings.Transaction.TTL = "foo"
-//
-//	err = p.setup()
-//	assert.Error(t, err)
-//}
+	"github.com/stretchr/testify/assert"
+	"github.com/vapor-ware/synse-sdk/sdk/config"
+	"github.com/vapor-ware/synse-sdk/sdk/policies"
+)
+
+// TestNewPlugin tests creating a new plugin.
+func TestNewPlugin(t *testing.T) {
+	var testTable = []struct {
+		desc    string
+		options []PluginOption
+	}{
+		{
+			desc:    "no plugin options",
+			options: []PluginOption{},
+		},
+		{
+			desc: "one options",
+			options: []PluginOption{
+				CustomDeviceIdentifier(func(i map[string]interface{}) string {
+					return "test"
+				}),
+			},
+		},
+		{
+			desc: "multiple options",
+			options: []PluginOption{
+				CustomDeviceIdentifier(func(i map[string]interface{}) string {
+					return "test"
+				}),
+				CustomDynamicDeviceRegistration(func(i map[string]interface{}) ([]*Device, error) {
+					return nil, nil
+				}),
+			},
+		},
+		{
+			desc: "duplicate options",
+			options: []PluginOption{
+				CustomDeviceIdentifier(func(i map[string]interface{}) string {
+					return "foo"
+				}),
+				CustomDeviceIdentifier(func(i map[string]interface{}) string {
+					return "bar"
+				}),
+			},
+		},
+	}
+
+	for _, testCase := range testTable {
+		plugin := NewPlugin(testCase.options...)
+		assert.NotNil(t, plugin)
+	}
+}
+
+// TestPlugin_SetConfigPolicies tests setting the config policies for the plugin.
+func TestPlugin_SetConfigPolicies(t *testing.T) {
+	plugin := NewPlugin()
+	plugin.SetConfigPolicies(
+		policies.DeviceConfigOptional,
+		policies.PluginConfigRequired,
+	)
+	assert.Equal(t, 2, len(plugin.policies))
+}
+
+// TestPlugin_RegisterOutputTypes tests registering the output types for the plugin.
+func TestPlugin_RegisterOutputTypes(t *testing.T) {
+	defer func() {
+		outputTypeMap = map[string]*config.OutputType{}
+	}()
+
+	types := []*config.OutputType{
+		{Name: "foo"},
+		{Name: "bar"},
+		{Name: "baz"},
+	}
+	plugin := NewPlugin()
+	assert.Equal(t, 0, len(outputTypeMap))
+
+	err := plugin.RegisterOutputTypes(types...)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(outputTypeMap))
+}
+
+// TestPlugin_RegisterOutputTypesError tests registering the output types for the
+// plugin when duplicate types are specified.
+func TestPlugin_RegisterOutputTypesError(t *testing.T) {
+	defer func() {
+		outputTypeMap = map[string]*config.OutputType{}
+	}()
+
+	types := []*config.OutputType{
+		{Name: "foo"},
+		{Name: "bar"},
+		{Name: "foo"},
+	}
+	plugin := NewPlugin()
+	assert.Equal(t, 0, len(outputTypeMap))
+
+	err := plugin.RegisterOutputTypes(types...)
+	assert.Error(t, err)
+	assert.True(t, len(outputTypeMap) > 0)
+}
+
+// TestPlugin_RegisterPreRunActions tests registering pre-run actions.
+func TestPlugin_RegisterPreRunActions(t *testing.T) {
+	defer func() {
+		preRunActions = []pluginAction{}
+	}()
+
+	actions := []pluginAction{
+		func(_ *Plugin) error { return nil },
+		func(_ *Plugin) error { return nil },
+		func(_ *Plugin) error { return nil },
+	}
+
+	plugin := NewPlugin()
+
+	assert.Equal(t, 0, len(preRunActions))
+	plugin.RegisterPreRunActions(actions...)
+	assert.Equal(t, 3, len(preRunActions))
+}
+
+// TestPlugin_RegisterPostRunActions tests registering post-run actions.
+func TestPlugin_RegisterPostRunActions(t *testing.T) {
+	defer func() {
+		postRunActions = []pluginAction{}
+	}()
+
+	actions := []pluginAction{
+		func(_ *Plugin) error { return nil },
+		func(_ *Plugin) error { return nil },
+		func(_ *Plugin) error { return nil },
+	}
+
+	plugin := NewPlugin()
+
+	assert.Equal(t, 0, len(postRunActions))
+	plugin.RegisterPostRunActions(actions...)
+	assert.Equal(t, 3, len(postRunActions))
+}
+
+// TestPlugin_RegisterDeviceSetupActions tests registering device setup actions.
+func TestPlugin_RegisterDeviceSetupActions(t *testing.T) {
+	defer func() {
+		deviceSetupActions = map[string][]deviceAction{}
+	}()
+
+	action := func(_ *Plugin, _ *Device) error { return nil }
+
+	plugin := NewPlugin()
+
+	assert.Equal(t, 0, len(deviceSetupActions))
+	plugin.RegisterDeviceSetupActions("kind=test", action, action, action)
+	assert.Equal(t, 1, len(deviceSetupActions))
+	assert.Equal(t, 3, len(deviceSetupActions["kind=test"]))
+}
+
+// TestPlugin_RegisterDeviceSetupActions2 tests registering device setup actions when
+// some already exist.
+func TestPlugin_RegisterDeviceSetupActions2(t *testing.T) {
+	defer func() {
+		deviceSetupActions = map[string][]deviceAction{}
+	}()
+
+	action := func(_ *Plugin, _ *Device) error { return nil }
+
+	// add something to the device setup actions to start with
+	deviceSetupActions["kind=test"] = []deviceAction{action}
+
+	plugin := NewPlugin()
+
+	assert.Equal(t, 1, len(deviceSetupActions))
+	plugin.RegisterDeviceSetupActions("kind=test", action)
+	assert.Equal(t, 1, len(deviceSetupActions))
+	assert.Equal(t, 2, len(deviceSetupActions["kind=test"]))
+}
+
+// TestPlugin_RegisterDeviceHandlers tests registering DeviceHandlers with the plugin.
+func TestPlugin_RegisterDeviceHandlers(t *testing.T) {
+	defer func() {
+		deviceHandlers = []*DeviceHandler{}
+	}()
+
+	fooHandler := &DeviceHandler{Name: "foo"}
+	barHandler := &DeviceHandler{Name: "bar"}
+
+	plugin := NewPlugin()
+
+	assert.Equal(t, 0, len(deviceHandlers))
+	plugin.RegisterDeviceHandlers(fooHandler, barHandler)
+	assert.Equal(t, 2, len(deviceHandlers))
+}
+
+// TestPlugin_logStartupInfo tests logging out info which is done on startup.
+// There isn't much to check here other than it runs and completes without
+// any issues.
+func TestPlugin_logStartupInfo(t *testing.T) {
+	plugin := NewPlugin()
+	plugin.logStartupInfo()
+}
+
+// TestPlugin_resolveFlags tests resolving flags. In this case, no flags are
+// set, so it should ultimately do nothing.
+func TestPlugin_resolveFlags(t *testing.T) {
+	plugin := NewPlugin()
+	plugin.resolveFlags()
+}

--- a/sdk/plugin_test.go
+++ b/sdk/plugin_test.go
@@ -1,24 +1,20 @@
 package sdk
 
-import (
-	"github.com/vapor-ware/synse-sdk/sdk/config"
-)
-
 // File level global test configuration.
-var testConfig = config.PluginConfig{
-	ConfigVersion: config.ConfigVersion{
-		Version: "1.0",
-	},
-	Network: &config.NetworkSettings{
-		Type:    "tcp",
-		Address: "test_config",
-	},
-	Settings: &config.PluginSettings{
-		Read:        &config.ReadSettings{Buffer: 1024},
-		Write:       &config.WriteSettings{Buffer: 1024},
-		Transaction: &config.TransactionSettings{TTL: "2s"},
-	},
-}
+//var testConfig = config.PluginConfig{
+//	SchemeVersion: config.SchemeVersion{
+//		Version: "1.0",
+//	},
+//	Network: &config.NetworkSettings{
+//		Type:    "tcp",
+//		Address: "test_config",
+//	},
+//	Settings: &config.PluginSettings{
+//		Read:        &config.ReadSettings{Buffer: 1024},
+//		Write:       &config.WriteSettings{Buffer: 1024},
+//		Transaction: &config.TransactionSettings{TTL: "2s"},
+//	},
+//}
 
 //// TestNewPluginNilHandlers tests creating a new Plugin with nil handlers
 //func TestNewPluginNilHandlers(t *testing.T) {

--- a/sdk/server_test.go
+++ b/sdk/server_test.go
@@ -1,9 +1,14 @@
 package sdk
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/vapor-ware/synse-sdk/internal/test"
+	"github.com/vapor-ware/synse-sdk/sdk/config"
+	"github.com/vapor-ware/synse-server-grpc/go"
 )
 
 // TestNewServer tests that a Server is returned when the constructor
@@ -15,91 +20,881 @@ func TestNewServer(t *testing.T) {
 	assert.Equal(t, "bar", s.address)
 }
 
+// TestServer_setup_TCP tests successfully setting up the server in TCP mode.
+func TestServer_setup_TCP(t *testing.T) {
+	defer func() {
+		postRunActions = []pluginAction{}
+	}()
+
+	s := NewServer(modeTCP, "test")
+	err := s.setup()
+	assert.NoError(t, err)
+}
+
+// TestServer_setup_Unix tests successfully setting up the server in Unix mode.
+func TestServer_setup_Unix(t *testing.T) {
+	defer func() {
+		postRunActions = []pluginAction{}
+	}()
+
+	// Set up a temporary directory for test data.
+	test.SetupTestDir(t)
+	defer test.ClearTestDir(t)
+
+	sockPath = test.TempDir
+
+	// first, check that there are no post-run actions
+	assert.Equal(t, 0, len(postRunActions))
+
+	s := NewServer(modeUnix, "test")
+	err := s.setup()
+	assert.NoError(t, err)
+
+	// now, there should be one post run action
+	assert.Equal(t, 1, len(postRunActions))
+}
+
+// TestServer_setup_Unknown tests successfully setting up the server in an unknown mode.
+func TestServer_setup_Unknown(t *testing.T) {
+	defer func() {
+		postRunActions = []pluginAction{}
+	}()
+
+	s := NewServer("foo", "test")
+	err := s.setup()
+	assert.Error(t, err)
+}
+
+// TestServer_cleanup_TCP tests cleaning up the server in TCP mode.
+func TestServer_cleanup_TCP(t *testing.T) {
+	s := NewServer(modeTCP, "test")
+	err := s.cleanup()
+	assert.NoError(t, err)
+}
+
+// TestServer_cleanup_Unix tests cleaning up the server in Unix mode.
+func TestServer_cleanup_Unix(t *testing.T) {
+	s := NewServer(modeUnix, "test")
+	err := s.cleanup()
+	assert.NoError(t, err)
+}
+
+// TestServer_cleanup_Unknown tests cleaning up the server in an unknown mode.
+func TestServer_cleanup_Unknown(t *testing.T) {
+	s := NewServer("foo", "test")
+	err := s.cleanup()
+	assert.Error(t, err)
+}
+
+// TestServer_Test tests the Test method of the gRPC plugin service.
+func TestServer_Test(t *testing.T) {
+	s := Server{}
+	req := &synse.Empty{}
+	resp, err := s.Test(context.Background(), req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, true, resp.Ok)
+}
+
+// TestServer_Version tests the Version method of the gRPC plugin service.
+func TestServer_Version(t *testing.T) {
+	s := Server{}
+	req := &synse.Empty{}
+	resp, err := s.Version(context.Background(), req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, Version.Arch, resp.Arch)
+	assert.Equal(t, Version.OS, resp.Os)
+	assert.Equal(t, Version.SDKVersion, resp.SdkVersion)
+	assert.Equal(t, Version.BuildDate, resp.BuildDate)
+	assert.Equal(t, Version.GitCommit, resp.GitCommit)
+	assert.Equal(t, Version.GitTag, resp.GitTag)
+	assert.Equal(t, Version.PluginVersion, resp.PluginVersion)
+}
+
+// TODO - implement health checks
+//func TestServer_Health(t *testing.T) {
 //
-//// TestSetupSocket tests setting up the socket when the socket path
-//// already exists.
-//func TestSetupSocket(t *testing.T) {
-//	// Set up a temporary directory for testing
-//	dir, err := ioutil.TempDir("", "testing")
-//	assert.NoError(t, err)
-//	defer func() {
-//		test.CheckErr(t, os.RemoveAll(dir))
-//	}()
-//
-//	// Set the socket path to the temp dir for the test
-//	sockPath = dir
-//
-//	sock, err := setupSocket("test.sock")
-//	if err != nil {
-//		t.Error(err)
-//	}
-//
-//	// Verify the socket path+name
-//	assert.Equal(t, filepath.Join(dir, "test.sock"), sock)
-//
-//	// Verify that the socket path exists
-//	_, err = os.Stat(sockPath)
-//	assert.NoError(t, err)
 //}
-//
-//// TestSetupSocket2 tests setting up the socket when the socket path
-//// does not already exists.
-//func TestSetupSocket2(t *testing.T) {
-//	// Set up a temporary directory for testing
-//	dir, err := ioutil.TempDir("", "testing")
-//	assert.NoError(t, err)
-//	// remove the temp dir now - it shouldn't exist when we set up the socket
-//	test.CheckErr(t, os.RemoveAll(dir))
-//
-//	// Set the socket path to the temp dir for the test
-//	sockPath = dir
-//
-//	sock, err := setupSocket("test.sock")
-//	if err != nil {
-//		t.Error(err)
-//	}
-//
-//	// Verify the socket path+name
-//	assert.Equal(t, filepath.Join(dir, "test.sock"), sock)
-//
-//	// Verify that the socket path exists
-//	_, err = os.Stat(sockPath)
-//	assert.NoError(t, err)
-//}
-//
-//// TestSetupSocket2 tests setting up the socket when the socket path
-//// and the socket itself already exist.
-//func TestSetupSocket3(t *testing.T) {
-//	// Set up a temporary directory for testing
-//	dir, err := ioutil.TempDir("", "testing")
-//	assert.NoError(t, err)
-//	defer func() {
-//		test.CheckErr(t, os.RemoveAll(dir))
-//	}()
-//
-//	// Set the socket path to the temp dir for the test
-//	sockPath = dir
-//
-//	// Make the socket file
-//	filename := filepath.Join(dir, "test.sock")
-//	_, err = os.Create(filename)
-//	assert.NoError(t, err)
-//
-//	sock, err := setupSocket("test.sock")
-//	if err != nil {
-//		t.Error(err)
-//	}
-//
-//	// Verify the socket path+name
-//	assert.Equal(t, filepath.Join(dir, "test.sock"), sock)
-//
-//	// Verify that the socket path exists
-//	_, err = os.Stat(sockPath)
-//	assert.NoError(t, err)
-//
-//	// Verify that the socket itself no longer exists (setupSocket cleans
-//	// up old socket instances)
-//	_, err = os.Stat(filename)
-//	exists := !os.IsNotExist(err)
-//	assert.False(t, exists, "socket should no longer exist, but still does")
-//}
+
+// TestServer_Capabilities tests the Capabilities method of the gRPC plugin service.
+func TestServer_Capabilities(t *testing.T) {
+	s := Server{}
+	req := &synse.Empty{}
+	mock := test.NewMockCapabilitiesStream()
+	err := s.Capabilities(req, mock)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(mock.Results))
+}
+
+// TestServer_Capabilities2 tests the Capabilities method of the gRPC plugin service
+// when there are actual devices to get capabilities from.
+func TestServer_Capabilities2(t *testing.T) {
+	defer func() {
+		deviceMap = map[string]*Device{}
+	}()
+	deviceMap["foo"] = &Device{
+		Kind: "foo",
+		Outputs: []*Output{
+			{OutputType: config.OutputType{Name: "output1"}},
+			{OutputType: config.OutputType{Name: "output2"}},
+		},
+	}
+	deviceMap["bar"] = &Device{
+		Kind: "bar",
+		Outputs: []*Output{
+			{OutputType: config.OutputType{Name: "output3"}},
+		},
+	}
+
+	s := Server{}
+	req := &synse.Empty{}
+	mock := test.NewMockCapabilitiesStream()
+	err := s.Capabilities(req, mock)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(mock.Results))
+	assert.Equal(t, 2, len(mock.Results["foo"].GetOutputs()))
+	assert.Equal(t, 1, len(mock.Results["bar"].GetOutputs()))
+}
+
+// TestServer_Capabilities3 tests the Capabilities method of the gRPC plugin service
+// when there is an error returned.
+func TestServer_Capabilities3(t *testing.T) {
+	defer func() {
+		deviceMap = map[string]*Device{}
+	}()
+	deviceMap["foo"] = &Device{
+		Kind: "foo",
+		Outputs: []*Output{
+			{OutputType: config.OutputType{Name: "output1"}},
+			{OutputType: config.OutputType{Name: "output2"}},
+		},
+	}
+	deviceMap["bar"] = &Device{
+		Kind: "bar",
+		Outputs: []*Output{
+			{OutputType: config.OutputType{Name: "output3"}},
+		},
+	}
+
+	s := Server{}
+	req := &synse.Empty{}
+	mock := &test.MockCapabilitiesStreamErr{}
+	err := s.Capabilities(req, mock)
+
+	assert.Error(t, err)
+}
+
+// TestServer_Devices tests the Devices method of the gRPC plugin service.
+func TestServer_Devices(t *testing.T) {
+	s := Server{}
+	req := &synse.DeviceFilter{}
+	mock := test.NewMockDevicesStream()
+	err := s.Devices(req, mock)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(mock.Results))
+}
+
+// TestServer_Devices_NoFilter tests the Devices method of the gRPC plugin service when
+// there are devices to get.
+func TestServer_Devices_NoFilter(t *testing.T) {
+	defer func() {
+		deviceMap = map[string]*Device{}
+	}()
+	foo := &Device{
+		Kind: "foo",
+		Location: &Location{
+			Rack:  "rack-1",
+			Board: "board-1",
+		},
+		Outputs: []*Output{
+			{OutputType: config.OutputType{Name: "output1"}},
+			{OutputType: config.OutputType{Name: "output2"}},
+		},
+	}
+	bar := &Device{
+		Kind: "bar",
+		Location: &Location{
+			Rack:  "rack-1",
+			Board: "board-2",
+		},
+		Outputs: []*Output{
+			{OutputType: config.OutputType{Name: "output3"}},
+		},
+	}
+	baz := &Device{
+		Kind: "baz",
+		Location: &Location{
+			Rack:  "rack-2",
+			Board: "board-1",
+		},
+		Outputs: []*Output{
+			{OutputType: config.OutputType{Name: "output4"}},
+		},
+	}
+
+	deviceMap["foo"] = foo
+	deviceMap["bar"] = bar
+	deviceMap["baz"] = baz
+
+	s := Server{}
+	req := &synse.DeviceFilter{}
+	mock := test.NewMockDevicesStream()
+	err := s.Devices(req, mock)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(mock.Results))
+	assert.NotNil(t, mock.Results[foo.ID()])
+	assert.NotNil(t, mock.Results[bar.ID()])
+	assert.NotNil(t, mock.Results[baz.ID()])
+}
+
+// TestServer_Devices_FilterRack tests the Devices method of the gRPC plugin service when
+// there are devices to get, and we filter on rack.
+func TestServer_Devices_FilterRack(t *testing.T) {
+	defer func() {
+		deviceMap = map[string]*Device{}
+	}()
+	foo := &Device{
+		Kind: "foo",
+		Location: &Location{
+			Rack:  "rack-1",
+			Board: "board-1",
+		},
+		Outputs: []*Output{
+			{OutputType: config.OutputType{Name: "output1"}},
+			{OutputType: config.OutputType{Name: "output2"}},
+		},
+	}
+	bar := &Device{
+		Kind: "bar",
+		Location: &Location{
+			Rack:  "rack-1",
+			Board: "board-2",
+		},
+		Outputs: []*Output{
+			{OutputType: config.OutputType{Name: "output3"}},
+		},
+	}
+	baz := &Device{
+		Kind: "baz",
+		Location: &Location{
+			Rack:  "rack-2",
+			Board: "board-1",
+		},
+		Outputs: []*Output{
+			{OutputType: config.OutputType{Name: "output4"}},
+		},
+	}
+
+	deviceMap["foo"] = foo
+	deviceMap["bar"] = bar
+	deviceMap["baz"] = baz
+
+	s := Server{}
+	req := &synse.DeviceFilter{
+		Rack: "rack-1",
+	}
+	mock := test.NewMockDevicesStream()
+	err := s.Devices(req, mock)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(mock.Results))
+	assert.NotNil(t, mock.Results[foo.ID()])
+	assert.NotNil(t, mock.Results[bar.ID()])
+	assert.Nil(t, mock.Results[baz.ID()])
+}
+
+// TestServer_Devices_FilterBoard tests the Devices method of the gRPC plugin service when
+// there are devices to get, and we filter on board.
+func TestServer_Devices_FilterBoard(t *testing.T) {
+	defer func() {
+		deviceMap = map[string]*Device{}
+	}()
+	foo := &Device{
+		Kind: "foo",
+		Location: &Location{
+			Rack:  "rack-1",
+			Board: "board-1",
+		},
+		Outputs: []*Output{
+			{OutputType: config.OutputType{Name: "output1"}},
+			{OutputType: config.OutputType{Name: "output2"}},
+		},
+	}
+	bar := &Device{
+		Kind: "bar",
+		Location: &Location{
+			Rack:  "rack-1",
+			Board: "board-2",
+		},
+		Outputs: []*Output{
+			{OutputType: config.OutputType{Name: "output3"}},
+		},
+	}
+	baz := &Device{
+		Kind: "baz",
+		Location: &Location{
+			Rack:  "rack-2",
+			Board: "board-1",
+		},
+		Outputs: []*Output{
+			{OutputType: config.OutputType{Name: "output4"}},
+		},
+	}
+
+	deviceMap["foo"] = foo
+	deviceMap["bar"] = bar
+	deviceMap["baz"] = baz
+
+	s := Server{}
+	req := &synse.DeviceFilter{
+		Rack:  "rack-1",
+		Board: "board-1",
+	}
+	mock := test.NewMockDevicesStream()
+	err := s.Devices(req, mock)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(mock.Results))
+	assert.NotNil(t, mock.Results[foo.ID()])
+	assert.Nil(t, mock.Results[bar.ID()])
+	assert.Nil(t, mock.Results[baz.ID()])
+}
+
+// TestServer_Devices_FilterNoMatch tests the Devices method of the gRPC plugin service when
+// there are devices to get, but the filter does not match any of them.
+func TestServer_Devices_FilterNoMatch(t *testing.T) {
+	defer func() {
+		deviceMap = map[string]*Device{}
+	}()
+	foo := &Device{
+		Kind: "foo",
+		Location: &Location{
+			Rack:  "rack-1",
+			Board: "board-1",
+		},
+		Outputs: []*Output{
+			{OutputType: config.OutputType{Name: "output1"}},
+			{OutputType: config.OutputType{Name: "output2"}},
+		},
+	}
+	bar := &Device{
+		Kind: "bar",
+		Location: &Location{
+			Rack:  "rack-1",
+			Board: "board-2",
+		},
+		Outputs: []*Output{
+			{OutputType: config.OutputType{Name: "output3"}},
+		},
+	}
+	baz := &Device{
+		Kind: "baz",
+		Location: &Location{
+			Rack:  "rack-2",
+			Board: "board-1",
+		},
+		Outputs: []*Output{
+			{OutputType: config.OutputType{Name: "output4"}},
+		},
+	}
+
+	deviceMap["foo"] = foo
+	deviceMap["bar"] = bar
+	deviceMap["baz"] = baz
+
+	s := Server{}
+	req := &synse.DeviceFilter{
+		Rack: "rack-3",
+	}
+	mock := test.NewMockDevicesStream()
+	err := s.Devices(req, mock)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(mock.Results))
+	assert.Nil(t, mock.Results[foo.ID()])
+	assert.Nil(t, mock.Results[bar.ID()])
+	assert.Nil(t, mock.Results[baz.ID()])
+}
+
+// TestServer_Devices_FilterDevice tests the Devices method of the gRPC plugin service when
+// there are devices to get, and we filter on device. We disallow filtering on device.
+func TestServer_Devices_FilterDevice(t *testing.T) {
+	s := Server{}
+	req := &synse.DeviceFilter{
+		Rack:   "rack-1",
+		Board:  "board-1",
+		Device: "device-1",
+	}
+	mock := test.NewMockDevicesStream()
+	err := s.Devices(req, mock)
+
+	assert.Error(t, err)
+	assert.Equal(t, 0, len(mock.Results))
+}
+
+// TestServer_Devices_Error tests the Devices method of the gRPC plugin service when
+// an error is returned because a device is specified.
+func TestServer_Devices_Error(t *testing.T) {
+	defer func() {
+		deviceMap = map[string]*Device{}
+	}()
+	foo := &Device{
+		Kind: "foo",
+		Location: &Location{
+			Rack:  "rack-1",
+			Board: "board-1",
+		},
+		Outputs: []*Output{
+			{OutputType: config.OutputType{Name: "output1"}},
+			{OutputType: config.OutputType{Name: "output2"}},
+		},
+	}
+	bar := &Device{
+		Kind: "bar",
+		Location: &Location{
+			Rack:  "rack-1",
+			Board: "board-2",
+		},
+		Outputs: []*Output{
+			{OutputType: config.OutputType{Name: "output3"}},
+		},
+	}
+	baz := &Device{
+		Kind: "baz",
+		Location: &Location{
+			Rack:  "rack-2",
+			Board: "board-1",
+		},
+		Outputs: []*Output{
+			{OutputType: config.OutputType{Name: "output4"}},
+		},
+	}
+
+	deviceMap["foo"] = foo
+	deviceMap["bar"] = bar
+	deviceMap["baz"] = baz
+
+	s := Server{}
+	req := &synse.DeviceFilter{
+		Rack:  "rack-1",
+		Board: "board-1",
+	}
+	mock := &test.MockDevicesStreamErr{}
+	err := s.Devices(req, mock)
+
+	assert.Error(t, err)
+}
+
+// TestServer_Devices_Error2 tests the Devices method of the gRPC plugin service when
+// an error is returned because a board is specified with no rack.
+func TestServer_Devices_Error2(t *testing.T) {
+	s := Server{}
+	req := &synse.DeviceFilter{
+		Board: "board",
+	}
+	mock := &test.MockDevicesStreamErr{}
+	err := s.Devices(req, mock)
+
+	assert.Error(t, err)
+}
+
+// TestServer_Metainfo tests the Metainfo method of the gRPC plugin service.
+func TestServer_Metainfo(t *testing.T) {
+	s := Server{}
+	req := &synse.Empty{}
+	resp, err := s.Metainfo(context.Background(), req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, metainfo.Name, resp.GetName())
+	assert.Equal(t, metainfo.Maintainer, resp.GetMaintainer())
+	assert.Equal(t, metainfo.Description, resp.GetDescription())
+	assert.Equal(t, metainfo.VCS, resp.GetVcs())
+
+	version := resp.GetVersion()
+	assert.Equal(t, Version.Arch, version.Arch)
+	assert.Equal(t, Version.OS, version.Os)
+	assert.Equal(t, Version.SDKVersion, version.SdkVersion)
+	assert.Equal(t, Version.BuildDate, version.BuildDate)
+	assert.Equal(t, Version.GitCommit, version.GitCommit)
+	assert.Equal(t, Version.GitTag, version.GitTag)
+	assert.Equal(t, Version.PluginVersion, version.PluginVersion)
+}
+
+// TestServer_Read tests the Read method of the gRPC plugin service.
+func TestServer_Read(t *testing.T) {
+	defer func() {
+		DataManager = newDataManager()
+		deviceMap = map[string]*Device{}
+		PluginConfig = &config.PluginConfig{}
+	}()
+	PluginConfig = &config.PluginConfig{
+		Settings: &config.PluginSettings{
+			Read: &config.ReadSettings{
+				Enabled: true,
+			},
+		},
+	}
+	deviceMap["rack-board-device"] = &Device{
+		id:   "device",
+		Kind: "foo",
+		Location: &Location{
+			Rack:  "rack",
+			Board: "board",
+		},
+		Outputs: []*Output{
+			{OutputType: config.OutputType{Name: "output1"}},
+			{OutputType: config.OutputType{Name: "output2"}},
+		},
+		Handler: &DeviceHandler{
+			Read: func(device *Device) ([]*Reading, error) {
+				return nil, nil
+			},
+		},
+	}
+	DataManager.readings["rack-board-device"] = []*Reading{
+		{
+			Timestamp: "now",
+			Type:      "temperature",
+			Value:     3,
+		},
+		{
+			Timestamp: "now",
+			Type:      "humidity",
+			Value:     5,
+		},
+	}
+
+	s := Server{}
+	req := &synse.DeviceFilter{
+		Rack:   "rack",
+		Board:  "board",
+		Device: "device",
+	}
+	mock := test.NewMockReadStream()
+	err := s.Read(req, mock)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(mock.Results))
+}
+
+// TestServer_Read2 tests the Read method of the gRPC plugin service when
+// the filter does not match anything.
+func TestServer_Read2(t *testing.T) {
+	s := Server{}
+	req := &synse.DeviceFilter{
+		Rack:   "rack",
+		Board:  "board",
+		Device: "device",
+	}
+	mock := test.NewMockReadStream()
+	err := s.Read(req, mock)
+
+	assert.Error(t, err)
+	assert.Equal(t, 0, len(mock.Results))
+}
+
+// TestServer_Read3 tests the Read method of the gRPC plugin service when
+// sending to the stream results in error.
+func TestServer_Read3(t *testing.T) {
+	defer func() {
+		DataManager = newDataManager()
+		deviceMap = map[string]*Device{}
+		PluginConfig = &config.PluginConfig{}
+	}()
+	PluginConfig = &config.PluginConfig{
+		Settings: &config.PluginSettings{
+			Read: &config.ReadSettings{
+				Enabled: true,
+			},
+		},
+	}
+	deviceMap["rack-board-device"] = &Device{
+		id:   "device",
+		Kind: "foo",
+		Location: &Location{
+			Rack:  "rack",
+			Board: "board",
+		},
+		Outputs: []*Output{
+			{OutputType: config.OutputType{Name: "output1"}},
+			{OutputType: config.OutputType{Name: "output2"}},
+		},
+		Handler: &DeviceHandler{
+			Read: func(device *Device) ([]*Reading, error) {
+				return nil, nil
+			},
+		},
+	}
+	DataManager.readings["rack-board-device"] = []*Reading{
+		{
+			Timestamp: "now",
+			Type:      "temperature",
+			Value:     3,
+		},
+		{
+			Timestamp: "now",
+			Type:      "humidity",
+			Value:     5,
+		},
+	}
+
+	s := Server{}
+	req := &synse.DeviceFilter{
+		Rack:   "rack",
+		Board:  "board",
+		Device: "device",
+	}
+	mock := &test.MockReadStreamErr{}
+	err := s.Read(req, mock)
+
+	assert.Error(t, err)
+}
+
+// TestServer_Read4 tests the Read method of the gRPC plugin service when
+// a bad device filter is specified.
+func TestServer_Read4(t *testing.T) {
+	s := Server{}
+	req := &synse.DeviceFilter{ // missing device to read
+		Rack:  "rack",
+		Board: "board",
+	}
+	mock := test.NewMockReadStream()
+	err := s.Read(req, mock)
+
+	assert.Error(t, err)
+}
+
+// TestServer_Write tests the Write method of the gRPC plugin service when
+// the specified device isn't found.
+func TestServer_Write(t *testing.T) {
+	s := Server{}
+	req := &synse.WriteInfo{
+		DeviceFilter: &synse.DeviceFilter{
+			Rack:   "rack",
+			Board:  "board",
+			Device: "device",
+		},
+		Data: []*synse.WriteData{
+			{Action: "test"},
+		},
+	}
+	resp, err := s.Write(context.Background(), req)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+// TestServer_Write2 tests the Write method of the gRPC plugin service
+// when a bad device filter is specified.
+func TestServer_Write2(t *testing.T) {
+	s := Server{}
+	req := &synse.WriteInfo{
+		DeviceFilter: &synse.DeviceFilter{ // missing device
+			Rack:  "rack",
+			Board: "board",
+		},
+		Data: []*synse.WriteData{
+			{Action: "test"},
+		},
+	}
+	resp, err := s.Write(context.Background(), req)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+// TestServer_Write3 tests the Write method of the gRPC plugin service when
+// there is only one WriteData specified.
+func TestServer_Write3(t *testing.T) {
+	setupTransactionCache(time.Duration(600) * time.Second)
+	defer func() {
+		deviceMap = map[string]*Device{}
+		PluginConfig = &config.PluginConfig{}
+		DataManager = newDataManager()
+	}()
+	DataManager.writeChannel = make(chan *WriteContext, 20)
+	PluginConfig = &config.PluginConfig{
+		Settings: &config.PluginSettings{
+			Write: &config.WriteSettings{
+				Enabled: true,
+			},
+		},
+	}
+	deviceMap["rack-board-device"] = &Device{
+		id:   "device",
+		Kind: "foo",
+		Location: &Location{
+			Rack:  "rack",
+			Board: "board",
+		},
+		Outputs: []*Output{
+			{OutputType: config.OutputType{Name: "output1"}},
+			{OutputType: config.OutputType{Name: "output2"}},
+		},
+		Handler: &DeviceHandler{
+			Write: func(device *Device, data *WriteData) error {
+				return nil
+			},
+		},
+	}
+
+	s := Server{}
+	req := &synse.WriteInfo{
+		DeviceFilter: &synse.DeviceFilter{
+			Rack:   "rack",
+			Board:  "board",
+			Device: "device",
+		},
+		Data: []*synse.WriteData{
+			{Action: "test"},
+		},
+	}
+	resp, err := s.Write(context.Background(), req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(resp.Transactions))
+}
+
+// TestServer_Write4 tests the Write method of the gRPC plugin service when
+// there are multiple write data specified.
+func TestServer_Write4(t *testing.T) {
+	setupTransactionCache(time.Duration(600) * time.Second)
+	defer func() {
+		deviceMap = map[string]*Device{}
+		PluginConfig = &config.PluginConfig{}
+		DataManager = newDataManager()
+	}()
+	DataManager.writeChannel = make(chan *WriteContext, 20)
+	PluginConfig = &config.PluginConfig{
+		Settings: &config.PluginSettings{
+			Write: &config.WriteSettings{
+				Enabled: true,
+			},
+		},
+	}
+	deviceMap["rack-board-device"] = &Device{
+		id:   "device",
+		Kind: "foo",
+		Location: &Location{
+			Rack:  "rack",
+			Board: "board",
+		},
+		Outputs: []*Output{
+			{OutputType: config.OutputType{Name: "output1"}},
+			{OutputType: config.OutputType{Name: "output2"}},
+		},
+		Handler: &DeviceHandler{
+			Write: func(device *Device, data *WriteData) error {
+				return nil
+			},
+		},
+	}
+
+	s := Server{}
+	req := &synse.WriteInfo{
+		DeviceFilter: &synse.DeviceFilter{
+			Rack:   "rack",
+			Board:  "board",
+			Device: "device",
+		},
+		Data: []*synse.WriteData{
+			{Action: "foo"},
+			{Action: "bar"},
+		},
+	}
+	resp, err := s.Write(context.Background(), req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(resp.Transactions))
+}
+
+// TestServer_Transaction tests the Transaction method of the gRPC plugin service.
+func TestServer_Transaction(t *testing.T) {
+	setupTransactionCache(time.Duration(600) * time.Second)
+
+	s := Server{}
+	req := &synse.TransactionFilter{}
+	mock := test.NewMockTransactionStream()
+	err := s.Transaction(req, mock)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(mock.Results))
+}
+
+// TestServer_Transaction2 tests the Transaction method of the gRPC plugin service
+// when there are transactions in the cache and no filter.
+func TestServer_Transaction2(t *testing.T) {
+	setupTransactionCache(time.Duration(600) * time.Second)
+
+	t1 := newTransaction()
+	t2 := newTransaction()
+
+	s := Server{}
+	req := &synse.TransactionFilter{}
+	mock := test.NewMockTransactionStream()
+	err := s.Transaction(req, mock)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(mock.Results))
+	assert.NotNil(t, mock.Results[t1.id])
+	assert.NotNil(t, mock.Results[t2.id])
+}
+
+// TestServer_Transaction3 tests the Transaction method of the gRPC plugin service
+// when there are transactions in the cache with a filter.
+func TestServer_Transaction3(t *testing.T) {
+	setupTransactionCache(time.Duration(600) * time.Second)
+
+	t1 := newTransaction()
+	t2 := newTransaction()
+
+	s := Server{}
+	req := &synse.TransactionFilter{Id: t1.id}
+	mock := test.NewMockTransactionStream()
+	err := s.Transaction(req, mock)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(mock.Results))
+	assert.NotNil(t, mock.Results[t1.id])
+	assert.Nil(t, mock.Results[t2.id])
+}
+
+// TestServer_Transaction4 tests the Transaction method of the gRPC plugin service
+// when the filter does not match any transactions.
+func TestServer_Transaction4(t *testing.T) {
+	setupTransactionCache(time.Duration(600) * time.Second)
+
+	t1 := newTransaction()
+	t2 := newTransaction()
+
+	s := Server{}
+	req := &synse.TransactionFilter{Id: "abc"}
+	mock := test.NewMockTransactionStream()
+	err := s.Transaction(req, mock)
+
+	assert.Error(t, err)
+	assert.Equal(t, 0, len(mock.Results))
+	assert.Nil(t, mock.Results[t1.id])
+	assert.Nil(t, mock.Results[t2.id])
+}
+
+// TestServer_Transaction5 tests the Transaction method of the gRPC plugin service
+// when sending the response results in error.
+func TestServer_Transaction5(t *testing.T) {
+	setupTransactionCache(time.Duration(600) * time.Second)
+
+	_ = newTransaction()
+	_ = newTransaction()
+
+	s := Server{}
+	req := &synse.TransactionFilter{}
+	mock := &test.MockTransactionStreamErr{}
+	err := s.Transaction(req, mock)
+
+	assert.Error(t, err)
+}

--- a/sdk/server_test.go
+++ b/sdk/server_test.go
@@ -14,3 +14,92 @@ func TestNewServer(t *testing.T) {
 	assert.Equal(t, "foo", s.network)
 	assert.Equal(t, "bar", s.address)
 }
+
+//
+//// TestSetupSocket tests setting up the socket when the socket path
+//// already exists.
+//func TestSetupSocket(t *testing.T) {
+//	// Set up a temporary directory for testing
+//	dir, err := ioutil.TempDir("", "testing")
+//	assert.NoError(t, err)
+//	defer func() {
+//		test.CheckErr(t, os.RemoveAll(dir))
+//	}()
+//
+//	// Set the socket path to the temp dir for the test
+//	sockPath = dir
+//
+//	sock, err := setupSocket("test.sock")
+//	if err != nil {
+//		t.Error(err)
+//	}
+//
+//	// Verify the socket path+name
+//	assert.Equal(t, filepath.Join(dir, "test.sock"), sock)
+//
+//	// Verify that the socket path exists
+//	_, err = os.Stat(sockPath)
+//	assert.NoError(t, err)
+//}
+//
+//// TestSetupSocket2 tests setting up the socket when the socket path
+//// does not already exists.
+//func TestSetupSocket2(t *testing.T) {
+//	// Set up a temporary directory for testing
+//	dir, err := ioutil.TempDir("", "testing")
+//	assert.NoError(t, err)
+//	// remove the temp dir now - it shouldn't exist when we set up the socket
+//	test.CheckErr(t, os.RemoveAll(dir))
+//
+//	// Set the socket path to the temp dir for the test
+//	sockPath = dir
+//
+//	sock, err := setupSocket("test.sock")
+//	if err != nil {
+//		t.Error(err)
+//	}
+//
+//	// Verify the socket path+name
+//	assert.Equal(t, filepath.Join(dir, "test.sock"), sock)
+//
+//	// Verify that the socket path exists
+//	_, err = os.Stat(sockPath)
+//	assert.NoError(t, err)
+//}
+//
+//// TestSetupSocket2 tests setting up the socket when the socket path
+//// and the socket itself already exist.
+//func TestSetupSocket3(t *testing.T) {
+//	// Set up a temporary directory for testing
+//	dir, err := ioutil.TempDir("", "testing")
+//	assert.NoError(t, err)
+//	defer func() {
+//		test.CheckErr(t, os.RemoveAll(dir))
+//	}()
+//
+//	// Set the socket path to the temp dir for the test
+//	sockPath = dir
+//
+//	// Make the socket file
+//	filename := filepath.Join(dir, "test.sock")
+//	_, err = os.Create(filename)
+//	assert.NoError(t, err)
+//
+//	sock, err := setupSocket("test.sock")
+//	if err != nil {
+//		t.Error(err)
+//	}
+//
+//	// Verify the socket path+name
+//	assert.Equal(t, filepath.Join(dir, "test.sock"), sock)
+//
+//	// Verify that the socket path exists
+//	_, err = os.Stat(sockPath)
+//	assert.NoError(t, err)
+//
+//	// Verify that the socket itself no longer exists (setupSocket cleans
+//	// up old socket instances)
+//	_, err = os.Stat(filename)
+//	exists := !os.IsNotExist(err)
+//	assert.False(t, exists, "socket should no longer exist, but still does")
+//}

--- a/sdk/transaction.go
+++ b/sdk/transaction.go
@@ -91,6 +91,7 @@ type transaction struct {
 // encode translates the transaction to a corresponding gRPC WriteResponse.
 func (t *transaction) encode() *synse.WriteResponse {
 	return &synse.WriteResponse{
+		Id:      t.id,
 		Status:  t.status,
 		State:   t.state,
 		Created: t.created,

--- a/sdk/transaction.go
+++ b/sdk/transaction.go
@@ -41,6 +41,7 @@ func setupTransactionCache(ttl time.Duration) {
 // we will terminate the plugin, as it is indicative of an improper plugin setup.
 func newTransaction() *transaction {
 	if transactionCache == nil {
+		// FIXME - need to update logger so we can specify our own exiter to test this..
 		logger.Fatalf("transaction cache was not initialized; likely an issue in plugin setup")
 	}
 

--- a/sdk/transaction_test.go
+++ b/sdk/transaction_test.go
@@ -1,331 +1,245 @@
 package sdk
 
-//
-//// InvalidateTransactionCache is a Test mechanism to invalidate the transaction
-//// cache. Returns an error if there is no transaction cache.
-//func InvalidateTransactionCache() (err error) {
-//	err = nil
-//	if transactionCache == nil {
-//		err = status.Errorf(codes.FailedPrecondition,
-//			"transactionCache not initialized.")
-//	} else {
-//		transactionCache = nil
-//	}
-//	return err
-//}
-//
-//// newTransactionHelper is a helper method to call newTransaction and fail the
-//// test if it does not succeed. Returns the new transaction.
-//func newTransactionHelper(t *testing.T) *transaction {
-//	transaction, err := newTransaction()
-//	assert.NoError(t, err)
-//	return transaction
-//}
-//
-//// getTransactionHelper is a helper method to call getTransaction and fail the
-//// test if it does not succeed. Returns the transaction retrieved.
-//func getTransactionHelper(t *testing.T, id string) *transaction {
-//	transaction, err := getTransaction(id)
-//	assert.NoError(t, err)
-//	return transaction
-//}
-//
-//// TestNewTransaction tests creating a new transaction and getting
-//// it back out from the cache.
-//func TestNewTransaction(t *testing.T) {
-//	// Setup the transaction cache so NewTransaction can succeed.
-//	// Ignore any error since a previous test may have set it up.
-//	_ = setupTransactionCache(time.Duration(600) * time.Second)
-//
-//	transaction := newTransactionHelper(t)
-//
-//	assert.Equal(t, statusUnknown, transaction.status)
-//	assert.Equal(t, stateOk, transaction.state)
-//	assert.Equal(t, transaction.created, transaction.updated)
-//	assert.Equal(t, "", transaction.message)
-//
-//	tr, found := transactionCache.Get(transaction.id)
-//	assert.True(t, found, "new transaction not added to the cache")
-//	assert.Equal(t, transaction, tr, "cache value does not equal returned value")
-//}
-//
-//// TestNewTransaction2 tests creating new transactions and getting
-//// them back out from the cache.
-//func TestNewTransaction2(t *testing.T) {
-//	// Setup the transaction cache so NewTransaction can succeed.
-//	// Ignore any error since a previous test may have set it up.
-//	_ = setupTransactionCache(time.Duration(600) * time.Second)
-//
-//	t1 := newTransactionHelper(t)
-//	t2 := newTransactionHelper(t)
-//
-//	assert.NotEqual(t, t1.id, t2.id, "two transactions should not have the same id")
-//
-//	assert.Equal(t, t1.status, t2.status)
-//	assert.Equal(t, t1.state, t2.state)
-//	assert.Equal(t, t1.message, t2.message)
-//
-//	tr, found := transactionCache.Get(t1.id)
-//	assert.True(t, found, "new transaction not added to the cache")
-//	assert.Equal(t, t1, tr, "cache value does not equal returned value")
-//
-//	tr, found = transactionCache.Get(t2.id)
-//	assert.True(t, found, "new transaction not added to the cache")
-//	assert.Equal(t, t2, tr, "cache value does not equal returned value")
-//}
-//
-//// TestGetTransaction tests getting a transaction from the cache.
-//func TestGetTransaction(t *testing.T) {
-//	// Setup the transaction cache so NewTransaction can succeed.
-//	// Ignore any error since a previous test may have set it up.
-//	_ = setupTransactionCache(time.Duration(600) * time.Second)
-//	tr := newTransactionHelper(t)
-//
-//	cached := getTransactionHelper(t, tr.id)
-//	assert.Equal(t, tr, cached)
-//}
-//
-//// TestGetTransaction2 tests getting a transaction from the cache
-//// that does not exist in the cache.
-//func TestGetTransaction2(t *testing.T) {
-//	transaction, err := getTransaction("123")
-//	assert.Nil(t, transaction)
-//	assert.NoError(t, err)
-//}
-//
-//// TestTransaction_setStateOk tests setting the state of a transaction to OK.
-//func TestTransaction_setStateOk(t *testing.T) {
-//	// Setup the transaction cache so NewTransaction can succeed.
-//	// Ignore any error since a previous test may have set it up.
-//	_ = setupTransactionCache(time.Duration(600) * time.Second)
-//	tr := newTransactionHelper(t)
-//
-//	tr.state = stateError
-//	assert.Equal(t, stateError, tr.state)
-//
-//	tr.setStateOk()
-//	assert.Equal(t, stateOk, tr.state)
-//}
-//
-//// TestTransaction_setStateOkCached tests setting the state of a cached
-//// transaction to OK.
-//func TestTransaction_setStateOkCached(t *testing.T) {
-//	// Setup the transaction cache so NewTransaction can succeed.
-//	// Ignore any error since a previous test may have set it up.
-//	_ = setupTransactionCache(time.Duration(600) * time.Second)
-//	tr := newTransactionHelper(t)
-//	cached := getTransactionHelper(t, tr.id)
-//
-//	cached.state = stateError
-//	assert.Equal(t, stateError, cached.state)
-//	assert.Equal(t, stateError, tr.state)
-//
-//	cached.setStateOk()
-//	assert.Equal(t, stateOk, cached.state)
-//	assert.Equal(t, stateOk, tr.state)
-//}
-//
-//// TestTransaction_setStateErr tests setting the state of a transaction to Error.
-//func TestTransaction_setStateErr(t *testing.T) {
-//	// Setup the transaction cache so NewTransaction can succeed.
-//	// Ignore any error since a previous test may have set it up.
-//	_ = setupTransactionCache(time.Duration(600) * time.Second)
-//	tr := newTransactionHelper(t)
-//
-//	tr.state = stateOk
-//	assert.Equal(t, stateOk, tr.state)
-//
-//	tr.setStateError()
-//	assert.Equal(t, stateError, tr.state)
-//}
-//
-//// TestTransaction_setStateErrCached tests setting the state of a cached
-//// transaction to Error.
-//func TestTransaction_setStateErrCached(t *testing.T) {
-//	// Setup the transaction cache so NewTransaction can succeed.
-//	// Ignore any error since a previous test may have set it up.
-//	_ = setupTransactionCache(time.Duration(600) * time.Second)
-//	tr := newTransactionHelper(t)
-//	cached := getTransactionHelper(t, tr.id)
-//
-//	cached.state = stateOk
-//	assert.Equal(t, stateOk, cached.state)
-//	assert.Equal(t, stateOk, tr.state)
-//
-//	cached.setStateError()
-//	assert.Equal(t, stateError, cached.state)
-//	assert.Equal(t, stateError, tr.state)
-//}
-//
-//// TestTransaction_setStatusUnknown tests setting the status of a transaction to Unknown.
-//func TestTransaction_setStatusUnknown(t *testing.T) {
-//	// Setup the transaction cache so NewTransaction can succeed.
-//	// Ignore any error since a previous test may have set it up.
-//	_ = setupTransactionCache(time.Duration(600) * time.Second)
-//	tr := newTransactionHelper(t)
-//
-//	tr.status = statusDone
-//	assert.Equal(t, statusDone, tr.status)
-//
-//	tr.setStatusUnknown()
-//	assert.Equal(t, statusUnknown, tr.status)
-//}
-//
-//// TestTransaction_setStatusUnknownCached tests setting the status of a cached
-//// transaction to Unknown.
-//func TestTransaction_setStatusUnknownCached(t *testing.T) {
-//	// Setup the transaction cache so NewTransaction can succeed.
-//	// Ignore any error since a previous test may have set it up.
-//	_ = setupTransactionCache(time.Duration(600) * time.Second)
-//	tr := newTransactionHelper(t)
-//	cached := getTransactionHelper(t, tr.id)
-//
-//	cached.status = statusDone
-//	assert.Equal(t, statusDone, cached.status)
-//	assert.Equal(t, statusDone, tr.status)
-//
-//	cached.setStatusUnknown()
-//	assert.Equal(t, statusUnknown, cached.status)
-//	assert.Equal(t, statusUnknown, tr.status)
-//}
-//
-//// TestTransaction_setStatusPending tests setting the status of a transaction to Pending.
-//func TestTransaction_setStatusPending(t *testing.T) {
-//	// Setup the transaction cache so NewTransaction can succeed.
-//	// Ignore any error since a previous test may have set it up.
-//	_ = setupTransactionCache(time.Duration(600) * time.Second)
-//	tr := newTransactionHelper(t)
-//
-//	tr.status = statusUnknown
-//	assert.Equal(t, statusUnknown, tr.status)
-//
-//	tr.setStatusPending()
-//	assert.Equal(t, statusPending, tr.status)
-//}
-//
-//// TestTransaction_setStatusPendingCached tests setting the status of a cached
-//// transaction to Pending.
-//func TestTransaction_setStatusPendingCached(t *testing.T) {
-//	// Setup the transaction cache so NewTransaction can succeed.
-//	// Ignore any error since a previous test may have set it up.
-//	_ = setupTransactionCache(time.Duration(600) * time.Second)
-//	tr := newTransactionHelper(t)
-//	cached := getTransactionHelper(t, tr.id)
-//
-//	cached.status = statusUnknown
-//	assert.Equal(t, statusUnknown, cached.status)
-//	assert.Equal(t, statusUnknown, tr.status)
-//
-//	cached.setStatusPending()
-//	assert.Equal(t, statusPending, cached.status)
-//	assert.Equal(t, statusPending, tr.status)
-//}
-//
-//// TestTransaction_setStatusWriting tests setting the status of a transaction to Writing.
-//func TestTransaction_setStatusWriting(t *testing.T) {
-//	// Setup the transaction cache so NewTransaction can succeed.
-//	// Ignore any error since a previous test may have set it up.
-//	_ = setupTransactionCache(time.Duration(600) * time.Second)
-//	tr := newTransactionHelper(t)
-//
-//	tr.status = statusUnknown
-//	assert.Equal(t, statusUnknown, tr.status)
-//
-//	tr.setStatusWriting()
-//	assert.Equal(t, statusWriting, tr.status)
-//}
-//
-//// TestTransaction_setStatusWritingCached tests setting the status of a cached
-//// transaction to Writing.
-//func TestTransaction_setStatusWritingCached(t *testing.T) {
-//	tr := newTransactionHelper(t)
-//	cached := getTransactionHelper(t, tr.id)
-//
-//	cached.status = statusUnknown
-//	assert.Equal(t, statusUnknown, cached.status)
-//	assert.Equal(t, statusUnknown, tr.status)
-//
-//	cached.setStatusWriting()
-//	assert.Equal(t, statusWriting, cached.status)
-//	assert.Equal(t, statusWriting, tr.status)
-//}
-//
-//// TestTransaction_setStatusDone tests setting the status of a transaction to Done.
-//func TestTransaction_setStatusDone(t *testing.T) {
-//	// Setup the transaction cache so NewTransaction can succeed.
-//	// Ignore any error since a previous test may have set it up.
-//	_ = setupTransactionCache(time.Duration(600) * time.Second)
-//	tr := newTransactionHelper(t)
-//
-//	tr.status = statusUnknown
-//	assert.Equal(t, statusUnknown, tr.status)
-//
-//	tr.setStatusDone()
-//	assert.Equal(t, statusDone, tr.status)
-//}
-//
-//// TestTransaction_setStatusDoneCached tests setting the status of a cached
-//// transaction to Done.
-//func TestTransaction_setStatusDoneCached(t *testing.T) {
-//	// Setup the transaction cache so NewTransaction can succeed.
-//	// Ignore any error since a previous test may have set it up.
-//	_ = setupTransactionCache(time.Duration(600) * time.Second)
-//	tr := newTransactionHelper(t)
-//	cached := getTransactionHelper(t, tr.id)
-//
-//	cached.status = statusUnknown
-//	assert.Equal(t, statusUnknown, cached.status)
-//	assert.Equal(t, statusUnknown, tr.status)
-//
-//	cached.setStatusDone()
-//	assert.Equal(t, statusDone, cached.status)
-//	assert.Equal(t, statusDone, tr.status)
-//}
-//
-//// TestTransaction_encode tests encoding an SDK transaction into the
-//// gRPC transaction struct.
-//func TestTransaction_encode(t *testing.T) {
-//	// Setup the transaction cache so NewTransaction can succeed.
-//	// Ignore any error since a previous test may have set it up.
-//	_ = setupTransactionCache(time.Duration(600) * time.Second)
-//	tr := newTransactionHelper(t)
-//	encoded := tr.encode()
-//
-//	assert.Equal(t, tr.status, encoded.Status)
-//	assert.Equal(t, tr.state, encoded.State)
-//	assert.Equal(t, tr.created, encoded.Created)
-//	assert.Equal(t, tr.updated, encoded.Updated)
-//	assert.Equal(t, tr.message, encoded.Message)
-//}
-//
-//// TestTransactionCache tests actions around the transaction cache (setting up,
-//// adding to, getting from, invalidating).
-//func TestTransactionCache(t *testing.T) {
-//	// Setup the transaction cache without error checking so we know it is initialized.
-//	_ = setupTransactionCache(time.Duration(600) * time.Second)
-//
-//	// Invalidate the transaction cache. Error should be nil.
-//	err := InvalidateTransactionCache()
-//	assert.NoError(t, err)
-//
-//	// Invalidate the transaction cache again. Error should not be nil.
-//	err = InvalidateTransactionCache()
-//	assert.Error(t, err)
-//
-//	// Call NewTransaction. Should fail without the transaction cache.
-//	_, err = newTransaction()
-//	assert.Error(t, err)
-//
-//	// Call GetTransaction. Should fail without the transaction cache.
-//	tr, err := getTransaction("zzz")
-//	assert.Nil(t, tr)
-//	assert.Error(t, err)
-//
-//	// Call setupTransactionCache. Should not error.
-//	err = setupTransactionCache(time.Duration(600) * time.Second)
-//	assert.NoError(t, err)
-//
-//	// Call setupTransactionCache again. Should error.
-//	err = setupTransactionCache(time.Duration(600) * time.Second)
-//	assert.Error(t, err)
-//}
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestNewTransaction tests creating a new transaction and getting
+// it back out from the cache.
+func TestNewTransaction(t *testing.T) {
+	setupTransactionCache(time.Duration(600) * time.Second)
+
+	transaction := newTransaction()
+
+	assert.Equal(t, statusUnknown, transaction.status)
+	assert.Equal(t, stateOk, transaction.state)
+	assert.Equal(t, transaction.created, transaction.updated)
+	assert.Equal(t, "", transaction.message)
+
+	tr, found := transactionCache.Get(transaction.id)
+	assert.True(t, found, "new transaction not added to the cache")
+	assert.Equal(t, transaction, tr, "cache value does not equal returned value")
+}
+
+// TestNewTransaction2 tests creating new transactions and getting
+// them back out from the cache.
+func TestNewTransaction2(t *testing.T) {
+	setupTransactionCache(time.Duration(600) * time.Second)
+
+	t1 := newTransaction()
+	t2 := newTransaction()
+
+	assert.NotEqual(t, t1.id, t2.id, "two transactions should not have the same id")
+
+	assert.Equal(t, t1.status, t2.status)
+	assert.Equal(t, t1.state, t2.state)
+	assert.Equal(t, t1.message, t2.message)
+
+	tr, found := transactionCache.Get(t1.id)
+	assert.True(t, found, "new transaction not added to the cache")
+	assert.Equal(t, t1, tr, "cache value does not equal returned value")
+
+	tr, found = transactionCache.Get(t2.id)
+	assert.True(t, found, "new transaction not added to the cache")
+	assert.Equal(t, t2, tr, "cache value does not equal returned value")
+}
+
+// TestGetTransaction tests getting a transaction from the cache.
+func TestGetTransaction(t *testing.T) {
+	setupTransactionCache(time.Duration(600) * time.Second)
+	tr := newTransaction()
+
+	cached := getTransaction(tr.id)
+	assert.Equal(t, tr, cached)
+}
+
+// TestGetTransaction2 tests getting a transaction from the cache
+// that does not exist in the cache.
+func TestGetTransaction2(t *testing.T) {
+	transaction := getTransaction("123")
+	assert.Nil(t, transaction)
+}
+
+// TestTransaction_setStateOk tests setting the state of a transaction to OK.
+func TestTransaction_setStateOk(t *testing.T) {
+	setupTransactionCache(time.Duration(600) * time.Second)
+	tr := newTransaction()
+
+	tr.state = stateError
+	assert.Equal(t, stateError, tr.state)
+
+	tr.setStateOk()
+	assert.Equal(t, stateOk, tr.state)
+}
+
+// TestTransaction_setStateOkCached tests setting the state of a cached
+// transaction to OK.
+func TestTransaction_setStateOkCached(t *testing.T) {
+	setupTransactionCache(time.Duration(600) * time.Second)
+	tr := newTransaction()
+	cached := getTransaction(tr.id)
+
+	cached.state = stateError
+	assert.Equal(t, stateError, cached.state)
+	assert.Equal(t, stateError, tr.state)
+
+	cached.setStateOk()
+	assert.Equal(t, stateOk, cached.state)
+	assert.Equal(t, stateOk, tr.state)
+}
+
+// TestTransaction_setStateErr tests setting the state of a transaction to Error.
+func TestTransaction_setStateErr(t *testing.T) {
+	setupTransactionCache(time.Duration(600) * time.Second)
+	tr := newTransaction()
+
+	tr.state = stateOk
+	assert.Equal(t, stateOk, tr.state)
+
+	tr.setStateError()
+	assert.Equal(t, stateError, tr.state)
+}
+
+// TestTransaction_setStateErrCached tests setting the state of a cached
+// transaction to Error.
+func TestTransaction_setStateErrCached(t *testing.T) {
+	setupTransactionCache(time.Duration(600) * time.Second)
+	tr := newTransaction()
+	cached := getTransaction(tr.id)
+
+	cached.state = stateOk
+	assert.Equal(t, stateOk, cached.state)
+	assert.Equal(t, stateOk, tr.state)
+
+	cached.setStateError()
+	assert.Equal(t, stateError, cached.state)
+	assert.Equal(t, stateError, tr.state)
+}
+
+// TestTransaction_setStatusUnknown tests setting the status of a transaction to Unknown.
+func TestTransaction_setStatusUnknown(t *testing.T) {
+	setupTransactionCache(time.Duration(600) * time.Second)
+	tr := newTransaction()
+
+	tr.status = statusDone
+	assert.Equal(t, statusDone, tr.status)
+
+	tr.setStatusUnknown()
+	assert.Equal(t, statusUnknown, tr.status)
+}
+
+// TestTransaction_setStatusUnknownCached tests setting the status of a cached
+// transaction to Unknown.
+func TestTransaction_setStatusUnknownCached(t *testing.T) {
+	setupTransactionCache(time.Duration(600) * time.Second)
+	tr := newTransaction()
+	cached := getTransaction(tr.id)
+
+	cached.status = statusDone
+	assert.Equal(t, statusDone, cached.status)
+	assert.Equal(t, statusDone, tr.status)
+
+	cached.setStatusUnknown()
+	assert.Equal(t, statusUnknown, cached.status)
+	assert.Equal(t, statusUnknown, tr.status)
+}
+
+// TestTransaction_setStatusPending tests setting the status of a transaction to Pending.
+func TestTransaction_setStatusPending(t *testing.T) {
+	setupTransactionCache(time.Duration(600) * time.Second)
+	tr := newTransaction()
+
+	tr.status = statusUnknown
+	assert.Equal(t, statusUnknown, tr.status)
+
+	tr.setStatusPending()
+	assert.Equal(t, statusPending, tr.status)
+}
+
+// TestTransaction_setStatusPendingCached tests setting the status of a cached
+// transaction to Pending.
+func TestTransaction_setStatusPendingCached(t *testing.T) {
+	setupTransactionCache(time.Duration(600) * time.Second)
+	tr := newTransaction()
+	cached := getTransaction(tr.id)
+
+	cached.status = statusUnknown
+	assert.Equal(t, statusUnknown, cached.status)
+	assert.Equal(t, statusUnknown, tr.status)
+
+	cached.setStatusPending()
+	assert.Equal(t, statusPending, cached.status)
+	assert.Equal(t, statusPending, tr.status)
+}
+
+// TestTransaction_setStatusWriting tests setting the status of a transaction to Writing.
+func TestTransaction_setStatusWriting(t *testing.T) {
+	setupTransactionCache(time.Duration(600) * time.Second)
+	tr := newTransaction()
+
+	tr.status = statusUnknown
+	assert.Equal(t, statusUnknown, tr.status)
+
+	tr.setStatusWriting()
+	assert.Equal(t, statusWriting, tr.status)
+}
+
+// TestTransaction_setStatusWritingCached tests setting the status of a cached
+// transaction to Writing.
+func TestTransaction_setStatusWritingCached(t *testing.T) {
+	tr := newTransaction()
+	cached := getTransaction(tr.id)
+
+	cached.status = statusUnknown
+	assert.Equal(t, statusUnknown, cached.status)
+	assert.Equal(t, statusUnknown, tr.status)
+
+	cached.setStatusWriting()
+	assert.Equal(t, statusWriting, cached.status)
+	assert.Equal(t, statusWriting, tr.status)
+}
+
+// TestTransaction_setStatusDone tests setting the status of a transaction to Done.
+func TestTransaction_setStatusDone(t *testing.T) {
+	setupTransactionCache(time.Duration(600) * time.Second)
+	tr := newTransaction()
+
+	tr.status = statusUnknown
+	assert.Equal(t, statusUnknown, tr.status)
+
+	tr.setStatusDone()
+	assert.Equal(t, statusDone, tr.status)
+}
+
+// TestTransaction_setStatusDoneCached tests setting the status of a cached
+// transaction to Done.
+func TestTransaction_setStatusDoneCached(t *testing.T) {
+	setupTransactionCache(time.Duration(600) * time.Second)
+	tr := newTransaction()
+	cached := getTransaction(tr.id)
+
+	cached.status = statusUnknown
+	assert.Equal(t, statusUnknown, cached.status)
+	assert.Equal(t, statusUnknown, tr.status)
+
+	cached.setStatusDone()
+	assert.Equal(t, statusDone, cached.status)
+	assert.Equal(t, statusDone, tr.status)
+}
+
+// TestTransaction_encode tests encoding an SDK transaction into the
+// gRPC transaction struct.
+func TestTransaction_encode(t *testing.T) {
+	setupTransactionCache(time.Duration(600) * time.Second)
+	tr := newTransaction()
+	encoded := tr.encode()
+
+	assert.Equal(t, tr.status, encoded.Status)
+	assert.Equal(t, tr.state, encoded.State)
+	assert.Equal(t, tr.created, encoded.Created)
+	assert.Equal(t, tr.updated, encoded.Updated)
+	assert.Equal(t, tr.message, encoded.Message)
+}

--- a/sdk/utils.go
+++ b/sdk/utils.go
@@ -59,9 +59,12 @@ func filterDevices(filter string) ([]*Device, error) {
 		k, v := pair[0], pair[1]
 
 		var isValid func(d *Device) bool
-		if k == "kind" {
+		switch k {
+		case "kind":
 			isValid = func(d *Device) bool { return d.Kind == v || v == "*" }
-		} else {
+		case "type":
+			isValid = func(d *Device) bool { return d.GetType() == v || v == "*" }
+		default:
 			return nil, fmt.Errorf("unsupported filter key. expect 'kind' but got %s", k)
 		}
 

--- a/sdk/utils.go
+++ b/sdk/utils.go
@@ -43,7 +43,7 @@ func newUID(components ...string) string {
 
 // filterDevices returns a list of Devices (a subset of the deviceMap) which
 // match the specified filter(s) in the given filter string.
-func filterDevices(filter string) ([]*Device, error) {
+func filterDevices(filter string) ([]*Device, error) { // nolint: gocyclo
 	filters := strings.Split(filter, ",")
 
 	var devices []*Device

--- a/sdk/utils_test.go
+++ b/sdk/utils_test.go
@@ -130,6 +130,9 @@ func TestFilterDevices(t *testing.T) {
 		"dev2": dev2,
 		"dev3": dev3,
 	}
+	defer delete(deviceMap, "dev1")
+	defer delete(deviceMap, "dev2")
+	defer delete(deviceMap, "dev3")
 
 	// Set up the test cases
 	var filterDevicesTestTable = []struct {
@@ -225,6 +228,8 @@ func TestFilterDevicesErr(t *testing.T) {
 		"dev1": dev1,
 		"dev2": dev2,
 	}
+	defer delete(deviceMap, "dev1")
+	defer delete(deviceMap, "dev2")
 
 	// Set up the test cases
 	var filterDevicesTestTable = []string{

--- a/sdk/utils_test.go
+++ b/sdk/utils_test.go
@@ -1,15 +1,14 @@
 package sdk
 
 import (
-	"io/ioutil"
-	"os"
-	"path/filepath"
+	//"io/ioutil"
+	//"os"
+	//"path/filepath"
 	//"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/vapor-ware/synse-sdk/internal/test"
+	//"github.com/vapor-ware/synse-sdk/internal/test"
 	//"github.com/vapor-ware/synse-sdk/sdk/config"
 )
 
@@ -91,94 +90,94 @@ import (
 //	_, err := makeDevices(inst, proto, plugin)
 //	assert.Error(t, err)
 //}
-
-// TestSetupSocket tests setting up the socket when the socket path
-// already exists.
-func TestSetupSocket(t *testing.T) {
-	// Set up a temporary directory for testing
-	dir, err := ioutil.TempDir("", "testing")
-	assert.NoError(t, err)
-	defer func() {
-		test.CheckErr(t, os.RemoveAll(dir))
-	}()
-
-	// Set the socket path to the temp dir for the test
-	sockPath = dir
-
-	sock, err := setupSocket("test.sock")
-	if err != nil {
-		t.Error(err)
-	}
-
-	// Verify the socket path+name
-	assert.Equal(t, filepath.Join(dir, "test.sock"), sock)
-
-	// Verify that the socket path exists
-	_, err = os.Stat(sockPath)
-	assert.NoError(t, err)
-}
-
-// TestSetupSocket2 tests setting up the socket when the socket path
-// does not already exists.
-func TestSetupSocket2(t *testing.T) {
-	// Set up a temporary directory for testing
-	dir, err := ioutil.TempDir("", "testing")
-	assert.NoError(t, err)
-	// remove the temp dir now - it shouldn't exist when we set up the socket
-	test.CheckErr(t, os.RemoveAll(dir))
-
-	// Set the socket path to the temp dir for the test
-	sockPath = dir
-
-	sock, err := setupSocket("test.sock")
-	if err != nil {
-		t.Error(err)
-	}
-
-	// Verify the socket path+name
-	assert.Equal(t, filepath.Join(dir, "test.sock"), sock)
-
-	// Verify that the socket path exists
-	_, err = os.Stat(sockPath)
-	assert.NoError(t, err)
-}
-
-// TestSetupSocket2 tests setting up the socket when the socket path
-// and the socket itself already exist.
-func TestSetupSocket3(t *testing.T) {
-	// Set up a temporary directory for testing
-	dir, err := ioutil.TempDir("", "testing")
-	assert.NoError(t, err)
-	defer func() {
-		test.CheckErr(t, os.RemoveAll(dir))
-	}()
-
-	// Set the socket path to the temp dir for the test
-	sockPath = dir
-
-	// Make the socket file
-	filename := filepath.Join(dir, "test.sock")
-	_, err = os.Create(filename)
-	assert.NoError(t, err)
-
-	sock, err := setupSocket("test.sock")
-	if err != nil {
-		t.Error(err)
-	}
-
-	// Verify the socket path+name
-	assert.Equal(t, filepath.Join(dir, "test.sock"), sock)
-
-	// Verify that the socket path exists
-	_, err = os.Stat(sockPath)
-	assert.NoError(t, err)
-
-	// Verify that the socket itself no longer exists (setupSocket cleans
-	// up old socket instances)
-	_, err = os.Stat(filename)
-	exists := !os.IsNotExist(err)
-	assert.False(t, exists, "socket should no longer exist, but still does")
-}
+//
+//// TestSetupSocket tests setting up the socket when the socket path
+//// already exists.
+//func TestSetupSocket(t *testing.T) {
+//	// Set up a temporary directory for testing
+//	dir, err := ioutil.TempDir("", "testing")
+//	assert.NoError(t, err)
+//	defer func() {
+//		test.CheckErr(t, os.RemoveAll(dir))
+//	}()
+//
+//	// Set the socket path to the temp dir for the test
+//	sockPath = dir
+//
+//	sock, err := setupSocket("test.sock")
+//	if err != nil {
+//		t.Error(err)
+//	}
+//
+//	// Verify the socket path+name
+//	assert.Equal(t, filepath.Join(dir, "test.sock"), sock)
+//
+//	// Verify that the socket path exists
+//	_, err = os.Stat(sockPath)
+//	assert.NoError(t, err)
+//}
+//
+//// TestSetupSocket2 tests setting up the socket when the socket path
+//// does not already exists.
+//func TestSetupSocket2(t *testing.T) {
+//	// Set up a temporary directory for testing
+//	dir, err := ioutil.TempDir("", "testing")
+//	assert.NoError(t, err)
+//	// remove the temp dir now - it shouldn't exist when we set up the socket
+//	test.CheckErr(t, os.RemoveAll(dir))
+//
+//	// Set the socket path to the temp dir for the test
+//	sockPath = dir
+//
+//	sock, err := setupSocket("test.sock")
+//	if err != nil {
+//		t.Error(err)
+//	}
+//
+//	// Verify the socket path+name
+//	assert.Equal(t, filepath.Join(dir, "test.sock"), sock)
+//
+//	// Verify that the socket path exists
+//	_, err = os.Stat(sockPath)
+//	assert.NoError(t, err)
+//}
+//
+//// TestSetupSocket2 tests setting up the socket when the socket path
+//// and the socket itself already exist.
+//func TestSetupSocket3(t *testing.T) {
+//	// Set up a temporary directory for testing
+//	dir, err := ioutil.TempDir("", "testing")
+//	assert.NoError(t, err)
+//	defer func() {
+//		test.CheckErr(t, os.RemoveAll(dir))
+//	}()
+//
+//	// Set the socket path to the temp dir for the test
+//	sockPath = dir
+//
+//	// Make the socket file
+//	filename := filepath.Join(dir, "test.sock")
+//	_, err = os.Create(filename)
+//	assert.NoError(t, err)
+//
+//	sock, err := setupSocket("test.sock")
+//	if err != nil {
+//		t.Error(err)
+//	}
+//
+//	// Verify the socket path+name
+//	assert.Equal(t, filepath.Join(dir, "test.sock"), sock)
+//
+//	// Verify that the socket path exists
+//	_, err = os.Stat(sockPath)
+//	assert.NoError(t, err)
+//
+//	// Verify that the socket itself no longer exists (setupSocket cleans
+//	// up old socket instances)
+//	_, err = os.Stat(filename)
+//	exists := !os.IsNotExist(err)
+//	assert.False(t, exists, "socket should no longer exist, but still does")
+//}
 
 // TestMakeIDString tests making a compound ID string out of the device
 // identifier components (rack, board, device).

--- a/sdk/utils_test.go
+++ b/sdk/utils_test.go
@@ -10,174 +10,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	//"github.com/vapor-ware/synse-sdk/internal/test"
 	//"github.com/vapor-ware/synse-sdk/sdk/config"
-)
+	"sort"
 
-//
-//// TestMakeDevices tests making devices where two instances match one prototype.
-//func TestMakeDevices(t *testing.T) {
-//	inst := []*config.DeviceConfig{&testDeviceConfig1, &testDeviceConfig2}
-//	proto := []*config.PrototypeConfig{&testPrototypeConfig1}
-//
-//	devices, err := makeDevices(inst, proto, &testPlugin)
-//	assert.NoError(t, err)
-//	assert.Equal(t, 2, len(devices))
-//}
-//
-//// TestMakeDevices2 tests making devices when no instances match the prototype.
-//func TestMakeDevices2(t *testing.T) {
-//	inst := []*config.DeviceConfig{&testDeviceConfig1, &testDeviceConfig2}
-//	proto := []*config.PrototypeConfig{&testPrototypeConfig2}
-//
-//	devices, err := makeDevices(inst, proto, &testPlugin)
-//	assert.NoError(t, err)
-//	assert.Equal(t, 0, len(devices))
-//}
-//
-//// TestMakeDevices3 tests making devices when one instance matches one of two prototypes.
-//func TestMakeDevices3(t *testing.T) {
-//	inst := []*config.DeviceConfig{&testDeviceConfig1}
-//	proto := []*config.PrototypeConfig{&testPrototypeConfig1, &testPrototypeConfig2}
-//
-//	devices, err := makeDevices(inst, proto, &testPlugin)
-//	assert.NoError(t, err)
-//	assert.Equal(t, 1, len(devices))
-//}
-//
-//// TestMakeDevices4 tests making devices when no prototypes exist for instances to
-//// match with.
-//func TestMakeDevices4(t *testing.T) {
-//	inst := []*config.DeviceConfig{&testDeviceConfig1, &testDeviceConfig2}
-//	var proto []*config.PrototypeConfig
-//
-//	devices, err := makeDevices(inst, proto, &testPlugin)
-//	assert.NoError(t, err)
-//	assert.Equal(t, 0, len(devices))
-//}
-//
-//// TestMakeDevices5 tests making devices when no instances exist for protocols to
-//// be matched with.
-//func TestMakeDevices5(t *testing.T) {
-//	var inst []*config.DeviceConfig
-//	proto := []*config.PrototypeConfig{&testPrototypeConfig1, &testPrototypeConfig2}
-//
-//	devices, err := makeDevices(inst, proto, &testPlugin)
-//	assert.NoError(t, err)
-//	assert.Equal(t, 0, len(devices))
-//}
-//
-//// TestMakeDevices6 tests making devices when the plugin is incorrectly configured
-//// (no device identifier handler), which should prohibit devices from being created.
-//func TestMakeDevices6(t *testing.T) {
-//	inst := []*config.DeviceConfig{&testDeviceConfig1, &testDeviceConfig2}
-//	proto := []*config.PrototypeConfig{&testPrototypeConfig1}
-//
-//	plugin := makeTestPlugin()
-//	plugin.handlers.DeviceIdentifier = nil
-//
-//	_, err := makeDevices(inst, proto, plugin)
-//	assert.Error(t, err)
-//}
-//
-//// TestMakeDevices7 tests making devices when the plugin is incorrectly configured
-//// (no device handlers), which should prohibit devices from being created.
-//func TestMakeDevices7(t *testing.T) {
-//	inst := []*config.DeviceConfig{&testDeviceConfig1, &testDeviceConfig2}
-//	proto := []*config.PrototypeConfig{&testPrototypeConfig1}
-//
-//	plugin := makeTestPlugin()
-//	plugin.deviceHandlers = []*DeviceHandler{}
-//
-//	_, err := makeDevices(inst, proto, plugin)
-//	assert.Error(t, err)
-//}
-//
-//// TestSetupSocket tests setting up the socket when the socket path
-//// already exists.
-//func TestSetupSocket(t *testing.T) {
-//	// Set up a temporary directory for testing
-//	dir, err := ioutil.TempDir("", "testing")
-//	assert.NoError(t, err)
-//	defer func() {
-//		test.CheckErr(t, os.RemoveAll(dir))
-//	}()
-//
-//	// Set the socket path to the temp dir for the test
-//	sockPath = dir
-//
-//	sock, err := setupSocket("test.sock")
-//	if err != nil {
-//		t.Error(err)
-//	}
-//
-//	// Verify the socket path+name
-//	assert.Equal(t, filepath.Join(dir, "test.sock"), sock)
-//
-//	// Verify that the socket path exists
-//	_, err = os.Stat(sockPath)
-//	assert.NoError(t, err)
-//}
-//
-//// TestSetupSocket2 tests setting up the socket when the socket path
-//// does not already exists.
-//func TestSetupSocket2(t *testing.T) {
-//	// Set up a temporary directory for testing
-//	dir, err := ioutil.TempDir("", "testing")
-//	assert.NoError(t, err)
-//	// remove the temp dir now - it shouldn't exist when we set up the socket
-//	test.CheckErr(t, os.RemoveAll(dir))
-//
-//	// Set the socket path to the temp dir for the test
-//	sockPath = dir
-//
-//	sock, err := setupSocket("test.sock")
-//	if err != nil {
-//		t.Error(err)
-//	}
-//
-//	// Verify the socket path+name
-//	assert.Equal(t, filepath.Join(dir, "test.sock"), sock)
-//
-//	// Verify that the socket path exists
-//	_, err = os.Stat(sockPath)
-//	assert.NoError(t, err)
-//}
-//
-//// TestSetupSocket2 tests setting up the socket when the socket path
-//// and the socket itself already exist.
-//func TestSetupSocket3(t *testing.T) {
-//	// Set up a temporary directory for testing
-//	dir, err := ioutil.TempDir("", "testing")
-//	assert.NoError(t, err)
-//	defer func() {
-//		test.CheckErr(t, os.RemoveAll(dir))
-//	}()
-//
-//	// Set the socket path to the temp dir for the test
-//	sockPath = dir
-//
-//	// Make the socket file
-//	filename := filepath.Join(dir, "test.sock")
-//	_, err = os.Create(filename)
-//	assert.NoError(t, err)
-//
-//	sock, err := setupSocket("test.sock")
-//	if err != nil {
-//		t.Error(err)
-//	}
-//
-//	// Verify the socket path+name
-//	assert.Equal(t, filepath.Join(dir, "test.sock"), sock)
-//
-//	// Verify that the socket path exists
-//	_, err = os.Stat(sockPath)
-//	assert.NoError(t, err)
-//
-//	// Verify that the socket itself no longer exists (setupSocket cleans
-//	// up old socket instances)
-//	_, err = os.Stat(filename)
-//	exists := !os.IsNotExist(err)
-//	assert.False(t, exists, "socket should no longer exist, but still does")
-//}
+	"github.com/vapor-ware/synse-sdk/sdk/config"
+)
 
 // TestMakeIDString tests making a compound ID string out of the device
 // identifier components (rack, board, device).
@@ -271,144 +107,164 @@ func TestNewUID(t *testing.T) {
 	}
 }
 
-//
-//// TestFilterDevices tests filtering devices successfully. These cases
-//// exercise valid filter strings against different combinations of filters
-//// and values.
-//func TestFilterDevices(t *testing.T) {
-//	dev1 := &Device{
-//		Type:    "temperature",
-//		Model:   "foo",
-//		Handler: &DeviceHandler{},
-//	}
-//	dev2 := &Device{
-//		Type:    "temperature",
-//		Model:   "bar",
-//		Handler: &DeviceHandler{},
-//	}
-//	dev3 := &Device{
-//		Type:    "pressure",
-//		Model:   "baz",
-//		Handler: &DeviceHandler{},
-//	}
-//
-//	// Populate the device map with the test devices.
-//	deviceMap = map[string]*Device{
-//		"dev1": dev1,
-//		"dev2": dev2,
-//		"dev3": dev3,
-//	}
-//
-//	// Set up the test cases
-//	var filterDevicesTestTable = []struct {
-//		filter   string
-//		expected []*Device
-//	}{
-//		{
-//			// devices with type temperature
-//			filter:   "type=temperature",
-//			expected: []*Device{dev1, dev2},
-//		},
-//		{
-//			// devices with type pressure
-//			filter:   "type=pressure",
-//			expected: []*Device{dev3},
-//		},
-//		{
-//			// devices with model baz
-//			filter:   "model=baz",
-//			expected: []*Device{dev3},
-//		},
-//		{
-//			// devices with type pressure and type temperature (can't have two types)
-//			filter:   "type=pressure,type=temperature",
-//			expected: []*Device{},
-//		},
-//		{
-//			// devices with type none (should not match any)
-//			filter:   "type=none",
-//			expected: []*Device{},
-//		},
-//		{
-//			// devices with type temperature and model foo
-//			filter:   "type=temperature,model=foo",
-//			expected: []*Device{dev1},
-//		},
-//		{
-//			// devices with type pressure and model foo
-//			filter:   "type=pressure,model=foo",
-//			expected: []*Device{},
-//		},
-//		{
-//			// devices of any type
-//			filter:   "type=*",
-//			expected: []*Device{dev1, dev2, dev3},
-//		},
-//		{
-//			// devices of any model
-//			filter:   "model=*",
-//			expected: []*Device{dev1, dev2, dev3},
-//		},
-//		{
-//			// devices of any model with type temperature
-//			filter:   "type=temperature,model=*",
-//			expected: []*Device{dev1, dev2},
-//		},
-//		{
-//			// devices of any type with model baz
-//			filter:   "type=*,model=baz",
-//			expected: []*Device{dev3},
-//		},
-//	}
-//
-//	for _, testCase := range filterDevicesTestTable {
-//		actual, err := filterDevices(testCase.filter)
-//		expected := testCase.expected
-//		assert.NoError(t, err)
-//		assert.Equal(t, len(expected), len(actual))
-//
-//		// Sort the expected and actual (we sort by model for the tests
-//		// since the model is unique for each test device)
-//		sort.SliceStable(expected, func(i int, j int) bool { return expected[i].Model < expected[j].Model })
-//		sort.SliceStable(actual, func(i int, j int) bool { return actual[i].Model < actual[j].Model })
-//		assert.Equal(t, testCase.expected, actual, "filter: %v", testCase.filter)
-//	}
-//}
-//
-//// TestFilterDevicesErr tests filtering devices when the given filter
-//// string results in a filtering error.
-//func TestFilterDevicesErr(t *testing.T) {
-//	dev1 := &Device{
-//		Type:    "temperature",
-//		Model:   "foo",
-//		Handler: &DeviceHandler{},
-//	}
-//	dev2 := &Device{
-//		Type:    "temperature",
-//		Model:   "bar",
-//		Handler: &DeviceHandler{},
-//	}
-//
-//	// Populate the device map with the test devices.
-//	deviceMap = map[string]*Device{
-//		"dev1": dev1,
-//		"dev2": dev2,
-//	}
-//
-//	// Set up the test cases
-//	var filterDevicesTestTable = []string{
-//		// no filter - when filtering, we should always have a filter
-//		// string specified when calling filterDevices
-//		"",
-//
-//		// unsupported filter keys
-//		"invalid=temperature",
-//		"MODEL=bar",
-//		"Type=temperature",
-//	}
-//
-//	for _, testCase := range filterDevicesTestTable {
-//		_, err := filterDevices(testCase)
-//		assert.Error(t, err)
-//	}
-//}
+// TestFilterDevices tests filtering devices successfully. These cases
+// exercise valid filter strings against different combinations of filters
+// and values.
+func TestFilterDevices(t *testing.T) {
+	dev1 := &Device{
+		Kind:    "foo.temperature",
+		Handler: &DeviceHandler{},
+	}
+	dev2 := &Device{
+		Kind:    "bar.temperature",
+		Handler: &DeviceHandler{},
+	}
+	dev3 := &Device{
+		Kind:    "baz.pressure",
+		Handler: &DeviceHandler{},
+	}
+
+	// Populate the device map with the test devices.
+	deviceMap = map[string]*Device{
+		"dev1": dev1,
+		"dev2": dev2,
+		"dev3": dev3,
+	}
+
+	// Set up the test cases
+	var filterDevicesTestTable = []struct {
+		desc     string
+		filter   string
+		expected []*Device
+	}{
+		{
+			desc:     "devices with type temperature",
+			filter:   "type=temperature",
+			expected: []*Device{dev1, dev2},
+		},
+		{
+			desc:     "devices with type pressure",
+			filter:   "type=pressure",
+			expected: []*Device{dev3},
+		},
+		{
+			desc:     "devices with kind baz.pressure",
+			filter:   "kind=baz.pressure",
+			expected: []*Device{dev3},
+		},
+		{
+			desc:     "devices with type pressure and type temperature (can't have two types)",
+			filter:   "type=pressure,type=temperature",
+			expected: []*Device{},
+		},
+		{
+			desc:     "devices with type none (should not match any)",
+			filter:   "type=none",
+			expected: []*Device{},
+		},
+		{
+			desc:     "devices with type temperature and kind foo.temperature",
+			filter:   "type=temperature,kind=foo.temperature",
+			expected: []*Device{dev1},
+		},
+		{
+			desc:     "devices with type pressure and kind foo.temperature",
+			filter:   "type=pressure,kind=foo.temperature",
+			expected: []*Device{},
+		},
+		{
+			desc:     "devices of any type",
+			filter:   "type=*",
+			expected: []*Device{dev1, dev2, dev3},
+		},
+		{
+			desc:     "devices of any kind",
+			filter:   "kind=*",
+			expected: []*Device{dev1, dev2, dev3},
+		},
+		{
+			desc:     "devices of any kind with type temperature",
+			filter:   "type=temperature,kind=*",
+			expected: []*Device{dev1, dev2},
+		},
+		{
+			desc:     "devices of any type with kind baz.pressure",
+			filter:   "type=*,kind=baz.pressure",
+			expected: []*Device{dev3},
+		},
+	}
+
+	for _, testCase := range filterDevicesTestTable {
+		actual, err := filterDevices(testCase.filter)
+		expected := testCase.expected
+		assert.NoError(t, err, testCase.desc)
+		assert.Equal(t, len(expected), len(actual), testCase.desc)
+
+		// Sort the expected and actual (we sort by Kind for the tests
+		// since it is unique for each test device)
+		sort.SliceStable(expected, func(i int, j int) bool { return expected[i].Kind < expected[j].Kind })
+		sort.SliceStable(actual, func(i int, j int) bool { return actual[i].Kind < actual[j].Kind })
+		assert.Equal(t, testCase.expected, actual, "filter: %v", testCase.filter, testCase.desc)
+	}
+}
+
+// TestFilterDevicesErr tests filtering devices when the given filter
+// string results in a filtering error.
+func TestFilterDevicesErr(t *testing.T) {
+	dev1 := &Device{
+		Kind:    "foo.temperature",
+		Handler: &DeviceHandler{},
+	}
+	dev2 := &Device{
+		Kind:    "bar.temperature",
+		Handler: &DeviceHandler{},
+	}
+
+	// Populate the device map with the test devices.
+	deviceMap = map[string]*Device{
+		"dev1": dev1,
+		"dev2": dev2,
+	}
+
+	// Set up the test cases
+	var filterDevicesTestTable = []string{
+		// no filter - when filtering, we should always have a filter
+		// string specified when calling filterDevices
+		"",
+
+		// unsupported filter keys
+		"invalid=temperature",
+		"KIND=bar",
+		"Type=temperature",
+	}
+
+	for _, testCase := range filterDevicesTestTable {
+		_, err := filterDevices(testCase)
+		assert.Error(t, err)
+	}
+}
+
+// TestGetCurrentTime tests getting the current time.
+func TestGetCurrentTime(t *testing.T) {
+	// TODO: figure out how to test the response...
+	out := GetCurrentTime()
+	assert.NotEmpty(t, out)
+}
+
+// Test_getTypeByNameOk tests getting a type that exists.
+func Test_getTypeByNameOk(t *testing.T) {
+	outputTypeMap["foo"] = &config.OutputType{Name: "foo"}
+	defer delete(outputTypeMap, "foo")
+
+	ot, err := getTypeByName("foo")
+	assert.NoError(t, err)
+	assert.NotNil(t, ot)
+	assert.Equal(t, "foo", ot.Name)
+}
+
+// Test_getTypeByNameErr tests getting a type that doesn't exist.
+func Test_getTypeByNameErr(t *testing.T) {
+	ot, err := getTypeByName("bar")
+	assert.Error(t, err)
+	assert.Nil(t, ot)
+}

--- a/sdk/verification_test.go
+++ b/sdk/verification_test.go
@@ -1,1 +1,349 @@
 package sdk
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vapor-ware/synse-sdk/sdk/config"
+	"github.com/vapor-ware/synse-sdk/sdk/errors"
+)
+
+// TestVerificationInit tests that the init function initialized things correctly.
+func TestVerificationInit(t *testing.T) {
+	assert.NotNil(t, deviceConfigLocations)
+	assert.Empty(t, deviceConfigLocations)
+	assert.NotNil(t, deviceConfigKinds)
+	assert.Empty(t, deviceConfigKinds)
+}
+
+// TestVerifyConfigs tests verifying the unified device config.
+func TestVerifyConfigs(t *testing.T) {
+	cfg := &config.DeviceConfig{
+		SchemeVersion: config.SchemeVersion{Version: "1.0"},
+		Locations:     []*config.Location{},
+		Devices:       []*config.DeviceKind{},
+	}
+
+	err := VerifyConfigs(cfg)
+	assert.NoError(t, err.Err())
+}
+
+// Test_verifyDeviceConfigLocations_Ok tests that there are no conflicting locations
+func Test_verifyDeviceConfigLocations_Ok(t *testing.T) {
+	defer func() {
+		deviceConfigLocations = map[string]*config.Location{}
+	}()
+
+	cfg := &config.DeviceConfig{
+		SchemeVersion: config.SchemeVersion{Version: "1.0"},
+		Locations: []*config.Location{
+			{
+				Name:  "foo",
+				Rack:  &config.LocationData{Name: "rack"},
+				Board: &config.LocationData{Name: "board"},
+			},
+			{
+				Name:  "foo",
+				Rack:  &config.LocationData{Name: "rack"},
+				Board: &config.LocationData{Name: "board"},
+			}, {
+				Name:  "bar",
+				Rack:  &config.LocationData{Name: "test"},
+				Board: &config.LocationData{Name: "test"},
+			},
+			{
+				Name:  "baz",
+				Rack:  &config.LocationData{Name: "1"},
+				Board: &config.LocationData{Name: "2"},
+			},
+		},
+		Devices: []*config.DeviceKind{},
+	}
+
+	err := errors.NewMultiError("test")
+	verifyDeviceConfigLocations(cfg, err)
+	assert.NoError(t, err.Err())
+}
+
+// Test_verifyDeviceConfigLocations_Error tests that there are conflicting locations
+func Test_verifyDeviceConfigLocations_Error(t *testing.T) {
+	defer func() {
+		deviceConfigLocations = map[string]*config.Location{}
+	}()
+
+	cfg := &config.DeviceConfig{
+		SchemeVersion: config.SchemeVersion{Version: "1.0"},
+		Locations: []*config.Location{
+			{
+				Name:  "foo",
+				Rack:  &config.LocationData{Name: "rack"},
+				Board: &config.LocationData{Name: "board"},
+			},
+			{
+				Name:  "foo",
+				Rack:  &config.LocationData{Name: "different"},
+				Board: &config.LocationData{Name: "different"},
+			},
+			{
+				Name:  "bar",
+				Rack:  &config.LocationData{Name: "rack"},
+				Board: &config.LocationData{Name: "board"},
+			},
+		},
+		Devices: []*config.DeviceKind{},
+	}
+
+	err := errors.NewMultiError("test")
+	verifyDeviceConfigLocations(cfg, err)
+	assert.Error(t, err.Err())
+	assert.Equal(t, 1, len(err.Errors), err.Error())
+}
+
+// Test_verifyDeviceConfigDeviceKinds_Ok tests that there are no duplicate device kinds defined.
+func Test_verifyDeviceConfigDeviceKinds_Ok(t *testing.T) {
+	defer func() {
+		deviceConfigKinds = map[string]*config.DeviceKind{}
+	}()
+
+	cfg := &config.DeviceConfig{
+		SchemeVersion: config.SchemeVersion{Version: "1.0"},
+		Locations:     []*config.Location{},
+		Devices: []*config.DeviceKind{
+			{Name: "test"},
+			{Name: "foo"},
+			{Name: "bar"},
+		},
+	}
+
+	err := errors.NewMultiError("test")
+	verifyDeviceConfigDeviceKinds(cfg, err)
+	assert.NoError(t, err.Err())
+}
+
+// Test_verifyDeviceConfigDeviceKinds_Error tests that there are duplicate device kinds defined.
+func Test_verifyDeviceConfigDeviceKinds_Error(t *testing.T) {
+	defer func() {
+		deviceConfigKinds = map[string]*config.DeviceKind{}
+	}()
+
+	cfg := &config.DeviceConfig{
+		SchemeVersion: config.SchemeVersion{Version: "1.0"},
+		Locations:     []*config.Location{},
+		Devices: []*config.DeviceKind{
+			{Name: "test"},
+			{Name: "foo"},
+			{Name: "bar"},
+			{Name: "foo"},
+			{Name: "test"},
+		},
+	}
+
+	err := errors.NewMultiError("test")
+	verifyDeviceConfigDeviceKinds(cfg, err)
+	assert.Error(t, err.Err())
+	assert.Equal(t, 2, len(err.Errors), err.Error())
+}
+
+// Test_verifyDeviceConfigInstances_Ok tests that the device instances are all correct.
+func Test_verifyDeviceConfigInstances_Ok(t *testing.T) {
+	defer delete(deviceConfigLocations, "foo")
+	defer delete(deviceConfigLocations, "bar")
+
+	// add the expected locations to the location map
+	deviceConfigLocations["foo"] = &config.Location{
+		Name:  "foo",
+		Rack:  &config.LocationData{Name: "rack"},
+		Board: &config.LocationData{Name: "board"},
+	}
+	deviceConfigLocations["bar"] = &config.Location{
+		Name:  "bar",
+		Rack:  &config.LocationData{Name: "test"},
+		Board: &config.LocationData{Name: "test"},
+	}
+
+	cfg := &config.DeviceConfig{
+		SchemeVersion: config.SchemeVersion{Version: "1.0"},
+		Locations:     []*config.Location{},
+		Devices: []*config.DeviceKind{
+			{
+				Name: "test",
+				Instances: []*config.DeviceInstance{
+					{Location: "foo"},
+					{Location: "foo"},
+					{Location: "bar"},
+				},
+			},
+			{
+				Name: "foo",
+				Instances: []*config.DeviceInstance{
+					{Location: "bar"},
+					{Location: "foo"},
+					{Location: "bar"},
+				},
+			},
+		},
+	}
+
+	err := errors.NewMultiError("test")
+	verifyDeviceConfigInstances(cfg, err)
+	assert.NoError(t, err.Err())
+}
+
+// Test_verifyDeviceConfigInstances_Error tests errors being detected in the instance
+// verification process.
+func Test_verifyDeviceConfigInstances_Error(t *testing.T) {
+	defer delete(deviceConfigLocations, "foo")
+
+	// add some expected locations to the location map
+	deviceConfigLocations["foo"] = &config.Location{
+		Name:  "foo",
+		Rack:  &config.LocationData{Name: "rack"},
+		Board: &config.LocationData{Name: "board"},
+	}
+
+	cfg := &config.DeviceConfig{
+		SchemeVersion: config.SchemeVersion{Version: "1.0"},
+		Locations:     []*config.Location{},
+		Devices: []*config.DeviceKind{
+			{
+				Name: "test",
+				Instances: []*config.DeviceInstance{
+					{Location: "foo"},
+					{Location: ""},    // err: empty definition
+					{Location: "bar"}, // err: doesn't exist
+				},
+			},
+			{
+				Name: "foo",
+				Instances: []*config.DeviceInstance{
+					{Location: "bar"}, // err: doesn't exist
+					{Location: "foo"},
+					{Location: "foo"},
+				},
+			},
+		},
+	}
+
+	err := errors.NewMultiError("test")
+	verifyDeviceConfigInstances(cfg, err)
+	assert.Error(t, err.Err())
+	assert.Equal(t, 3, len(err.Errors), err.Error())
+}
+
+// Test_verifyDeviceConfigOutputs_Ok tests verifying no issues with device outputs.
+func Test_verifyDeviceConfigOutputs_Ok(t *testing.T) {
+	defer func() {
+		outputTypeMap = map[string]*config.OutputType{}
+	}()
+
+	// add some expected outputs
+	outputTypeMap["foo"] = &config.OutputType{Name: "foo"}
+	outputTypeMap["bar"] = &config.OutputType{Name: "bar"}
+
+	cfg := &config.DeviceConfig{
+		SchemeVersion: config.SchemeVersion{Version: "1.0"},
+		Locations:     []*config.Location{},
+		Devices: []*config.DeviceKind{
+			{
+				Name: "test",
+				Outputs: []*config.DeviceOutput{
+					{Type: "foo"},
+				},
+				Instances: []*config.DeviceInstance{
+					{
+						Location: "foo",
+						Outputs: []*config.DeviceOutput{
+							{Type: "foo"},
+							{Type: "bar"},
+						},
+					},
+					{
+						Location: "foo",
+						Outputs: []*config.DeviceOutput{
+							{Type: "foo"},
+							{Type: "bar"},
+						},
+					},
+				},
+			},
+			{
+				Name: "foo",
+				Outputs: []*config.DeviceOutput{
+					{Type: "foo"},
+					{Type: "bar"},
+				},
+				Instances: []*config.DeviceInstance{
+					{
+						Location: "bar",
+						Outputs: []*config.DeviceOutput{
+							{Type: "foo"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := errors.NewMultiError("test")
+	verifyDeviceConfigOutputs(cfg, err)
+	assert.NoError(t, err.Err())
+}
+
+// Test_verifyDeviceConfigOutputs_Error tests verification errors with device outputs.
+func Test_verifyDeviceConfigOutputs_Error(t *testing.T) {
+	defer func() {
+		outputTypeMap = map[string]*config.OutputType{}
+	}()
+
+	// add some expected outputs
+	outputTypeMap["foo"] = &config.OutputType{Name: "foo"}
+
+	cfg := &config.DeviceConfig{
+		SchemeVersion: config.SchemeVersion{Version: "1.0"},
+		Locations:     []*config.Location{},
+		Devices: []*config.DeviceKind{
+			{
+				Name: "test",
+				Outputs: []*config.DeviceOutput{
+					{Type: "foo"},
+				},
+				Instances: []*config.DeviceInstance{
+					{
+						Location: "foo",
+						Outputs: []*config.DeviceOutput{
+							{Type: "foo"},
+							{Type: "bar"}, // err: doesn't exist
+						},
+					},
+					{
+						Location: "foo",
+						Outputs: []*config.DeviceOutput{
+							{Type: "foo"},
+							{Type: "bar"}, // err: doesn't exist
+						},
+					},
+				},
+			},
+			{
+				Name: "foo",
+				Outputs: []*config.DeviceOutput{
+					{Type: "foo"},
+					{Type: "bar"}, // err: doesn't exist
+				},
+				Instances: []*config.DeviceInstance{
+					{
+						Location: "bar",
+						Outputs: []*config.DeviceOutput{
+							{Type: "foo"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := errors.NewMultiError("test")
+	verifyDeviceConfigOutputs(cfg, err)
+	assert.Error(t, err.Err())
+	assert.Equal(t, 3, len(err.Errors), err.Error())
+}

--- a/sdk/version.go
+++ b/sdk/version.go
@@ -12,7 +12,7 @@ import (
 // SDKVersion specifies the version of the Synse Plugin SDK.
 const SDKVersion = "1.0.0"
 
-// version is a reference to a BinVersion that can be used to get
+// Version is a reference to a BinVersion that can be used to get
 // the version info for a plugin.
 var Version *BinVersion
 

--- a/sdk/version_test.go
+++ b/sdk/version_test.go
@@ -1,52 +1,57 @@
 package sdk
 
-//
-//// TestGetVersion gets the version and verifies that all fields are
-//// set correctly. In this case, we do not have all variables set, so
-//// we expect some fields to contain the default "empty" string.
-//func TestGetVersion(t *testing.T) {
-//	version := GetVersion()
-//
-//	// These fields are not set via global vars, so they should be empty
-//	assert.Equal(t, "-", version.BuildDate)
-//	assert.Equal(t, "-", version.GitCommit)
-//	assert.Equal(t, "-", version.GitTag)
-//	assert.Equal(t, "-", version.GoVersion)
-//	assert.Equal(t, "-", version.PluginVersion)
-//
-//	// These should be set.
-//	assert.Equal(t, runtime.GOOS, version.OS)
-//	assert.Equal(t, runtime.GOARCH, version.Arch)
-//	assert.Equal(t, SDKVersion, version.SDKVersion)
-//}
-//
-//// TestGetVersion2 gets the version info when there are some variable set.
-//func TestGetVersion2(t *testing.T) {
-//	GitCommit = "123"
-//	GitTag = "456"
-//	PluginVersion = "1.2.3"
-//
-//	version := GetVersion()
-//
-//	// These fields are not set via global vars, so they should be empty
-//	assert.Equal(t, "-", version.BuildDate)
-//	assert.Equal(t, "-", version.GoVersion)
-//
-//	// These should be set.
-//	assert.Equal(t, GitCommit, version.GitCommit)
-//	assert.Equal(t, GitTag, version.GitTag)
-//	assert.Equal(t, PluginVersion, version.PluginVersion)
-//	assert.Equal(t, runtime.GOOS, version.OS)
-//	assert.Equal(t, runtime.GOARCH, version.Arch)
-//	assert.Equal(t, SDKVersion, version.SDKVersion)
-//}
-//
-//// TestBinVersion_Format tests printing out the version info string.
-//func TestBinVersion_Format(t *testing.T) {
-//	version := GetVersion()
-//	versionStr := version.Format()
-//
-//	// the version string will be different depending on when/where the
-//	// test is run, so just verify that the string isn't empty..
-//	assert.NotEmpty(t, versionStr)
-//}
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestVersionInit tests that the init function initialized things correctly.
+func TestVersionInit(t *testing.T) {
+	assert.NotNil(t, Version)
+	assert.Equal(t, "-", Version.BuildDate)
+	assert.Equal(t, "-", Version.GitCommit)
+	assert.Equal(t, "-", Version.GitTag)
+	assert.Equal(t, "-", Version.PluginVersion)
+	assert.Equal(t, "-", Version.GoVersion)
+	assert.Equal(t, SDKVersion, Version.SDKVersion)
+	assert.Equal(t, runtime.GOARCH, Version.Arch)
+	assert.Equal(t, runtime.GOOS, Version.OS)
+}
+
+// Test_setField tests setting a field value.
+func Test_setField(t *testing.T) {
+	f := setField("")
+	assert.Equal(t, "-", f)
+
+	f = setField("foo")
+	assert.Equal(t, "foo", f)
+}
+
+// TestBinVersion_Encode tests converting the BinVersion to the gRPC VersionInfo.
+func TestBinVersion_Encode(t *testing.T) {
+	vi := Version.Encode()
+	assert.NotNil(t, vi)
+	assert.Equal(t, "-", vi.PluginVersion)
+	assert.Equal(t, "-", vi.GitTag)
+	assert.Equal(t, "-", vi.GitCommit)
+	assert.Equal(t, "-", vi.BuildDate)
+	assert.Equal(t, SDKVersion, vi.SdkVersion)
+	assert.Equal(t, runtime.GOOS, vi.Os)
+	assert.Equal(t, runtime.GOARCH, vi.Arch)
+}
+
+// TestBinVersion_Format tests producing a formatted string representation
+// of the BinVersion.
+func TestBinVersion_Format(t *testing.T) {
+	// since the values here will change based on when/where this is run,
+	// we can only verify that it produces something.
+	out := Version.Format()
+	assert.NotEmpty(t, out)
+}
+
+// TestBinVersion_Log tests logging out the BinVersion
+func TestBinVersion_Log(t *testing.T) {
+	Version.Log()
+}


### PR DESCRIPTION
This is a massive PR that overhauls the SDK tests and brings them up to speed. There are still a few places, particularly around `plugin.go`, where more tests will still be needed, but there are likely to be some more changes there, so those will be added later.

fixes #152 