### PR TITLE
add support for custom data validation functions

### DIFF
--- a/sdk/config/device_test.go
+++ b/sdk/config/device_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"testing"
 
+	"fmt"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/vapor-ware/synse-sdk/sdk/errors"
 )
@@ -749,5 +751,171 @@ func TestDeviceOutput_Validate_Error(t *testing.T) {
 		testCase.output.Validate(merr)
 		assert.Error(t, merr.Err(), testCase.desc)
 		assert.Equal(t, testCase.errCount, len(merr.Errors), merr.Error())
+	}
+}
+
+// TestDeviceConfig_ValidateDeviceConfigDataOk tests validating config data when there
+// are no errors.
+func TestDeviceConfig_ValidateDeviceConfigDataOk(t *testing.T) {
+	var testTable = []struct {
+		desc   string
+		config DeviceConfig
+	}{
+		{
+			desc: "no data field in the device config",
+			config: DeviceConfig{
+				SchemeVersion: SchemeVersion{Version: "1.0"},
+				Locations:     []*Location{},
+				Devices:       []*DeviceKind{},
+			},
+		},
+		{
+			desc: "data in the device kind output",
+			config: DeviceConfig{
+				SchemeVersion: SchemeVersion{Version: "1.0"},
+				Locations:     []*Location{},
+				Devices: []*DeviceKind{
+					{
+						Outputs: []*DeviceOutput{
+							{
+								Data: map[string]interface{}{
+									"foo": "bar",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc: "data in the device instance",
+			config: DeviceConfig{
+				SchemeVersion: SchemeVersion{Version: "1.0"},
+				Locations:     []*Location{},
+				Devices: []*DeviceKind{
+					{
+						Instances: []*DeviceInstance{
+							{
+								Data: map[string]interface{}{
+									"foo": "bar",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc: "data in the device instance output",
+			config: DeviceConfig{
+				SchemeVersion: SchemeVersion{Version: "1.0"},
+				Locations:     []*Location{},
+				Devices: []*DeviceKind{
+					{
+						Instances: []*DeviceInstance{
+							{
+								Outputs: []*DeviceOutput{
+									{
+										Data: map[string]interface{}{
+											"foo": "bar",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// define the validator function. it does nothing and returns nil,
+	// so we should never get an error.
+	var validator = func(_ map[string]interface{}) error {
+		return nil
+	}
+
+	for _, testCase := range testTable {
+		err := testCase.config.ValidateDeviceConfigData(validator)
+		assert.NoError(t, err.Err(), testCase.desc)
+	}
+}
+
+// TestDeviceConfig_ValidateDeviceConfigDataError tests validating config data when there
+// are errors.
+func TestDeviceConfig_ValidateDeviceConfigDataError(t *testing.T) {
+	var testTable = []struct {
+		desc   string
+		config DeviceConfig
+	}{
+		{
+			desc: "data in the device kind output",
+			config: DeviceConfig{
+				SchemeVersion: SchemeVersion{Version: "1.0"},
+				Locations:     []*Location{},
+				Devices: []*DeviceKind{
+					{
+						Outputs: []*DeviceOutput{
+							{
+								Data: map[string]interface{}{
+									"foo": "bar",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc: "data in the device instance",
+			config: DeviceConfig{
+				SchemeVersion: SchemeVersion{Version: "1.0"},
+				Locations:     []*Location{},
+				Devices: []*DeviceKind{
+					{
+						Instances: []*DeviceInstance{
+							{
+								Data: map[string]interface{}{
+									"foo": "bar",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc: "data in the device instance output",
+			config: DeviceConfig{
+				SchemeVersion: SchemeVersion{Version: "1.0"},
+				Locations:     []*Location{},
+				Devices: []*DeviceKind{
+					{
+						Instances: []*DeviceInstance{
+							{
+								Outputs: []*DeviceOutput{
+									{
+										Data: map[string]interface{}{
+											"foo": "bar",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// define the validator function. it does nothing and returns an error, so
+	// all things should fail validation.
+	var validator = func(_ map[string]interface{}) error {
+		return fmt.Errorf("test error")
+	}
+
+	for _, testCase := range testTable {
+		err := testCase.config.ValidateDeviceConfigData(validator)
+		assert.Error(t, err.Err(), testCase.desc)
 	}
 }

--- a/sdk/config/plugin_test.go
+++ b/sdk/config/plugin_test.go
@@ -558,11 +558,19 @@ func TestTransactionSettings_Validate_Error(t *testing.T) {
 	}
 }
 
-// TestDynamicRegistrationSettings_Validate tests validating a DynamicRegistrationSetting.
+// TestDynamicRegistrationSettings_Validate tests validating a DynamicRegistrationSettings.
 // Validation should always pass here.
 func TestDynamicRegistrationSettings_Validate(t *testing.T) {
 	merr := errors.NewMultiError("test")
 	config := DynamicRegistrationSettings{}
+	config.Validate(merr)
+	assert.NoError(t, merr.Err())
+}
+
+// TestHealthSettings_Validate tests validating a HealthSettings. Validation should always pass.
+func TestHealthSettings_Validate(t *testing.T) {
+	merr := errors.NewMultiError("test")
+	config := HealthSettings{}
 	config.Validate(merr)
 	assert.NoError(t, merr.Err())
 }

--- a/sdk/context.go
+++ b/sdk/context.go
@@ -19,6 +19,11 @@ type DynamicDeviceRegistrar func(map[string]interface{}) ([]*Device, error)
 // is specific to the plugin/protocol.
 type DynamicDeviceConfigRegistrar func(map[string]interface{}) ([]*config.DeviceConfig, error)
 
+// DeviceDataValidator is a function that takes the `Data` field of a device config
+// and performs some validation on it. This allows users to provide validation on the
+// plugin-specific config fields.
+type DeviceDataValidator func(map[string]interface{}) error
+
 // Context is the global context for the plugin. It stores various plugin settings,
 // including handler functions for customizable plugin functionality.
 var Context = newPluginContext()
@@ -30,6 +35,7 @@ type PluginContext struct {
 	deviceIdentifier             DeviceIdentifier
 	dynamicDeviceRegistrar       DynamicDeviceRegistrar
 	dynamicDeviceConfigRegistrar DynamicDeviceConfigRegistrar
+	deviceDataValidator          DeviceDataValidator
 }
 
 // newPluginContext creates a new instance of the plugin context, supplying the default
@@ -39,5 +45,6 @@ func newPluginContext() *PluginContext {
 		deviceIdentifier:             defaultDeviceIdentifier,
 		dynamicDeviceRegistrar:       defaultDynamicDeviceRegistration,
 		dynamicDeviceConfigRegistrar: defaultDynamicDeviceConfigRegistration,
+		deviceDataValidator:          defaultDeviceDataValidator,
 	}
 }

--- a/sdk/context_test.go
+++ b/sdk/context_test.go
@@ -17,4 +17,5 @@ func Test_newPluginContext(t *testing.T) {
 	assert.NotNil(t, ctx.deviceIdentifier)
 	assert.NotNil(t, ctx.dynamicDeviceRegistrar)
 	assert.NotNil(t, ctx.dynamicDeviceConfigRegistrar)
+	assert.NotNil(t, ctx.deviceDataValidator)
 }

--- a/sdk/defaults.go
+++ b/sdk/defaults.go
@@ -8,7 +8,7 @@ import (
 )
 
 // defaultDeviceIdentifier is the default implementation that fulfils the DeviceIdentifier
-// type for a plugin.
+// type for a plugin context.
 //
 // This implementation creates a string by joining all values found in the provided
 // device data map. Non-string values in the map are cast to a string.
@@ -35,7 +35,7 @@ func defaultDeviceIdentifier(data map[string]interface{}) string {
 }
 
 // defaultDynamicDeviceRegistration is the default implementation that fulfils the
-// DynamicDeviceRegistrar type for a plugin.
+// DynamicDeviceRegistrar type for a plugin context.
 //
 // This implementation simply returns an empty slice. A plugin will not do any dynamic
 // registration by default.
@@ -44,10 +44,19 @@ func defaultDynamicDeviceRegistration(_ map[string]interface{}) ([]*Device, erro
 }
 
 // defaultDynamicDeviceConfigRegistration is the default implementation that fulfils the
-// DynamicDeviceConfigRegistrar type for a plugin.
+// DynamicDeviceConfigRegistrar type for a plugin context.
 //
 // This implementation simply returns an empty slice. A plugin will not do any dynamic
 // registration by default.
 func defaultDynamicDeviceConfigRegistration(_ map[string]interface{}) ([]*config.DeviceConfig, error) {
 	return []*config.DeviceConfig{}, nil
+}
+
+// defaultDeviceDataValidator is the default implementation that fulfils the
+// DeviceDataValidator type for a plugin context.
+//
+// This implementation simply returns nil. By default, this will not do any custom
+// validation.
+func defaultDeviceDataValidator(_ map[string]interface{}) error {
+	return nil
 }

--- a/sdk/defaults_test.go
+++ b/sdk/defaults_test.go
@@ -33,3 +33,9 @@ func Test_defaultDynamicDeviceConfigRegistration(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Empty(t, cfgs)
 }
+
+// Test_defaultDeviceDataValidator tests the default device data validator functionality.
+func Test_defaultDeviceDataValidator(t *testing.T) {
+	err := defaultDeviceDataValidator(testData)
+	assert.NoError(t, err)
+}

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -29,3 +29,12 @@ func CustomDynamicDeviceConfigRegistration(registrar DynamicDeviceConfigRegistra
 		ctx.dynamicDeviceConfigRegistrar = registrar
 	}
 }
+
+// CustomDeviceDataValidator lets you set a custom function for validating the Data field
+// of a device's config. By default, this data is not validated by the SDK, since it is
+// plugin-specific.
+func CustomDeviceDataValidator(validator DeviceDataValidator) PluginOption {
+	return func(ctx *PluginContext) {
+		ctx.deviceDataValidator = validator
+	}
+}

--- a/sdk/options_test.go
+++ b/sdk/options_test.go
@@ -51,3 +51,18 @@ func TestCustomDynamicDeviceConfigRegistration(t *testing.T) {
 	opt(&ctx)
 	assert.NotNil(t, ctx.dynamicDeviceConfigRegistrar)
 }
+
+// TestCustomDeviceDataValidator tests creating a PluginOption for a custom
+// device data validator function.
+func TestCustomDeviceDataValidator(t *testing.T) {
+	opt := CustomDeviceDataValidator(
+		func(i map[string]interface{}) error {
+			return nil
+		},
+	)
+	ctx := PluginContext{}
+	assert.Nil(t, ctx.deviceDataValidator)
+
+	opt(&ctx)
+	assert.NotNil(t, ctx.deviceDataValidator)
+}

--- a/sdk/plugin.go
+++ b/sdk/plugin.go
@@ -386,6 +386,15 @@ func (plugin *Plugin) processConfig() error { // nolint: gocyclo
 		if multiErr.HasErrors() {
 			return multiErr
 		}
+
+		// Now that we have the configs and have the base scheme validated, we want to
+		// validate the `Data` field of the Device config. This field is plugin-specific,
+		// so we require the plugin author to provide the function for validation.
+		cfg := ctx.Config.(*config.DeviceConfig)
+		multiErr = cfg.ValidateDeviceConfigData(Context.deviceDataValidator)
+		if multiErr.HasErrors() {
+			return multiErr
+		}
 	}
 
 	// 3. Unify Configs


### PR DESCRIPTION
fixes #258 

@Kontazler this can be used for doing validation of the door lock config when we upgrade to sdk1.0