### PR TITLE
Apply namespacing conventions to metainfo tag

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -59,7 +59,7 @@
   branch = "sdk-1.0"
   name = "github.com/vapor-ware/synse-server-grpc"
   packages = ["go"]
-  revision = "7922ce761ae1e8ea87f61527a88ae96f33ba43d9"
+  revision = "4a4c1ab03388660a10abfd90e5660da6c3269f5f"
 
 [[projects]]
   branch = "master"
@@ -88,7 +88,7 @@
     "unix",
     "windows"
   ]
-  revision = "bff228c7b664c5fce602223a05fb708fd8654986"
+  revision = "f4b713d59635e9af9041b0e1b1fd102d95812dbe"
 
 [[projects]]
   name = "golang.org/x/text"

--- a/sdk/meta.go
+++ b/sdk/meta.go
@@ -1,6 +1,9 @@
 package sdk
 
 import (
+	"fmt"
+	"strings"
+
 	log "github.com/Sirupsen/logrus"
 )
 
@@ -11,6 +14,7 @@ var metainfo meta
 type meta struct {
 	Name        string
 	Maintainer  string
+	Tag         string
 	Description string
 	VCS         string
 }
@@ -29,7 +33,17 @@ func SetPluginMeta(name, maintainer, desc, vcs string) {
 	metainfo = meta{
 		Name:        name,
 		Maintainer:  maintainer,
+		Tag:         makeTag(name, maintainer),
 		Description: desc,
 		VCS:         vcs,
 	}
+}
+
+// makeTag creates the tag used in the plugin metainformation.
+func makeTag(name, maintainer string) string {
+	tag := fmt.Sprintf("%s/%s", maintainer, name)
+	tag = strings.ToLower(tag)
+	tag = strings.Replace(tag, "-", "_", -1)
+	tag = strings.Replace(tag, " ", "-", -1)
+	return tag
 }

--- a/sdk/meta_test.go
+++ b/sdk/meta_test.go
@@ -30,3 +30,43 @@ func TestSetPluginMeta(t *testing.T) {
 func TestMetaLog(t *testing.T) {
 	metainfo.log()
 }
+
+// Test_makeTag tests making metainfo tags.
+func Test_makeTag(t *testing.T) {
+	var testTable = []struct {
+		name       string
+		maintainer string
+		expected   string
+	}{
+		{
+			name:       "test",
+			maintainer: "vapor io",
+			expected:   "vapor-io/test",
+		},
+		{
+			name:       "Test",
+			maintainer: "vaporio",
+			expected:   "vaporio/test",
+		},
+		{
+			name:       "Simple Plugin",
+			maintainer: "Vapor I-0",
+			expected:   "vapor-i_0/simple-plugin",
+		},
+		{
+			name:       "Simple Modbus-over-IP",
+			maintainer: "Vapor IO",
+			expected:   "vapor-io/simple-modbus_over_ip",
+		},
+		{
+			name:       "99 bottles of beer",
+			maintainer: "The Wall",
+			expected:   "the-wall/99-bottles-of-beer",
+		},
+	}
+
+	for _, testCase := range testTable {
+		actual := makeTag(testCase.name, testCase.maintainer)
+		assert.Equal(t, testCase.expected, actual)
+	}
+}

--- a/sdk/server.go
+++ b/sdk/server.go
@@ -239,6 +239,7 @@ func (server *server) Metainfo(ctx context.Context, request *synse.Empty) (*syns
 	return &synse.Metadata{
 		Name:        metainfo.Name,
 		Maintainer:  metainfo.Maintainer,
+		Tag:         metainfo.Tag,
 		Description: metainfo.Description,
 		Vcs:         metainfo.VCS,
 		Version:     version.Encode(),


### PR DESCRIPTION
fixes #271 

this PR adds in a `Tag` field to the metainfo, where the maintainer and name are normalized into a namespaced identifier for a plugin.