### PR TITLE
simplify scope of config field versioning

### DIFF
--- a/sdk/config.go
+++ b/sdk/config.go
@@ -85,6 +85,16 @@ func (ctx *ConfigContext) IsOutputTypeConfig() bool {
 	return ok
 }
 
+// TODO (etd) [v2]: In SDK v2, we can probably get rid of this. While versioning
+// the configuration fields is a unique approach to ensuring config compatibility,
+// it doesn't actually buy us much and at this point just adds complexity to the
+// code base. We should be fine to version the config files themselves (e.g.
+// 1, 1.0, v1, ...) and distinguish a v1 config from a v2 config, but at the most
+// all we would be able to do from that is complain and say that the given config
+// file is not compatible with the current version of the SDK, so it really only
+// makes sense to have validation of version at the config level, not at the field
+// level. For v1, we will keep this in for compatibility, but this can be removed
+// for v2. All similar components will be marked with a TODO [v2] tag for removal.
 const (
 	tagAddedIn      = "addedIn"
 	tagDeprecatedIn = "deprecatedIn"
@@ -95,6 +105,9 @@ const (
 // that can be compared to other SchemeVersions.
 type ConfigVersion struct {
 	Major int
+
+	// TODO (etd) [v2]: for v1, disabled checking against the minor version,
+	// can be removed for v2.
 	Minor int
 }
 
@@ -142,31 +155,19 @@ func (version *ConfigVersion) String() string {
 // IsLessThan returns true if the Version is less than the Version
 // provided as a parameter.
 func (version *ConfigVersion) IsLessThan(other *ConfigVersion) bool {
-	if version.Major < other.Major {
-		return true
-	}
-	if version.Major == other.Major && version.Minor < other.Minor {
-		return true
-	}
-	return false
+	return version.Major < other.Major
 }
 
 // IsGreaterOrEqualTo returns true if the ConfigVersion is greater than or equal to
 // the Version provided as a parameter.
 func (version *ConfigVersion) IsGreaterOrEqualTo(other *ConfigVersion) bool {
-	if version.Major > other.Major {
-		return true
-	}
-	if version.Major == other.Major && version.Minor >= other.Minor {
-		return true
-	}
-	return false
+	return version.Major >= other.Major
 }
 
 // IsEqual returns true if the Version is equal to the Version provided
 // as a parameter.
 func (version *ConfigVersion) IsEqual(other *ConfigVersion) bool {
-	return version.Major == other.Major && version.Minor == other.Minor
+	return version.Major == other.Major
 }
 
 // SchemeVersion is a struct that is used to extract the configuration

--- a/sdk/config_test.go
+++ b/sdk/config_test.go
@@ -267,6 +267,8 @@ func TestSchemeVersion_String(t *testing.T) {
 }
 
 // TestSchemeVersion_IsEqual test equality of SchemeVersions
+// TODO (etd) [v2]: this will be changed for v2. for v1, this was updated to
+// only check on the major component of the version.
 func TestSchemeVersion_IsEqual(t *testing.T) {
 	var testTable = []struct {
 		scheme1 *ConfigVersion
@@ -296,7 +298,7 @@ func TestSchemeVersion_IsEqual(t *testing.T) {
 		{
 			scheme1: &ConfigVersion{1, 1},
 			scheme2: &ConfigVersion{1, 2},
-			equal:   false,
+			equal:   true,
 		},
 	}
 
@@ -307,6 +309,8 @@ func TestSchemeVersion_IsEqual(t *testing.T) {
 }
 
 // TestSchemeVersion_IsLessThan tests if one Version is less than another
+// TODO (etd) [v2]: this will be changed for v2. for v1, this was updated to
+// only check on the major component of the version.
 func TestSchemeVersion_IsLessThan(t *testing.T) {
 	var testTable = []struct {
 		scheme1  *ConfigVersion
@@ -336,7 +340,7 @@ func TestSchemeVersion_IsLessThan(t *testing.T) {
 		{
 			scheme1:  &ConfigVersion{1, 1},
 			scheme2:  &ConfigVersion{1, 2},
-			lessThan: true,
+			lessThan: false,
 		},
 		{
 			scheme1:  &ConfigVersion{1, 2},
@@ -352,7 +356,7 @@ func TestSchemeVersion_IsLessThan(t *testing.T) {
 }
 
 // TestSchemeVersion_IsGreaterOrEqualTo tests if one Version is greater than
-// or qual to another
+// or equal to another
 func TestSchemeVersion_IsGreaterOrEqualTo(t *testing.T) {
 	var testTable = []struct {
 		scheme1 *ConfigVersion
@@ -382,7 +386,7 @@ func TestSchemeVersion_IsGreaterOrEqualTo(t *testing.T) {
 		{
 			scheme1: &ConfigVersion{1, 1},
 			scheme2: &ConfigVersion{1, 2},
-			gte:     false,
+			gte:     true,
 		},
 		{
 			scheme1: &ConfigVersion{1, 2},

--- a/sdk/plugin.go
+++ b/sdk/plugin.go
@@ -372,8 +372,7 @@ type PluginSettings struct {
 	Mode string `default:"serial" yaml:"mode,omitempty" addedIn:"1.0"`
 
 	// Listen contains the settings to configure listener behavior.
-	// FIXME (etd) - field versioning is messed up, for now leaving this at 1.0
-	Listen *ListenSettings `default:"{}" yaml:"listen,omitempty" addedIn:"1.0"`
+	Listen *ListenSettings `default:"{}" yaml:"listen,omitempty" addedIn:"1.2"`
 
 	// Read contains the settings to configure read behavior.
 	Read *ReadSettings `default:"{}" yaml:"read,omitempty" addedIn:"1.0"`
@@ -516,16 +515,14 @@ func (settings LimiterSettings) Validate(multiErr *errors.MultiError) {
 // ListenSettings provides configuration options for listener operations.
 // A listener is a function that is used to collect push-based data.
 type ListenSettings struct {
-	// FIXME (etd) - field versioning is messed up, for now leaving this at 1.0
-
 	// Enabled globally enables or disables listening for the plugin.
 	// By default a plugin will have listening enabled.
-	Enabled bool `default:"true" yaml:"enabled,omitempty" addedIn:"1.0"`
+	Enabled bool `default:"true" yaml:"enabled,omitempty" addedIn:"1.2"`
 
 	// Buffer defines the size of the listen buffer. This will be the
 	// size of the channel that passes all the collected push data from
 	// all listener instances to the data manager.
-	Buffer int `default:"100" yaml:"buffer,omitempty" addedIn:"1.0"`
+	Buffer int `default:"100" yaml:"buffer,omitempty" addedIn:"1.2"`
 }
 
 // Validate validates that the ListenSettings has no confiugration errors.

--- a/sdk/validate_test.go
+++ b/sdk/validate_test.go
@@ -353,7 +353,6 @@ func TestSchemeValidator_Validate_Complex_Ok(t *testing.T) {
 		Source: "<complex test config>",
 		Config: &complexTestConfig{
 			SchemeVersion: SchemeVersion{Version: "1.0"},
-			Foo:           true,
 			FloatVal:      20,
 			IntVal:        3,
 			UintVal:       2,
@@ -429,7 +428,7 @@ func TestSchemeValidator_Validate_Complex_Error(t *testing.T) {
 
 	err := validator.Validate(toValidate)
 	assert.Error(t, err.Err())
-	assert.Equal(t, 2, len(err.Errors), err.Error())
+	assert.Equal(t, 1, len(err.Errors), err.Error())
 
 	// check that validation cleanup was successful
 	checkValidationCleanup(t)


### PR DESCRIPTION
#306

This PR disables the check on the minor version of the config field annotated version for addedIn/deprecatedIn/removedIn -- now all checking is only done on the major version. 

This preserves compatibility for the current version (we can specify 1, 1.0, 1.1, 1.2, ...) as the config version and all of them are valid. 

I added some notes where things should be changed/simplified/removed for v2. I've also started a v2 project to start tracking some of these issues.