### PR TITLE
Log time in milliseconds.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,12 +2,12 @@
 
 
 [[projects]]
-  digest = "1:3f53e9e4dfbb664cd62940c9c4b65a2171c66acd0b7621a1a6b8e78513525a52"
+  digest = "1:69b1cc331fca23d702bd72f860c6a647afd0aa9fcbc1d0659b1365e26546dd70"
   name = "github.com/Sirupsen/logrus"
   packages = ["."]
   pruneopts = "UT"
-  revision = "ad15b42461921f1fb3529b058c6786c6a45d5162"
-  version = "v1.1.1"
+  revision = "bcd833dfe83d3cebad139e4a29ed79cb2318bf95"
+  version = "v1.2.0"
 
 [[projects]]
   digest = "1:7f769a7ea697a8e50c8a79a829f53a469e3ca7b8e314434ea9d9a25ca8401cb7"
@@ -93,11 +93,11 @@
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
   pruneopts = "UT"
-  revision = "0c41d7ab0a0ee717d4590a44bcb987dfd9e183eb"
+  revision = "3d3f9f413869b949e48070b5bc593aa22cc2b8f2"
 
 [[projects]]
   branch = "master"
-  digest = "1:505dbee0833715a72a529bb57c354826ad42a4496fad787fa143699b4de1a6d0"
+  digest = "1:6ca51c5d8a610b3da56856df7a8f8f3e075eba8d5f7a4acbadd79b2d2a368054"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -109,18 +109,18 @@
     "trace",
   ]
   pruneopts = "UT"
-  revision = "9b4f9f5ad5197c79fd623a3638e70d8b26cef344"
+  revision = "adae6a3d119ae4890b46832a2e88a95adc62b8e7"
 
 [[projects]]
   branch = "master"
-  digest = "1:899c684138eb2844811b7f97e264d3c65d533dbedc59549fa58fc2bf316f83a1"
+  digest = "1:6a875550c3b582f6c2d7e2ce44aba792511f00016d7c46b0a4fb26f730ef3058"
   name = "golang.org/x/sys"
   packages = [
     "unix",
     "windows",
   ]
   pruneopts = "UT"
-  revision = "44b849a8bc13eb42e95e6c6c5e360481b73ec710"
+  revision = "66b7b1311ac80bbafcd2daeef9a5e6e2cd1e2399"
 
 [[projects]]
   digest = "1:a2ab62866c75542dd18d2b069fec854577a20211d7c0ea6ae746072a1dccdd18"
@@ -147,11 +147,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:c9e7a4b4d47c0ed205d257648b0e5b0440880cb728506e318f8ac7cd36270bc4"
+  digest = "1:9fdc2b55e8e0fafe4b41884091e51e77344f7dc511c5acedcfd98200003bff90"
   name = "golang.org/x/time"
   packages = ["rate"]
   pruneopts = "UT"
-  revision = "fbb02b2291d28baffd63558aa44b4b56f178d650"
+  revision = "85acf8d2951cb2a3bde7632f9ff273ef0379bcbd"
 
 [[projects]]
   branch = "master"
@@ -159,7 +159,7 @@
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
   pruneopts = "UT"
-  revision = "94acd270e44e65579b9ee3cdab25034d33fed608"
+  revision = "b5d43981345bdb2c233eb4bf3277847b48c6fdc6"
 
 [[projects]]
   digest = "1:c3ad9841823db6da420a5625b367913b4ff54bbe60e8e3c98bd20e243e62e2d2"

--- a/sdk/device.go
+++ b/sdk/device.go
@@ -1,11 +1,10 @@
 package sdk
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
-
-	"encoding/json"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/vapor-ware/synse-sdk/sdk/errors"

--- a/sdk/plugin.go
+++ b/sdk/plugin.go
@@ -1,13 +1,12 @@
 package sdk
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
-
-	"encoding/json"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/creasty/defaults"
@@ -176,12 +175,28 @@ func (plugin *Plugin) onQuit() {
 	os.Exit(0)
 }
 
+// setupLogger sets up the logger. Currently this just gives us sub second time
+// resolution, but can be expanded on later.
+func setupLogger() error {
+	// Set formatter that gives at least milliseconds.
+	log.SetFormatter(&log.TextFormatter{
+		TimestampFormat: "2006-01-02T15:04:05.999Z07:00",
+	})
+
+	return nil // There may be scenarios where we need to fail later (unclear).
+}
+
 // setup performs the pre-run setup actions for a plugin.
 func (plugin *Plugin) setup() error {
 	// Register system calls for graceful stopping.
 	signal.Notify(plugin.quit, syscall.SIGTERM)
 	signal.Notify(plugin.quit, syscall.SIGINT)
 	go plugin.onQuit()
+
+	err := setupLogger()
+	if err != nil {
+		return err
+	}
 
 	// The plugin name must be set as metainfo, since it is used in the Device
 	// model. Check if it is set here. If not, return an error.
@@ -194,7 +209,7 @@ func (plugin *Plugin) setup() error {
 	parseFlags()
 
 	// Check that the registered device handlers do not have any conflicting names.
-	err := ctx.checkDeviceHandlers()
+	err = ctx.checkDeviceHandlers()
 	if err != nil {
 		return err
 	}

--- a/sdk/utils_test.go
+++ b/sdk/utils_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"sort"
 	"testing"
-
 	"time"
 
 	"github.com/stretchr/testify/assert"


### PR DESCRIPTION
Tested on the VEM with i2c master. We can now see how long calls are taking. Previous traces were seconds only.

```
time="2018-11-15T21:19:12.672Z" level=debug msg="SDP610 reading channel 1."
time="2018-11-15T21:19:12.674Z" level=debug msg="channel 1, chReading \x01, readChannel 1"
time="2018-11-15T21:19:12.674Z" level=debug msg="OK: set differential pressure channel to: 1"
time="2018-11-15T21:19:12.694Z" level=debug msg="[grpc] devices rpc request" request=
time="2018-11-15T21:19:12.865Z" level=debug msg="SDP610 reading channel 1 returning [-191.89999999999998 -165.29999999999998 -
```