### PR TITLE
add basic support for handler listener function

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,12 +2,12 @@
 
 
 [[projects]]
-  digest = "1:d867dfa6751c8d7a435821ad3b736310c2ed68945d05b50fb9d23aee0540c8cc"
+  digest = "1:3f53e9e4dfbb664cd62940c9c4b65a2171c66acd0b7621a1a6b8e78513525a52"
   name = "github.com/Sirupsen/logrus"
   packages = ["."]
   pruneopts = "UT"
-  revision = "3e01752db0189b9157070a0e1668a620f9a85da2"
-  version = "v1.0.6"
+  revision = "ad15b42461921f1fb3529b058c6786c6a45d5162"
+  version = "v1.1.1"
 
 [[projects]]
   digest = "1:7f769a7ea697a8e50c8a79a829f53a469e3ca7b8e314434ea9d9a25ca8401cb7"
@@ -38,6 +38,14 @@
   pruneopts = "UT"
   revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
   version = "v1.2.0"
+
+[[projects]]
+  digest = "1:0a69a1c0db3591fcefb47f115b224592c8dfa4368b7ba9fae509d5e16cdc95c8"
+  name = "github.com/konsorten/go-windows-terminal-sequences"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "5c8c8bd35d3832f5d134ae1e1e375b69a4d25242"
+  version = "v1.0.1"
 
 [[projects]]
   digest = "1:808cdddf087fb64baeae67b8dfaee2069034d9704923a3cb8bd96a995421a625"
@@ -85,11 +93,11 @@
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
   pruneopts = "UT"
-  revision = "182538f80094b6a8efaade63a8fd8e0d9d5843dd"
+  revision = "a92615f3c49003920a58dedcf32cf55022cefb8d"
 
 [[projects]]
   branch = "master"
-  digest = "1:1427ef3c5200ade53e1569b34a7fd49dff8df0c2b3cdb9539a727f69ae5eddfa"
+  digest = "1:5dbea1a55ed20bd18a9584b8d50a431ceedc4c48a5872fceb429d59a4c30b3f9"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -101,18 +109,18 @@
     "trace",
   ]
   pruneopts = "UT"
-  revision = "8a410e7b638dca158bf9e766925842f6651ff828"
+  revision = "49bb7cea24b1df9410e1712aa6433dae904ff66a"
 
 [[projects]]
   branch = "master"
-  digest = "1:8ba0a13c04eb83e02db82d7fc4029a62b07b502615424db95dfd2a5be82bca3b"
+  digest = "1:306e2db17d22ee51108d97f0e053755543b4d504d5b699e8aea295cbc4514306"
   name = "golang.org/x/sys"
   packages = [
     "unix",
     "windows",
   ]
   pruneopts = "UT"
-  revision = "49385e6e15226593f68b26af201feec29d5bba22"
+  revision = "fa43e7bc11baaae89f3f902b2b4d832b68234844"
 
 [[projects]]
   digest = "1:7509ba4347d1f8de6ae9be8818b0cd1abc3deeffe28aeaf4be6d4b6b5178d9ca"
@@ -147,14 +155,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:077c1c599507b3b3e9156d17d36e1e61928ee9b53a5b420f10f28ebd4a0b275c"
+  digest = "1:56b0bca90b7e5d1facf5fbdacba23e4e0ce069d25381b8e2f70ef1e7ebfb9c1a"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
   pruneopts = "UT"
-  revision = "c66870c02cf823ceb633bcd05be3c7cda29976f4"
+  revision = "af9cb2a35e7f169ec875002c1829c9b315cddc04"
 
 [[projects]]
-  digest = "1:74f4a872f90f363778088654a2edea7101d62e6fc0784945d38b0ef85e1828d8"
+  digest = "1:23f6471aaea2518fc2f7be25dc12de5980aeab1220c765e657e5c131f550df1c"
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -185,8 +193,8 @@
     "tap",
   ]
   pruneopts = "UT"
-  revision = "32fb0ac620c32ba40a4626ddf94d90d12cce3455"
-  version = "v1.14.0"
+  revision = "8dea3dc473e90c8179e519d91302d0597c0ca1d1"
+  version = "v1.15.0"
 
 [[projects]]
   digest = "1:342378ac4dcb378a5448dd723f0784ae519383532f5e70ade24132c4c8693202"

--- a/examples/listener/.gitignore
+++ b/examples/listener/.gitignore
@@ -1,0 +1,2 @@
+plugin
+device

--- a/examples/listener/Makefile
+++ b/examples/listener/Makefile
@@ -1,0 +1,31 @@
+#
+# Listener Plugin Example
+#
+
+PLUGIN_VERSION := 1.0
+
+GIT_COMMIT ?= $(shell git rev-parse --short HEAD 2> /dev/null || true)
+GIT_TAG    ?= $(shell git describe --tags 2> /dev/null || true)
+BUILD_DATE := $(shell date -u +%Y-%m-%dT%T 2> /dev/null)
+GO_VERSION := $(shell go version | awk '{ print $$3 }')
+
+PKG_CTX := github.com/vapor-ware/synse-sdk/sdk
+LDFLAGS := -w \
+	-X ${PKG_CTX}.BuildDate=${BUILD_DATE} \
+	-X ${PKG_CTX}.GitCommit=${GIT_COMMIT} \
+	-X ${PKG_CTX}.GitTag=${GIT_TAG} \
+	-X ${PKG_CTX}.GoVersion=${GO_VERSION} \
+	-X ${PKG_CTX}.PluginVersion=${PLUGIN_VERSION}
+
+
+all: build pusher
+
+build:
+	@go build -ldflags "${LDFLAGS}" -o plugin
+
+pusher:
+	@go build -o device ./pusher/...
+
+
+.PHONY: all build pusher
+.DEFAULT_GOAL := all

--- a/examples/listener/README.md
+++ b/examples/listener/README.md
@@ -1,0 +1,84 @@
+### Listener Plugin
+
+This directory contains an example of a simple plugin that defines a listener
+function in its device handler. Generally, a device that uses a listener is one
+that generates push-based data for the plugin to collect. The listener will
+listen for this data and update the plugin state accordingly.
+
+In this case, there is only one kind of device, a "pusher". It will push random
+data. In order to collect pushed data, we need something to actually push that
+data. A simple program is defined in the "pusher" directory which can be run
+alongside this plugin to provide the data. See the next section on how to build
+and run the plugin and the pusher data source.
+ 
+#### Usage
+
+To build the pusher data source program, simply
+```bash
+make pusher
+```
+from within this directory. The plugin binary can be built with
+```bash
+make build
+```
+
+Both binaries will be output to the 'listener' directory and should
+be named `device` and `plugin`, respectively. You can run both simultaneously
+in separate shell instances (order doesn't matter):
+
+**Shell 1**
+```console
+$ ./device 
+2018/10/12 11:03:15 Sending data on: :8553
+2018/10/12 11:03:15 << 2596996162
+2018/10/12 11:03:18 << 4039455774
+2018/10/12 11:03:21 << 2854263694
+2018/10/12 11:03:24 << 1879968118
+2018/10/12 11:03:27 << 1823804162
+2018/10/12 11:03:30 << 2949882636
+2018/10/12 11:03:33 << 281908850
+```
+
+**Shell 2**
+```console
+./plugin 
+DEBU[0000] [sdk] adding 1 devices from config           
+DEBU[0000] [sdk] executing 0 pre-run action(s)          
+DEBU[0000] [sdk] executing 0 device setup action(s)     
+INFO[0000] Plugin Info:                                 
+INFO[0000]   Tag:         vaporio/listener-plugin       
+INFO[0000]   Name:        listener plugin               
+INFO[0000]   Maintainer:  vaporio                       
+INFO[0000]   Description: An example plugin with listener device 
+INFO[0000]   VCS:                                       
+INFO[0000] Version Info:                                
+INFO[0000]   Plugin Version: 1.0                        
+INFO[0000]   SDK Version:    1.1.0                      
+INFO[0000]   Git Commit:     95a2def                    
+INFO[0000]   Git Tag:        1.1.0                      
+INFO[0000]   Build Date:     2018-10-12T15:01:46        
+INFO[0000]   Go Version:     go1.10.2                   
+INFO[0000]   OS/Arch:        darwin/amd64               
+INFO[0000] Registered Devices:                          
+INFO[0000]   rack-1-board-1-f9def8b577bf354577e7c0c907fc5b86 (pusher) 
+INFO[0000] --------------------------------             
+DEBU[0000] [sdk] starting plugin run                    
+DEBU[0000] [sdk] registering default health checks      
+DEBU[0000] [health] new periodic health check            interval=30s name="read buffer health"
+DEBU[0000] [health] new periodic health check            interval=30s name="write buffer health"
+DEBU[0000] [data manager] setting up data manager state 
+INFO[0000] [data manager] setting up listeners           handler=pusher
+INFO[0000] [data manager] starting read goroutine (reads enabled)  mode=serial
+INFO[0000] [data manager] starting write goroutine (writes enabled)  mode=serial
+INFO[0000] [data manager] running                       
+DEBU[0000] [grpc] setting up server                      mode=unix
+DEBU[0000] [server] configuring grpc server for insecure transport 
+INFO[0000] [grpc] listening on unix:/tmp/synse/procs/example-plugin.sock 
+INFO[0000] [data manager] running listener               device=f9def8b577bf354577e7c0c907fc5b86 handler=pusher
+[listener] got data: 2854263694
+[listener] got data: 1879968118
+[listener] got data: 1823804162
+[listener] got data: 2949882636
+[listener] got data: 281908850
+```
+

--- a/examples/listener/config.yml
+++ b/examples/listener/config.yml
@@ -1,0 +1,5 @@
+version: 1.2  # listeners added in cfg version 1.2
+debug: true
+network:
+  type: unix
+  address: example-plugin.sock

--- a/examples/listener/config/device/pusher.yaml
+++ b/examples/listener/config/device/pusher.yaml
@@ -1,0 +1,18 @@
+version: 1.0
+locations:
+  - name: r1b1
+    rack:
+      name: rack-1
+    board:
+      name: board-1
+devices:
+  - name: pusher
+    metadata:
+      model: test-device
+    outputs:
+      - type: push_data
+    instances:
+      - info: Test Pusher Device
+        location: r1b1
+        data:
+          address: "localhost:8553"

--- a/examples/listener/plugin.go
+++ b/examples/listener/plugin.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"encoding/binary"
+	"fmt"
+	"log"
+	"net"
+
+	"github.com/vapor-ware/synse-sdk/sdk"
+)
+
+var (
+	pluginName       = "listener plugin"
+	pluginMaintainer = "vaporio"
+	pluginDesc       = "An example plugin with listener device"
+)
+
+// Output types are defined, either statically in the plugin code, or via YAML
+// configuration files. They define the potential outputs of the plugin's devices.
+// A single device could support multiple outputs, but at a minimum requires one.
+var (
+	// The random data coming back from the pusher is random and meaningless,
+	// so we don't ascribe any precision or unit to it.
+	pusherOutput = sdk.OutputType{
+		Name: "push_data",
+	}
+)
+
+// Device Handlers need to be defined to tell the plugin how to handle reads and
+// writes for the different kinds of devices it supports.
+var (
+	// pusherHandler defines the listen behavior for the "pusher" device kind.
+	pusherHandler = sdk.DeviceHandler{
+		Name: "pusher",
+		Listen: func(device *sdk.Device, data chan *sdk.ReadContext) error {
+			// The device data defines the host/port to listen on.
+			address := device.Data["address"].(string)
+
+			addr, err := net.ResolveUDPAddr("udp", address)
+			if err != nil {
+				return err
+			}
+			conn, err := net.ListenUDP("udp", addr)
+			if err != nil {
+				return err
+			}
+			buffer := make([]byte, 4)
+			for {
+				size, err := conn.Read(buffer)
+				if err != nil {
+					// failed read, try again
+					continue
+				}
+				if size != 4 {
+					// Unexpected packet size, try again
+					continue
+				}
+				value := binary.LittleEndian.Uint32(buffer)
+				fmt.Printf("[listener] got data: %v\n", value)
+				reading, err := device.GetOutput("push_data").MakeReading(value)
+				if err != nil {
+					return err
+				}
+				data <- sdk.NewReadContext(device, []*sdk.Reading{reading})
+			}
+		},
+	}
+)
+
+func main() {
+	// Set the metadata for the plugin.
+	sdk.SetPluginMeta(
+		pluginName,
+		pluginMaintainer,
+		pluginDesc,
+		"",
+	)
+
+	// Create a new Plugin instance.
+	plugin := sdk.NewPlugin()
+
+	// Register our output types with the Plugin.
+	err := plugin.RegisterOutputTypes(
+		&pusherOutput,
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Register our device handlers with the Plugin.
+	plugin.RegisterDeviceHandlers(
+		&pusherHandler,
+	)
+
+	// Run the plugin.
+	if err := plugin.Run(); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/examples/listener/pusher/main.go
+++ b/examples/listener/pusher/main.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"encoding/binary"
+	"log"
+	"math/rand"
+	"net"
+	"time"
+)
+
+func main() {
+	addr, err := net.ResolveUDPAddr("udp", ":8553")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	conn, err := net.Dial("udp", addr.String())
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer conn.Close() // nolint: errcheck
+
+	log.Printf("Sending data on: %v", addr.String())
+	for {
+		b := make([]byte, 4)
+		data := rand.Uint32()
+		binary.LittleEndian.PutUint32(b, data)
+		log.Printf("<< %v", data)
+		_, err := conn.Write(b)
+		if err != nil {
+			log.Printf("failed to write. continuing.")
+		}
+		time.Sleep(3 * time.Second)
+	}
+}

--- a/sdk/data_manager.go
+++ b/sdk/data_manager.go
@@ -15,6 +15,29 @@ import (
 // DataManager is the global data manager for the plugin.
 var DataManager = newDataManager()
 
+// ListenerCtx is the context needed for a listener function to be called
+// and retried at a later time if it errors out after the listener goroutine
+// is initially dispatched.
+type ListenerCtx struct {
+	// handler is the DeviceHandler that defines the handler function.
+	handler *DeviceHandler
+
+	// device is the Device that is being listened to via the listener.
+	device *Device
+
+	// restarts is the number of times the listener has been restarted.
+	restarts int
+}
+
+// NewListenerCtx creates a new ListenerCtx for the given handler and device.
+func NewListenerCtx(handler *DeviceHandler, device *Device) *ListenerCtx {
+	return &ListenerCtx{
+		handler:  handler,
+		device:   device,
+		restarts: 0,
+	}
+}
+
 // dataManager handles the reading from and writing to configured devices.
 // It executes the read and write goroutines and uses the channels between
 // those goroutines and its process to update the read and write state.
@@ -33,6 +56,18 @@ type dataManager struct {
 	// Write data is sent to the channel by the `Write` function and is
 	// received by the `pollWrite` function.
 	writeChannel chan *WriteContext
+
+	// listenChannel is the channel that is used to get data from a device
+	// that is being listened to. This is used by the SDK to collect push
+	// based data. While the data in the listenChannel and the data in the
+	// readChannel are similar, they are kept separate so the behaviors of
+	// pull-based/push-based reading can be tuned independently.
+	listenChannel chan *ReadContext
+
+	// listenerRetry is a channel that all listeners will pass a ListenerRetryCtx
+	// to if they fail. This channel is read by a separate goroutine which will
+	// attempt to re-run the listener.
+	listenerRetry chan *ListenerCtx
 
 	// readings is a map of readings, where the key is the GUID of a
 	// device, and the values are the readings associated with that device.
@@ -68,12 +103,16 @@ func (manager *dataManager) run() error {
 		return err
 	}
 
-	// Start the reader/writer
+	// Start the listeners/reader/writer
+	manager.goListen()
 	manager.goRead()
 	manager.goWrite()
 
 	// Update the manager readings state
 	manager.goUpdateData()
+
+	// Watch for failed listeners to retry them
+	go manager.watchForListenerRetry()
 
 	log.Info("[data manager] running")
 	return nil
@@ -88,7 +127,9 @@ func (manager *dataManager) setup() error {
 		return fmt.Errorf("plugin config not set, cannot setup data manager")
 	}
 
-	// Initialize the read and write channels
+	// Initialize the listen, read, and write channels
+	manager.listenerRetry = make(chan *ListenerCtx, 50)
+	manager.listenChannel = make(chan *ReadContext, Config.Plugin.Settings.Listen.Buffer)
 	manager.readChannel = make(chan *ReadContext, Config.Plugin.Settings.Read.Buffer)
 	manager.writeChannel = make(chan *WriteContext, Config.Plugin.Settings.Write.Buffer)
 
@@ -106,6 +147,78 @@ func (manager *dataManager) setup() error {
 // the configuration.
 func (manager *dataManager) writesEnabled() bool {
 	return Config.Plugin.Settings.Write.Enabled
+}
+
+// goListen starts the goroutines for any listener functions for the configured
+// devices. If there are no listener functions defined, this will do nothing.
+func (manager *dataManager) goListen() {
+	// Although we consider listening to be a type of "read" behavior (e.g. collecting
+	// push-based readings vs. collecting pull-based readings), we use different
+	// configuration fields for listening to make it easier to tune independent of
+	// pull-based collection needs. If listening is globally disabled, there is
+	// nothing to do here.
+	if !Config.Plugin.Settings.Listen.Enabled {
+		log.Info("[data manager] skipping listener goroutine(s) (listen disabled)")
+		return
+	}
+
+	// For each handler that has a listener function defined, get the devices for
+	// that handler and start the listener for the devices.
+	for _, handler := range ctx.deviceHandlers {
+		hlog := log.WithField("handler", handler.Name)
+		if handler.Listen != nil {
+			hlog.Info("[data manager] setting up listeners")
+
+			// Get all of the devices that have registered with the handler
+			devices := handler.getDevicesForHandler()
+			if len(devices) == 0 {
+				hlog.Debugf("[data manager] found no devices for handler")
+				continue
+			}
+
+			// For each device, run the listener goroutine
+			for _, device := range devices {
+				ctx := NewListenerCtx(handler, device)
+				go manager.runListener(ctx)
+			}
+		}
+	}
+}
+
+// runListener runs the listener function for a device. If the listener
+// fails, it will attempt to restart the listener.
+func (manager *dataManager) runListener(ctx *ListenerCtx) {
+	log.WithFields(log.Fields{
+		"handler": ctx.handler.Name,
+		"device":  ctx.device.ID(),
+	}).Info("[data manager] running listener")
+
+	err := ctx.handler.Listen(ctx.device, manager.listenChannel)
+	if err != nil {
+		log.WithField("device", ctx.device.ID()).Errorf(
+			"[data manager] failed to listen for device readings: %v", err,
+		)
+		// pass the context to retry channel
+		manager.listenerRetry <- ctx
+	}
+}
+
+// watchForListenerRetry waits for the 'runListener' function to pass a
+// listener context to it via the 'listenerRetry' channel. If it gets
+// a context, that listener had failed and needs to be restarted.
+func (manager *dataManager) watchForListenerRetry() {
+	for {
+		ctx := <-manager.listenerRetry
+		// increment the restart counter
+		ctx.restarts++
+
+		llog := log.WithFields(log.Fields{
+			"manager": ctx.handler.Name,
+			"device":  ctx.device.ID(),
+		})
+		llog.Infof("[data manager] restarting failed listener (restarts %v)", ctx.restarts)
+		go manager.runListener(ctx)
+	}
 }
 
 // goRead starts the goroutine for reading from configured devices.
@@ -378,9 +491,24 @@ func (manager *dataManager) write(w *WriteContext) {
 func (manager *dataManager) goUpdateData() {
 	go func() {
 		for {
-			reading := <-manager.readChannel
+			var (
+				id       string
+				readings []*Reading
+			)
+
+			// Read from the listen and read channel for incoming readings
+			select {
+			case reading := <-manager.readChannel:
+				id = reading.ID()
+				readings = reading.Reading
+			case reading := <-manager.listenChannel:
+				id = reading.ID()
+				readings = reading.Reading
+			}
+
+			// Update the internal map of current reading state
 			manager.dataLock.Lock()
-			manager.readings[reading.ID()] = reading.Reading
+			manager.readings[id] = readings
 			manager.dataLock.Unlock()
 		}
 	}()

--- a/sdk/data_manager_test.go
+++ b/sdk/data_manager_test.go
@@ -72,6 +72,7 @@ func TestDataManager_readOneOkNoLimiter(t *testing.T) {
 		Settings: &PluginSettings{
 			Read:        &ReadSettings{Buffer: 200},
 			Write:       &WriteSettings{Buffer: 200},
+			Listen:      &ListenSettings{Buffer: 100},
 			Transaction: &TransactionSettings{TTL: "2s"},
 		},
 	}
@@ -129,6 +130,7 @@ func TestDataManager_readOneOkWithLimiter(t *testing.T) {
 		Settings: &PluginSettings{
 			Read:        &ReadSettings{Buffer: 200},
 			Write:       &WriteSettings{Buffer: 200},
+			Listen:      &ListenSettings{Buffer: 100},
 			Transaction: &TransactionSettings{TTL: "2s"},
 		},
 		Limiter: &LimiterSettings{Rate: 200, Burst: 200},
@@ -186,6 +188,7 @@ func TestDataManager_readOneErr(t *testing.T) {
 		Settings: &PluginSettings{
 			Read:        &ReadSettings{Buffer: 200},
 			Write:       &WriteSettings{Buffer: 200},
+			Listen:      &ListenSettings{Buffer: 100},
 			Transaction: &TransactionSettings{TTL: "2s"},
 		},
 	}
@@ -234,6 +237,7 @@ func TestDataManager_readBulkOkNoLimiter(t *testing.T) {
 		Settings: &PluginSettings{
 			Read:        &ReadSettings{Buffer: 200},
 			Write:       &WriteSettings{Buffer: 200},
+			Listen:      &ListenSettings{Buffer: 100},
 			Transaction: &TransactionSettings{TTL: "2s"},
 		},
 	}
@@ -310,6 +314,7 @@ func TestDataManager_readBulkOkWithLimiter(t *testing.T) {
 		Settings: &PluginSettings{
 			Read:        &ReadSettings{Buffer: 200},
 			Write:       &WriteSettings{Buffer: 200},
+			Listen:      &ListenSettings{Buffer: 100},
 			Transaction: &TransactionSettings{TTL: "2s"},
 		},
 		Limiter: &LimiterSettings{Rate: 200, Burst: 200},
@@ -386,6 +391,7 @@ func TestDataManager_readBulkError(t *testing.T) {
 		Settings: &PluginSettings{
 			Read:        &ReadSettings{Buffer: 200},
 			Write:       &WriteSettings{Buffer: 200},
+			Listen:      &ListenSettings{Buffer: 100},
 			Transaction: &TransactionSettings{TTL: "2s"},
 		},
 	}
@@ -440,6 +446,7 @@ func TestDataManager_serialReadSingle(t *testing.T) {
 		Settings: &PluginSettings{
 			Read:        &ReadSettings{Buffer: 200},
 			Write:       &WriteSettings{Buffer: 200},
+			Listen:      &ListenSettings{Buffer: 100},
 			Transaction: &TransactionSettings{TTL: "2s"},
 		},
 	}
@@ -501,6 +508,7 @@ func TestDataManager_serialReadSingleBulk(t *testing.T) {
 		Settings: &PluginSettings{
 			Read:        &ReadSettings{Buffer: 200},
 			Write:       &WriteSettings{Buffer: 200},
+			Listen:      &ListenSettings{Buffer: 100},
 			Transaction: &TransactionSettings{TTL: "2s"},
 		},
 	}
@@ -576,6 +584,7 @@ func TestDataManager_parallelReadSingle(t *testing.T) {
 		Settings: &PluginSettings{
 			Read:        &ReadSettings{Buffer: 200},
 			Write:       &WriteSettings{Buffer: 200},
+			Listen:      &ListenSettings{Buffer: 100},
 			Transaction: &TransactionSettings{TTL: "2s"},
 		},
 	}
@@ -638,6 +647,7 @@ func TestDataManager_parallelReadSingleBulk(t *testing.T) {
 		Settings: &PluginSettings{
 			Read:        &ReadSettings{Buffer: 200},
 			Write:       &WriteSettings{Buffer: 200},
+			Listen:      &ListenSettings{Buffer: 100},
 			Transaction: &TransactionSettings{TTL: "2s"},
 		},
 	}
@@ -713,6 +723,7 @@ func TestDataManager_serialReadMultiple(t *testing.T) {
 		Settings: &PluginSettings{
 			Read:        &ReadSettings{Buffer: 200},
 			Write:       &WriteSettings{Buffer: 200},
+			Listen:      &ListenSettings{Buffer: 100},
 			Transaction: &TransactionSettings{TTL: "2s"},
 		},
 	}
@@ -815,6 +826,7 @@ func TestDataManager_parallelReadMultiple(t *testing.T) {
 		Settings: &PluginSettings{
 			Read:        &ReadSettings{Buffer: 200},
 			Write:       &WriteSettings{Buffer: 200},
+			Listen:      &ListenSettings{Buffer: 100},
 			Transaction: &TransactionSettings{TTL: "2s"},
 		},
 	}
@@ -918,6 +930,7 @@ func TestDataManager_writeOkNoLimiter(t *testing.T) {
 		Settings: &PluginSettings{
 			Read:        &ReadSettings{Buffer: 200},
 			Write:       &WriteSettings{Buffer: 200},
+			Listen:      &ListenSettings{Buffer: 100},
 			Transaction: &TransactionSettings{TTL: "2s"},
 		},
 	}
@@ -979,6 +992,7 @@ func TestDataManager_writeOkWithLimiter(t *testing.T) {
 		Settings: &PluginSettings{
 			Read:        &ReadSettings{Buffer: 200},
 			Write:       &WriteSettings{Buffer: 200},
+			Listen:      &ListenSettings{Buffer: 100},
 			Transaction: &TransactionSettings{TTL: "2s"},
 		},
 		Limiter: &LimiterSettings{Rate: 200, Burst: 200},
@@ -1041,6 +1055,7 @@ func TestDataManager_writeNoDevice(t *testing.T) {
 		Settings: &PluginSettings{
 			Read:        &ReadSettings{Buffer: 200},
 			Write:       &WriteSettings{Buffer: 200},
+			Listen:      &ListenSettings{Buffer: 100},
 			Transaction: &TransactionSettings{TTL: "2s"},
 		},
 	}
@@ -1083,6 +1098,7 @@ func TestDataManager_writeError(t *testing.T) {
 		Settings: &PluginSettings{
 			Read:        &ReadSettings{Buffer: 200},
 			Write:       &WriteSettings{Buffer: 200},
+			Listen:      &ListenSettings{Buffer: 100},
 			Transaction: &TransactionSettings{TTL: "2s"},
 		},
 	}
@@ -1144,6 +1160,7 @@ func TestDataManager_serialWriteSingle(t *testing.T) {
 		Settings: &PluginSettings{
 			Read:        &ReadSettings{Buffer: 200},
 			Write:       &WriteSettings{Buffer: 200, Max: 200},
+			Listen:      &ListenSettings{Buffer: 100},
 			Transaction: &TransactionSettings{TTL: "2s"},
 		},
 		Limiter: &LimiterSettings{Rate: 200, Burst: 200},
@@ -1208,6 +1225,7 @@ func TestDataManager_serialWriteMultiple(t *testing.T) {
 		Settings: &PluginSettings{
 			Read:        &ReadSettings{Buffer: 200},
 			Write:       &WriteSettings{Buffer: 200, Max: 200},
+			Listen:      &ListenSettings{Buffer: 100},
 			Transaction: &TransactionSettings{TTL: "2s"},
 		},
 		Limiter: &LimiterSettings{Rate: 200, Burst: 200},
@@ -1294,6 +1312,7 @@ func TestDataManager_parallelWriteSingle(t *testing.T) {
 		Settings: &PluginSettings{
 			Read:        &ReadSettings{Buffer: 200},
 			Write:       &WriteSettings{Buffer: 200, Max: 200},
+			Listen:      &ListenSettings{Buffer: 100},
 			Transaction: &TransactionSettings{TTL: "2s"},
 		},
 		Limiter: &LimiterSettings{Rate: 200, Burst: 200},
@@ -1358,6 +1377,7 @@ func TestDataManager_parallelWriteMultiple(t *testing.T) {
 		Settings: &PluginSettings{
 			Read:        &ReadSettings{Buffer: 200},
 			Write:       &WriteSettings{Buffer: 200, Max: 200},
+			Listen:      &ListenSettings{Buffer: 100},
 			Transaction: &TransactionSettings{TTL: "2s"},
 		},
 		Limiter: &LimiterSettings{Rate: 200, Burst: 200},


### PR DESCRIPTION
#303 

This PR does the bulk of the work for adding a listener as an option to a device handler. It includes a simple example with this working. 

This PR will go into the v1.2.0-staging branch, waiting for other 1.2.0 work to be done before merging into master and cutting a new release.