### PR TITLE
Windowed cache

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -80,12 +80,12 @@
   version = "v1.2.2"
 
 [[projects]]
-  branch = "master"
-  digest = "1:bf033fb06435e52e54e920d172f72b11b2ea91e44b2b9a5e21e57a616590f9d7"
+  branch = "cached-readings"
+  digest = "1:a95be5a656edf57b48a06335bbb627fc2eb5f37890df1183bbaab9443c43cae1"
   name = "github.com/vapor-ware/synse-server-grpc"
   packages = ["go"]
   pruneopts = "UT"
-  revision = "5a6280c2ec33b2eb3781e7700ddfec04294bf3c6"
+  revision = "b080d990ed2c4a7b52d6b1510b76fd2e2c911d4f"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -47,7 +47,7 @@
 
 [[constraint]]
   name = "github.com/vapor-ware/synse-server-grpc"
-  branch = "master"
+  branch = "cached-readings"
 
 [[constraint]]
   branch = "master"

--- a/internal/test/grpc.go
+++ b/internal/test/grpc.go
@@ -7,6 +7,10 @@ import (
 	"google.golang.org/grpc"
 )
 
+//
+// CAPABILITIES
+//
+
 // MockCapabilitiesStream mocks the stream for the Capabilities request, with no error.
 type MockCapabilitiesStream struct {
 	grpc.ServerStream
@@ -35,6 +39,10 @@ type MockCapabilitiesStreamErr struct {
 func (mock *MockCapabilitiesStreamErr) Send(capability *synse.DeviceCapability) error {
 	return fmt.Errorf("grpc error")
 }
+
+//
+// DEVICES
+//
 
 // MockDevicesStream mocks the stream for the Devices request, with no error.
 type MockDevicesStream struct {
@@ -65,6 +73,10 @@ func (mock *MockDevicesStreamErr) Send(device *synse.Device) error {
 	return fmt.Errorf("grpc error")
 }
 
+//
+// READ
+//
+
 // MockReadStream mocks the stream for the Read request, with no error.
 type MockReadStream struct {
 	grpc.ServerStream
@@ -93,6 +105,43 @@ type MockReadStreamErr struct {
 func (mock *MockReadStreamErr) Send(reading *synse.Reading) error {
 	return fmt.Errorf("grpc error")
 }
+
+//
+// READ CACHED
+//
+
+// MockReadCachedStream mocks the stream for the ReadCached request, with no error.
+type MockReadCachedStream struct {
+	grpc.ServerStream
+	Results []*synse.DeviceReading
+}
+
+// NewMockReadCachedStream creates a new mock read cache stream.
+func NewMockReadCachedStream() *MockReadCachedStream {
+	return &MockReadCachedStream{
+		Results: []*synse.DeviceReading{},
+	}
+}
+
+// Send fulfils the stream interface for the mock grpc stream.
+func (mock *MockReadCachedStream) Send(reading *synse.DeviceReading) error {
+	mock.Results = append(mock.Results, reading)
+	return nil
+}
+
+// MockReadCachedStreamErr mocks the stream for a ReadCached request, with error.
+type MockReadCachedStreamErr struct {
+	grpc.ServerStream
+}
+
+// Send fulfils the stream interface for the mock grpc stream.
+func (mock *MockReadCachedStreamErr) Send(reading *synse.DeviceReading) error {
+	return fmt.Errorf("grpc error")
+}
+
+//
+// TRANSACTION
+//
 
 // MockTransactionStream mocks the stream for the Transaction request, with no error.
 type MockTransactionStream struct {

--- a/sdk/cache.go
+++ b/sdk/cache.go
@@ -61,11 +61,11 @@ func getReadingsFromCache(start, end string, readings chan *ReadContext) {
 
 	// Parse the timestamps for the starting and ending bounds on the data
 	// window, if they are set.
-	startTime, err := ParseRFC3339(start)
+	startTime, err := ParseRFC3339Nano(start)
 	if err != nil {
 		log.Errorf("[cache] failed to parse start time: %v", err)
 	}
-	endTime, err := ParseRFC3339(end)
+	endTime, err := ParseRFC3339Nano(end)
 	if err != nil {
 		log.Errorf("[cache] failed to parse end time: %v", err)
 	}
@@ -84,7 +84,7 @@ func getReadingsFromCache(start, end string, readings chan *ReadContext) {
 // on the provided start and end bounds, and passes them to the provided channel.
 func getCachedReadings(start, end time.Time, readings chan *ReadContext) {
 	for ts, item := range readingsCache.Items() {
-		cachedTime, err := ParseRFC3339(ts)
+		cachedTime, err := ParseRFC3339Nano(ts)
 		if err != nil {
 			// If we can't parse the timestamp from the cache, an error is logged
 			// and we move on. We should always be using RFC3339 formatted timestamps
@@ -130,9 +130,9 @@ func getCurrentReadings(readings chan *ReadContext) {
 		}
 
 		readings <- &ReadContext{
-			Rack: dev.Location.Rack,
-			Board: dev.Location.Board,
-			Device: dev.id,
+			Rack:    dev.Location.Rack,
+			Board:   dev.Location.Board,
+			Device:  dev.id,
 			Reading: data,
 		}
 	}

--- a/sdk/cache.go
+++ b/sdk/cache.go
@@ -58,6 +58,10 @@ func addReadingToCache(ctx *ReadContext) {
 // reading data from the cache and pass it through the channel. Once the function returns,
 // the channel will be closed.
 func getReadingsFromCache(start, end string, readings chan *ReadContext) { // nolint: gocyclo
+
+	// TODO (etd): If cached readings are disabled for the plugin, just
+	// get and return the current readings.
+
 	// Whether we exit the function by passing all cached readings through
 	// the channel or by erroring out, we want to close the channel. This
 	// will signal to caller (who provides the channel) that we are done.

--- a/sdk/cache.go
+++ b/sdk/cache.go
@@ -1,0 +1,72 @@
+package sdk
+
+import (
+	log "github.com/Sirupsen/logrus"
+	"github.com/patrickmn/go-cache"
+)
+
+// readingsCache is the cache that will store the readings collected by the
+// plugin, if it is enabled in the plugin configuration.
+var readingsCache *cache.Cache
+
+// cacheContexts is how ReadContexts are stored in the readings cache. Since
+// we may want to filter readings based on the timestamp they were added, we
+// want to store the ReadContexts against a timestamp key. In order to support
+// multiple contexts at a given time, we store them as a slice.
+type cacheContexts []*ReadContext
+
+// setupReadingsCache sets up a cache that will be used to store readings,
+// if it is enabled in the plugin configuration.
+func setupReadingsCache() {
+	cacheSettings := Config.Plugin.Settings.Cache
+	if cacheSettings.Enabled {
+		log.Debugf("[cache] readings cache is enabled")
+		if readingsCache == nil {
+			log.WithField(
+				"ttl", cacheSettings.TTL,
+			).Info("[cache] creating new readings cache")
+			readingsCache = cache.New(cacheSettings.TTL, cacheSettings.TTL*2)
+		}
+	} else {
+		log.Debug("[cache] readings cache disabled - will only provide current readings")
+	}
+}
+
+// TODO (etd) - have a "ReadingCache" type or something to encapsulate
+// all of this?
+
+// TODO (etd) -- this needs some testing..
+// addReading adds a reading to the readings cache.
+func addReadingToCache(ctx *ReadContext) {
+	if Config.Plugin.Settings.Cache.Enabled {
+		now := GetCurrentTime()
+		item, exists := readingsCache.Get(now)
+		if !exists {
+			newCtxs := cacheContexts([]*ReadContext{ctx})
+			readingsCache.Set(now, &newCtxs, cache.DefaultExpiration)
+		} else {
+			cached := item.(*cacheContexts)
+			*cached = append(*cached, ctx)
+		}
+	}
+}
+
+// todo: figure out the grpc api - we'll probably want some filtering
+// on the cache and this can specify the bounds of that filter.
+type readingCacheFilter struct {
+	from string
+	until string
+}
+
+// TODO - maybe passing in a channel and dumping all the read contexts
+// to the channel makes more sense.
+func getReadingsFromCache(filter *readingCacheFilter) []*ReadContext {
+	var out []*ReadContext
+	for _, item := range readingsCache.Items() {
+		ctxs := item.Object.(*cacheContexts)
+		for _, ctx := range *ctxs {
+			out = append(out, ctx)
+		}
+	}
+	return out
+}

--- a/sdk/cache_test.go
+++ b/sdk/cache_test.go
@@ -1,0 +1,324 @@
+package sdk
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Test setting up the readings cache when it is enabled in the config.
+func Test_setupReadingsCache_Enabled(t *testing.T) {
+	defer func() {
+		// reset plugin state
+		resetContext()
+		Config.reset()
+
+		// reset readings cache
+		readingsCache = nil
+	}()
+
+	Config.Plugin = &PluginConfig{
+		Settings: &PluginSettings{
+			Cache: &CacheSettings{
+				Enabled: true,
+			},
+		},
+	}
+
+	assert.Nil(t, readingsCache)
+	setupReadingsCache()
+	assert.NotNil(t, readingsCache)
+}
+
+// Test setting up the readings cache when it is disabled in the config.
+func Test_setupReadingsCache_Disabled(t *testing.T) {
+	defer func() {
+		// reset plugin state
+		resetContext()
+		Config.reset()
+
+		// reset readings cache
+		readingsCache = nil
+	}()
+
+	Config.Plugin = &PluginConfig{
+		Settings: &PluginSettings{
+			Cache: &CacheSettings{
+				Enabled: false,
+			},
+		},
+	}
+
+	assert.Nil(t, readingsCache)
+	setupReadingsCache()
+	assert.Nil(t, readingsCache)
+}
+
+// Test adding a reading to the cache when the timestamp does not already
+// exist in the cache.
+// TODO: figure out how to mock out GetCurrentTime to test when the timestamp does exist
+func Test_addReadingToCache_Enabled(t *testing.T) {
+	defer func() {
+		// reset plugin state
+		resetContext()
+		Config.reset()
+
+		// reset readings cache
+		readingsCache = nil
+	}()
+
+	Config.Plugin = &PluginConfig{
+		Settings: &PluginSettings{
+			Cache: &CacheSettings{
+				Enabled: true,
+			},
+		},
+	}
+	setupReadingsCache()
+
+	assert.Equal(t, 0, readingsCache.ItemCount())
+	addReadingToCache(&ReadContext{
+		Rack:    "rack",
+		Board:   "board",
+		Device:  "device",
+		Reading: []*Reading{{Type: "test", Value: 1}},
+	})
+	assert.Equal(t, 1, readingsCache.ItemCount())
+}
+
+// Test adding a reading to the cache when it is disabled in the config.
+func Test_addReadingToCache_Disabled(t *testing.T) {
+	defer func() {
+		// reset plugin state
+		resetContext()
+		Config.reset()
+
+		// reset readings cache
+		readingsCache = nil
+	}()
+
+	Config.Plugin = &PluginConfig{
+		Settings: &PluginSettings{
+			Cache: &CacheSettings{
+				Enabled: false,
+			},
+		},
+	}
+
+	assert.Nil(t, readingsCache)
+	addReadingToCache(&ReadContext{
+		Rack:    "rack",
+		Board:   "board",
+		Device:  "device",
+		Reading: []*Reading{{Type: "test", Value: 1}},
+	})
+	assert.Nil(t, readingsCache)
+}
+
+// Test getting readings when the cache is enabled.
+func Test_getReadingsFromCache_Enabled(t *testing.T) {
+	defer func() {
+		// reset plugin state
+		resetContext()
+		Config.reset()
+
+		// reset readings cache
+		readingsCache = nil
+	}()
+
+	Config.Plugin = &PluginConfig{
+		Settings: &PluginSettings{
+			Cache: &CacheSettings{
+				Enabled: true,
+			},
+		},
+	}
+	setupReadingsCache()
+
+	// manually add to the readingsCache
+	ctx := &ReadContext{
+		Rack:    "rack",
+		Board:   "board",
+		Device:  "device",
+		Reading: []*Reading{{Type: "test", Value: 1}},
+	}
+	ctxs := cacheContexts([]*ReadContext{ctx})
+	readingsCache.Set("2018-10-16T22:08:50.000000000Z", &ctxs, 0)
+
+	c := make(chan *ReadContext, 10)
+	go getReadingsFromCache("", "", c)
+
+	var results []*ReadContext
+	for r := range c {
+		results = append(results, r)
+	}
+	assert.Equal(t, 1, len(results))
+}
+
+// Test getting readings from the cache with a start bound applied.
+func Test_getReadingsFromCache_Enabled_Start(t *testing.T) {
+	defer func() {
+		// reset plugin state
+		resetContext()
+		Config.reset()
+
+		// reset readings cache
+		readingsCache = nil
+	}()
+
+	Config.Plugin = &PluginConfig{
+		Settings: &PluginSettings{
+			Cache: &CacheSettings{
+				Enabled: true,
+			},
+		},
+	}
+	setupReadingsCache()
+
+	// manually add to the readingsCache
+	ctx := &ReadContext{
+		Rack:    "rack",
+		Board:   "board",
+		Device:  "device",
+		Reading: []*Reading{{Type: "test", Value: 1}},
+	}
+	ctxs := cacheContexts([]*ReadContext{ctx})
+	readingsCache.Set("2018-10-16T22:08:50.000000000Z", &ctxs, 0)
+	readingsCache.Set("2018-10-16T22:08:51.000000000Z", &ctxs, 0)
+	readingsCache.Set("2018-10-16T22:08:52.000000000Z", &ctxs, 0)
+
+	c := make(chan *ReadContext, 10)
+	go getReadingsFromCache("2018-10-16T22:08:51.000000000Z", "", c)
+
+	var results []*ReadContext
+	for r := range c {
+		results = append(results, r)
+	}
+	assert.Equal(t, 2, len(results))
+}
+
+// Test getting readings from the cache with an end bound applied.
+func Test_getReadingsFromCache_Enabled_End(t *testing.T) {
+	defer func() {
+		// reset plugin state
+		resetContext()
+		Config.reset()
+
+		// reset readings cache
+		readingsCache = nil
+	}()
+
+	Config.Plugin = &PluginConfig{
+		Settings: &PluginSettings{
+			Cache: &CacheSettings{
+				Enabled: true,
+			},
+		},
+	}
+	setupReadingsCache()
+
+	// manually add to the readingsCache
+	ctx := &ReadContext{
+		Rack:    "rack",
+		Board:   "board",
+		Device:  "device",
+		Reading: []*Reading{{Type: "test", Value: 1}},
+	}
+	ctxs := cacheContexts([]*ReadContext{ctx})
+	readingsCache.Set("2018-10-16T22:08:50.000000000Z", &ctxs, 0)
+	readingsCache.Set("2018-10-16T22:08:51.000000000Z", &ctxs, 0)
+	readingsCache.Set("2018-10-16T22:08:52.000000000Z", &ctxs, 0)
+
+	c := make(chan *ReadContext, 10)
+	go getReadingsFromCache("", "2018-10-16T22:08:51.000000000Z", c)
+
+	var results []*ReadContext
+	for r := range c {
+		results = append(results, r)
+	}
+	assert.Equal(t, 2, len(results))
+}
+
+// Test getting readings from the cache with both start and end bounds applied.
+func Test_getReadingsFromCache_Enabled_StartEnd(t *testing.T) {
+	defer func() {
+		// reset plugin state
+		resetContext()
+		Config.reset()
+
+		// reset readings cache
+		readingsCache = nil
+	}()
+
+	Config.Plugin = &PluginConfig{
+		Settings: &PluginSettings{
+			Cache: &CacheSettings{
+				Enabled: true,
+			},
+		},
+	}
+	setupReadingsCache()
+
+	// manually add to the readingsCache
+	ctx := &ReadContext{
+		Rack:    "rack",
+		Board:   "board",
+		Device:  "device",
+		Reading: []*Reading{{Type: "test", Value: 1}},
+	}
+	ctxs := cacheContexts([]*ReadContext{ctx})
+	readingsCache.Set("2018-10-16T22:08:50.000000000Z", &ctxs, 0)
+	readingsCache.Set("2018-10-16T22:08:51.000000000Z", &ctxs, 0)
+	readingsCache.Set("2018-10-16T22:08:52.000000000Z", &ctxs, 0)
+	readingsCache.Set("2018-10-16T22:08:53.000000000Z", &ctxs, 0)
+	readingsCache.Set("2018-10-16T22:08:54.000000000Z", &ctxs, 0)
+
+	c := make(chan *ReadContext, 10)
+	go getReadingsFromCache("2018-10-16T22:08:51.500000000Z", "2018-10-16T22:08:53.000000000Z", c)
+	var results []*ReadContext
+	for r := range c {
+		results = append(results, r)
+	}
+	assert.Equal(t, 2, len(results))
+}
+
+// Test getting readings from the cache when no data falls within the bounds.
+func Test_getReadingsFromCache_Enabled_OutOfBounds(t *testing.T) {
+	defer func() {
+		// reset plugin state
+		resetContext()
+		Config.reset()
+
+		// reset readings cache
+		readingsCache = nil
+	}()
+
+	Config.Plugin = &PluginConfig{
+		Settings: &PluginSettings{
+			Cache: &CacheSettings{
+				Enabled: true,
+			},
+		},
+	}
+}
+
+// Test getting readings from the cache when the cache is disabled. This
+// should lead to the current readings (the data manager state) being used.
+func Test_getReadingsFromCache_Disabled(t *testing.T) {
+	defer func() {
+		// reset plugin state
+		resetContext()
+		Config.reset()
+
+		// reset readings cache
+		readingsCache = nil
+	}()
+
+	Config.Plugin = &PluginConfig{
+		Settings: &PluginSettings{
+			Cache: &CacheSettings{
+				Enabled: false,
+			},
+		},
+	}
+}

--- a/sdk/data_manager.go
+++ b/sdk/data_manager.go
@@ -529,6 +529,22 @@ func (manager *dataManager) getReadings(device string) []*Reading {
 	return manager.readings[device]
 }
 
+// getAllReadings safely copies the current reading state in the data manager and
+// returns all of the readings.
+func (manager *dataManager) getAllReadings() map[string][]*Reading {
+	mapCopy := make(map[string][]*Reading)
+	manager.dataLock.RLock()
+	defer manager.dataLock.RUnlock()
+
+	// Iterate over the map to make a copy - we want a copy or else we would be
+	// returning a reference to the underlying data which should only be accessed
+	// in a lock context.
+	for k, v := range manager.readings {
+		mapCopy[k] = v
+	}
+	return mapCopy
+}
+
 // Read fulfills a Read request by providing the latest data read from a device
 // and framing it up for the gRPC response.
 func (manager *dataManager) Read(req *synse.DeviceFilter) ([]*synse.Reading, error) {

--- a/sdk/data_manager.go
+++ b/sdk/data_manager.go
@@ -497,11 +497,12 @@ func (manager *dataManager) goUpdateData() {
 			)
 
 			// Read from the listen and read channel for incoming readings
+			var reading *ReadContext
 			select {
-			case reading := <-manager.readChannel:
+			case reading = <-manager.readChannel:
 				id = reading.ID()
 				readings = reading.Reading
-			case reading := <-manager.listenChannel:
+			case reading = <-manager.listenChannel:
 				id = reading.ID()
 				readings = reading.Reading
 			}
@@ -510,6 +511,9 @@ func (manager *dataManager) goUpdateData() {
 			manager.dataLock.Lock()
 			manager.readings[id] = readings
 			manager.dataLock.Unlock()
+
+			// update the readings cache
+			addReadingToCache(reading)
 		}
 	}()
 }

--- a/sdk/data_manager_test.go
+++ b/sdk/data_manager_test.go
@@ -1446,3 +1446,14 @@ func TestDataManager_parallelWriteMultiple(t *testing.T) {
 		assert.Equal(t, "", ctx.transaction.message)
 	}
 }
+
+// Test creating a new instance of a listener context.
+func TestNewListenerCtx(t *testing.T) {
+	handler := &DeviceHandler{}
+	device := &Device{}
+
+	ctx := NewListenerCtx(handler, device)
+	assert.Equal(t, handler, ctx.handler)
+	assert.Equal(t, device, ctx.device)
+	assert.Equal(t, 0, ctx.restarts)
+}

--- a/sdk/device.go
+++ b/sdk/device.go
@@ -441,7 +441,7 @@ func updateDeviceMap(devices []*Device) {
 		ctx.devices[d.GUID()] = d
 	}
 	if foundDuplicates {
-		log.Fatal("[sdk] unable to run plugin with duplicate device configurations")
+		log.Panic("[sdk] unable to run plugin with duplicate device configurations")
 	}
 }
 

--- a/sdk/plugin.go
+++ b/sdk/plugin.go
@@ -231,6 +231,10 @@ func (plugin *Plugin) setup() error {
 	}
 	setupTransactionCache(ttl)
 
+	// Set up the readings cache, if its configured
+	// TODO
+
+
 	// Initialize a gRPC server for the Plugin to use.
 	plugin.server = newServer(
 		Config.Plugin.Network.Type,
@@ -383,6 +387,10 @@ type PluginSettings struct {
 	// Transaction contains the settings to configure transaction
 	// handling behavior.
 	Transaction *TransactionSettings `default:"{}" yaml:"transaction,omitempty" addedIn:"1.0"`
+
+	// Cache contains the settings to configure local data caching
+	// by the plugin.
+	Cache *CacheSettings `default:"{}" yaml:"cache,omitempty" addedIn:"1.2"`
 }
 
 // Validate validates that the PluginSettings has no configuration errors.
@@ -672,5 +680,24 @@ type HealthSettings struct {
 
 // Validate validates that the HealthSettings has no configuration errors.
 func (settings HealthSettings) Validate(multiErr *errors.MultiError) {
+	// Nothing to validate
+}
+
+// CacheSettings provides configuration options for an in-memory windowed
+// cache for plugin readings.
+type CacheSettings struct{
+	// Enabled sets whether the plugin will use a local
+	// in-memory cache to store a small window of readings.
+	// By default, the cache is not enabled.
+	Enabled bool `default:"false" yaml:"enabled,omitempty" addedIn:"1.2"`
+
+	// TTL is the time-to-live for a reading in the readings cache.
+	// This will only be used if the cache is enabled. Once a reading
+	// has exceeded its TTL, it will be removed from the cache.
+	TTL time.Duration `default:"3m" yaml:"ttl,omitempty" addedIn:"1.2"`
+}
+
+// Validate validates that the CacheSettings has no configuration errors.
+func (settings CacheSettings) Validate(multiErr *errors.MultiError) {
 	// Nothing to validate
 }

--- a/sdk/plugin.go
+++ b/sdk/plugin.go
@@ -232,8 +232,7 @@ func (plugin *Plugin) setup() error {
 	setupTransactionCache(ttl)
 
 	// Set up the readings cache, if its configured
-	// TODO
-
+	setupReadingsCache()
 
 	// Initialize a gRPC server for the Plugin to use.
 	plugin.server = newServer(
@@ -685,7 +684,7 @@ func (settings HealthSettings) Validate(multiErr *errors.MultiError) {
 
 // CacheSettings provides configuration options for an in-memory windowed
 // cache for plugin readings.
-type CacheSettings struct{
+type CacheSettings struct {
 	// Enabled sets whether the plugin will use a local
 	// in-memory cache to store a small window of readings.
 	// By default, the cache is not enabled.

--- a/sdk/plugin_test.go
+++ b/sdk/plugin_test.go
@@ -737,3 +737,97 @@ func TestHealthSettings_Validate(t *testing.T) {
 	config.Validate(merr)
 	assert.NoError(t, merr.Err())
 }
+
+// Test validating the ListenSettings successfully.
+func TestListenSettings_Validate_Ok(t *testing.T) {
+	var testTable = []struct {
+		desc   string
+		config ListenSettings
+	}{
+		{
+			desc: "listen enabled, small buffer",
+			config: ListenSettings{
+				Enabled: true,
+				Buffer:  1,
+			},
+		},
+		{
+			desc: "listen enabled, larger buffer",
+			config: ListenSettings{
+				Enabled: true,
+				Buffer:  100,
+			},
+		},
+		{
+			desc: "listen disabled, small buffer",
+			config: ListenSettings{
+				Enabled: false,
+				Buffer:  1,
+			},
+		},
+		{
+			desc: "listen disabled, larger buffer",
+			config: ListenSettings{
+				Enabled: false,
+				Buffer:  100,
+			},
+		},
+	}
+
+	for _, testCase := range testTable {
+		merr := errors.NewMultiError("test")
+
+		testCase.config.Validate(merr)
+		assert.NoError(t, merr.Err(), testCase.desc)
+	}
+}
+
+// Test validating the ListenSettings unsuccessfully.
+func TestListenSettings_Validate_Error(t *testing.T) {
+	var testTable = []struct {
+		desc     string
+		errCount int
+		config   ListenSettings
+	}{
+		{
+			desc:     "listen enabled, zero buffer",
+			errCount: 1,
+			config: ListenSettings{
+				Enabled: true,
+				Buffer:  0,
+			},
+		},
+		{
+			desc:     "listen enabled, negative buffer",
+			errCount: 1,
+			config: ListenSettings{
+				Enabled: true,
+				Buffer:  -1,
+			},
+		},
+		{
+			desc:     "listen disabled, zero buffer",
+			errCount: 1,
+			config: ListenSettings{
+				Enabled: false,
+				Buffer:  0,
+			},
+		},
+		{
+			desc:     "listen disabled, negative buffer",
+			errCount: 1,
+			config: ListenSettings{
+				Enabled: false,
+				Buffer:  -1,
+			},
+		},
+	}
+
+	for _, testCase := range testTable {
+		merr := errors.NewMultiError("test")
+
+		testCase.config.Validate(merr)
+		assert.Error(t, merr.Err(), testCase.desc)
+		assert.Equal(t, testCase.errCount, len(merr.Errors), merr.Error())
+	}
+}

--- a/sdk/type_test.go
+++ b/sdk/type_test.go
@@ -543,3 +543,41 @@ func TestNilOutput(t *testing.T) {
 		t.Error("nil OutputType should fail")
 	}
 }
+
+// Test dumping an OutputType to a JSON string.
+func TestOutputType_JSON(t *testing.T) {
+	var testTable = []struct {
+		output   OutputType
+		expected string
+	}{
+		{
+			output:   OutputType{},
+			expected: `{"Version":"","Name":"","Precision":0,"Unit":{"Name":"","Symbol":""},"ScalingFactor":""}`,
+		},
+		{
+			output: OutputType{
+				Name:      "foo",
+				Precision: 2,
+			},
+			expected: `{"Version":"","Name":"foo","Precision":2,"Unit":{"Name":"","Symbol":""},"ScalingFactor":""}`,
+		},
+		{
+			output: OutputType{
+				Name:      "test",
+				Precision: 4,
+				Unit: Unit{
+					Name:   "unit",
+					Symbol: "u",
+				},
+				ScalingFactor: "1e6",
+			},
+			expected: `{"Version":"","Name":"test","Precision":4,"Unit":{"Name":"unit","Symbol":"u"},"ScalingFactor":"1e6"}`,
+		},
+	}
+
+	for _, testCase := range testTable {
+		actual, err := testCase.output.JSON()
+		assert.NoError(t, err)
+		assert.Equal(t, testCase.expected, actual)
+	}
+}

--- a/sdk/utils.go
+++ b/sdk/utils.go
@@ -21,6 +21,22 @@ func GetCurrentTime() string {
 	return time.Now().UTC().Format(time.RFC3339Nano)
 }
 
+// ParseRFC3339 parses a timestamp string in RFC3339 format into a Time struct.
+// If it is given an empty string, it will return the zero-value for a Time
+// instance. You can check if it is a zero time with the Time's `IsZero` method.
+func ParseRFC3339(timestamp string) (t time.Time, err error) {
+	if timestamp == "" {
+		return
+	}
+	t, err = time.Parse(time.RFC3339, timestamp)
+	if err != nil {
+		log.WithField(
+			"timestamp", timestamp,
+		).Error("[sdk] failed to parse timestamp from RFC3339 format")
+	}
+	return
+}
+
 // GetTypeByName gets the output type with the given name from the collection of
 // output types registered with the SDK for the plugin. If an output type with the
 // given name does not exist, an error is returned.

--- a/sdk/utils.go
+++ b/sdk/utils.go
@@ -21,18 +21,18 @@ func GetCurrentTime() string {
 	return time.Now().UTC().Format(time.RFC3339Nano)
 }
 
-// ParseRFC3339 parses a timestamp string in RFC3339 format into a Time struct.
+// ParseRFC3339Nano parses a timestamp string in RFC3339Nano format into a Time struct.
 // If it is given an empty string, it will return the zero-value for a Time
 // instance. You can check if it is a zero time with the Time's `IsZero` method.
-func ParseRFC3339(timestamp string) (t time.Time, err error) {
+func ParseRFC3339Nano(timestamp string) (t time.Time, err error) {
 	if timestamp == "" {
 		return
 	}
-	t, err = time.Parse(time.RFC3339, timestamp)
+	t, err = time.Parse(time.RFC3339Nano, timestamp)
 	if err != nil {
 		log.WithField(
 			"timestamp", timestamp,
-		).Error("[sdk] failed to parse timestamp from RFC3339 format")
+		).Error("[sdk] failed to parse timestamp from RFC3339Nano format")
 	}
 	return
 }

--- a/sdk/utils_test.go
+++ b/sdk/utils_test.go
@@ -5,6 +5,8 @@ import (
 	"sort"
 	"testing"
 
+	"time"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -238,6 +240,82 @@ func TestFilterDevicesErr(t *testing.T) {
 	for _, testCase := range filterDevicesTestTable {
 		_, err := filterDevices(testCase)
 		assert.Error(t, err)
+	}
+}
+
+// TestParseRFC3339Nano_Ok tests successfully parsing an RFC3339 timestamp
+// into a Time struct.
+func TestParseRFC3339Nano_Ok(t *testing.T) {
+	// get the EST location
+	est, err := time.LoadLocation("EST")
+	assert.NoError(t, err)
+
+	var tests = []struct {
+		timestamp string
+		expected  time.Time
+	}{
+		{
+			// no timestamp defaults to zero value for time
+			timestamp: "",
+			expected:  time.Time{},
+		},
+		{
+			// rfc3339 utc
+			timestamp: "2018-10-16T18:22:50Z",
+			expected:  time.Date(2018, 10, 16, 18, 22, 50, 0, time.UTC),
+		},
+		{
+			// rfc3339nano utc
+			timestamp: "2018-10-16T18:22:50.573971054Z",
+			expected:  time.Date(2018, 10, 16, 18, 22, 50, 573971054, time.UTC),
+		},
+		{
+			// rcf3339 est
+			timestamp: "2018-10-16T13:25:00-05:00",
+			expected:  time.Date(2018, 10, 16, 13, 25, 0, 0, est),
+		},
+		{
+			// rfc3339nano est
+			timestamp: "2018-10-16T13:25:00.410241272-05:00",
+			expected:  time.Date(2018, 10, 16, 13, 25, 0, 410241272, est),
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			actual, err := ParseRFC3339Nano(tt.timestamp)
+			assert.NoError(t, err)
+			assert.True(t, tt.expected.Equal(actual))
+		})
+	}
+}
+
+// TestParseRFC3339Nano_Error tests unsuccessfully parsing a timestamp into
+// a Time struct
+func TestParseRFC3339Nano_Error(t *testing.T) {
+	var tests = []string{
+		"foobar",
+		"...",
+		"16 Oct 18 18:22 UTC",
+		"16 Oct 18 13:25 EST",
+		"Tue Oct 16 18:22:50 2018",
+		"Tue Oct 16 13:25:00 2018",
+		"6:22PM",
+		"1:25PM",
+		"Tue, 16 Oct 2018 18:22:50 +0000",
+		"Tue, 16 Oct 2018 13:25:00 -0500",
+		"Oct 16 18:22:50.573997",
+		"Oct 16 13:25:00.410271",
+		"Tue Oct 16 18:22:50 UTC 2018",
+		"Tue Oct 16 13:25:00 EST 2018",
+	}
+
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			actual, err := ParseRFC3339Nano(tt)
+			assert.Error(t, err)
+			assert.Empty(t, actual)
+		})
 	}
 }
 


### PR DESCRIPTION
#305 

This PR adds a configurable windowed cache for storing plugin data locally. If disabled, it behaves like it does currently. The new ReadCached grpc route will just return a dump of all the current readings.

If enabled, each reading will be cached for a configurable amount of time. This means that we can get better data resolution if we need it. Read would still get the current reading, but historical things (like blackbox) could get a dump of the reading cache to see all the readings (which could be useful since otherwise the resolution would be tied to the poll rate, which may lose lots of data depending on how slow it is - this is particularly the case with push-based data sources).