### PR TITLE
Add optional delay after serial reads to avoid overwhelming a small d…

### DIFF
--- a/sdk/data_manager_test.go
+++ b/sdk/data_manager_test.go
@@ -482,7 +482,7 @@ func TestDataManager_serialReadSingle(t *testing.T) {
 
 	// Pass a reading in
 	assert.Equal(t, 0, len(d.readChannel))
-	d.serialRead()
+	d.serialRead(time.Nanosecond)
 	assert.Equal(t, 1, len(d.readChannel))
 
 	// Get the reading out
@@ -558,7 +558,7 @@ func TestDataManager_serialReadSingleBulk(t *testing.T) {
 
 	// Pass a reading in
 	assert.Equal(t, 0, len(d.readChannel))
-	d.serialRead()
+	d.serialRead(time.Nanosecond)
 	assert.Equal(t, 1, len(d.readChannel))
 
 	// Get the reading out
@@ -799,7 +799,7 @@ func TestDataManager_serialReadMultiple(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, 0, len(d.readChannel))
-	d.serialRead()
+	d.serialRead(time.Nanosecond)
 	assert.Equal(t, 3, len(d.readChannel))
 
 	for i := 0; i < 3; i++ {

--- a/sdk/plugin.go
+++ b/sdk/plugin.go
@@ -560,6 +560,10 @@ type ReadSettings struct {
 	// Buffer defines the size of the read buffer. This will be
 	// the size of the channel that passes along read responses.
 	Buffer int `default:"100" yaml:"buffer,omitempty" addedIn:"1.0"`
+
+	// SerialReadInterval specifies the interval to pause between serial reads.
+	// This is here to avoid overwhelming a device. This is 0s by default.
+	SerialReadInterval string `default:"0s" yaml:"serialReadInterval,omitempty" addedIn:"1.3"`
 }
 
 // Validate validates that the ReadSettings has no configuration errors.
@@ -568,6 +572,13 @@ func (settings ReadSettings) Validate(multiErr *errors.MultiError) {
 	_, err := settings.GetInterval()
 	if err != nil {
 		log.WithField("config", settings).Error("[validation] bad interval")
+		multiErr.Add(errors.NewValidationError(multiErr.Context["source"], err.Error()))
+	}
+
+	// Try parsing the serial read interval to validate it is a correctly specified duration string.
+	_, err = settings.GetSerialReadInterval()
+	if err != nil {
+		log.WithField("config", settings).Error("[validation] bad serial read interval")
 		multiErr.Add(errors.NewValidationError(multiErr.Context["source"], err.Error()))
 	}
 
@@ -588,6 +599,13 @@ func (settings ReadSettings) Validate(multiErr *errors.MultiError) {
 // has been validated successfully, this should never return an error.
 func (settings *ReadSettings) GetInterval() (time.Duration, error) {
 	return time.ParseDuration(settings.Interval)
+}
+
+// GetSerialReadInterval gets the duration to wait between serial reads.
+// This is here to avoid overwhelming a device.
+func (settings *ReadSettings) GetSerialReadInterval() (time.Duration, error) {
+	log.Debugf("GetSerialReadInterval settings: %v", settings)
+	return time.ParseDuration(settings.SerialReadInterval)
 }
 
 // WriteSettings provides configuration options for write operations.

--- a/sdk/plugin_test.go
+++ b/sdk/plugin_test.go
@@ -523,10 +523,11 @@ func TestReadSettings_Validate_Ok(t *testing.T) {
 		config ReadSettings
 	}{
 		{
-			desc: "ReadSettings has valid interval and buffer size",
+			desc: "ReadSettings has valid interval and buffer size and SerialReadInterval",
 			config: ReadSettings{
-				Interval: "5s",
-				Buffer:   100,
+				Interval:           "5s",
+				Buffer:             100,
+				SerialReadInterval: "0s",
 			},
 		},
 	}
@@ -550,29 +551,41 @@ func TestReadSettings_Validate_Error(t *testing.T) {
 			desc:     "ReadSettings has invalid interval",
 			errCount: 1,
 			config: ReadSettings{
-				Interval: "foobar",
-				Buffer:   100,
+				Interval:           "foobar",
+				Buffer:             100,
+				SerialReadInterval: "1s",
+			},
+		},
+		{
+			desc:     "ReadSettings has invalid serial read interval",
+			errCount: 1,
+			config: ReadSettings{
+				Interval:           "5s",
+				Buffer:             100,
+				SerialReadInterval: "invalid",
 			},
 		},
 		{
 			desc:     "ReadSettings has invalid buffer size",
 			errCount: 1,
 			config: ReadSettings{
-				Interval: "1s",
-				Buffer:   0,
+				Interval:           "1s",
+				Buffer:             0,
+				SerialReadInterval: "1s",
 			},
 		},
 		{
 			desc:     "ReadSettings has invalid interval and invalid buffer size",
 			errCount: 2,
 			config: ReadSettings{
-				Interval: "xyz",
-				Buffer:   -1,
+				Interval:           "xyz",
+				Buffer:             -1,
+				SerialReadInterval: "1s",
 			},
 		},
 		{
 			desc:     "ReadSettings is empty",
-			errCount: 2,
+			errCount: 3,
 			config:   ReadSettings{},
 		},
 	}


### PR DESCRIPTION
…evice.

We need this for the VEM PLC since it can't keep up with our poll rates. If it does, then the browser (which BasX uses) will fail.

Tested with modbus (which uses it) and i2c (which doesn't).