### PR TITLE
reuse node for docker stages in ci

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -23,6 +23,7 @@ pipeline {
       agent {
         docker {
           image 'vaporio/golang:1.11'
+          reuseNode true
         }
       }
       steps {
@@ -49,6 +50,7 @@ pipeline {
       agent {
         docker {
           image 'vaporio/golang:1.11'
+          reuseNode true
         }
       }
       steps {
@@ -69,6 +71,7 @@ pipeline {
       agent {
         docker {
           image 'vaporio/golang:1.11'
+          reuseNode true
         }
       }
       environment {
@@ -93,6 +96,7 @@ pipeline {
       agent {
         docker {
           image 'vaporio/golang:1.11'
+          reuseNode true
         }
       }
       steps {


### PR DESCRIPTION
When working on migrating other repos to Jenkins, I noticed that Jenkins uses a second workspace for things that run in docker vs. things that run on the host node. This isn't a huge deal here since we aren't generating build artifacts for releases, etc, but I wanted to update here to remain consistent with how we will be doing it in other places. Plus, if we do eventually want to use build artifacts from a container, this will mean we are already set up to do so.