### PR TITLE
updates to device and config logging

### DIFF
--- a/sdk/config.go
+++ b/sdk/config.go
@@ -417,14 +417,17 @@ func processPluginConfig() error { // nolint: gocyclo
 	}
 
 	// Regardless of whether we pass policy checks/config validation,
-	// we will want to see what the config is, if in debug mode.
-	if log.GetLevel() == log.DebugLevel {
+	// we will want to see what the config is. The config can be nil
+	// if only defaults are being used.
+	if pluginCtx == nil {
+		log.Info("[sdk] no config found from file, checking policy and using defaults")
+	} else {
 		cfg := pluginCtx.Config.(*PluginConfig)
 		json, e := cfg.JSON()
 		if e != nil {
 			log.Errorf("[sdk] failed to marshal plugin config to json: %v", err)
 		} else {
-			log.Debugf("[sdk] plugin config: %v", json)
+			log.Infof("[sdk] plugin config: %v", json)
 		}
 	}
 

--- a/sdk/reader.go
+++ b/sdk/reader.go
@@ -175,11 +175,21 @@ func findConfigs(searchPaths []string, env, name string) (configs []string, err 
 		if len(configs) != 0 {
 			absPath, err := filepath.Abs(path)
 			if err != nil {
+				pwd, e := os.Getwd()
+				if e != nil {
+					// If we fail to resolve the current working directory, there isn't
+					// much else we can do to provide additional context, so we just log
+					// the error and continue on. Chances are that if this is happening
+					// something is wrong, since we should always be able to resolve
+					// the working directory from within the plugin container.
+					log.Warnf("[sdk] unable to get current working directory: %v", e)
+				}
 				// If we fail to get the absolute path, log an error and just
 				// keep the relative path for logging.
-				log.WithField(
-					"path", path,
-				).Error("[sdk] failed to get absolute path for config")
+				log.WithFields(log.Fields{
+					"path": path,
+					"pwd":  pwd,
+				}).Error("[sdk] failed to get absolute path for config")
 				absPath = path
 			}
 			log.WithFields(log.Fields{

--- a/sdk/reader.go
+++ b/sdk/reader.go
@@ -173,7 +173,19 @@ func findConfigs(searchPaths []string, env, name string) (configs []string, err 
 		}
 
 		if len(configs) != 0 {
-			log.WithField("path", path).Debugf("[sdk] found %d config(s)", len(configs))
+			absPath, err := filepath.Abs(path)
+			if err != nil {
+				// If we fail to get the absolute path, log an error and just
+				// keep the relative path for logging.
+				log.WithField(
+					"path", path,
+				).Error("[sdk] failed to get absolute path for config")
+				absPath = path
+			}
+			log.WithFields(log.Fields{
+				"path":    absPath,
+				"configs": configs,
+			}).Info("[sdk] found config files")
 			break
 		}
 	}


### PR DESCRIPTION
fixes #309

this pr:
- logs the device config when a duplicate device ID is found
- logs plugin config at INFO level by default (was DEBUG)
- more context information with files/paths of config files used

The below snippet shows all of the above changes:
```
INFO[0000] [sdk] found config files                      configs="[config.yml]" path=/Users/edaniszewski/go/src/github.com/vapor-ware/synse-sdk/examples/multi_device_plugin
INFO[0000] [sdk] plugin config: {"Version":"1","Debug":true,"Settings":{"Mode":"serial","Read":{"Enabled":true,"Interval":"5s","Buffer":100},"Write":{"Enabled":true,"Interval":"5s","Buffer":100,"Max":100},"Transaction":{"TTL":"8m"}},"Network":{"Type":"unix","Address":"example-plugin.sock","TLS":null},"DynamicRegistration":{"Config":[]},"Limiter":null,"Health":{"UseDefaults":true},"Context":{}} 
INFO[0000] [sdk] found config files                      configs="[config/device/airflow.yaml config/device/temperature.yaml config/device/voltage.yaml]" path=/Users/edaniszewski/go/src/github.com/vapor-ware/synse-sdk/examples/multi_device_plugin/config/device
DEBU[0000] [sdk] adding 10 devices from config          
FATA[0000] [sdk] duplicate id found for device: {"Kind":"airflow","Metadata":{"model":"air8884"},"Plugin":"multi device plugin","Info":"Airflow Device 3","Location":{"Rack":"rack-2","Board":"board-1"},"Data":{"id":3},"Outputs":[{"Version":"","Name":"airflow","Precision":2,"Unit":{"Name":"cubic feet per meter","Symbol":"CFM"},"ScalingFactor":"","Info":"","Data":null}],"SortOrdinal":0} 
```