### PR TITLE
update server to use v3 grpc API

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,20 +2,20 @@
 
 
 [[projects]]
-  digest = "1:69b1cc331fca23d702bd72f860c6a647afd0aa9fcbc1d0659b1365e26546dd70"
+  digest = "1:87c2e02fb01c27060ccc5ba7c5a407cc91147726f8f40b70cceeedbc52b1f3a8"
   name = "github.com/Sirupsen/logrus"
   packages = ["."]
   pruneopts = "UT"
-  revision = "bcd833dfe83d3cebad139e4a29ed79cb2318bf95"
-  version = "v1.2.0"
+  revision = "e1e72e9de974bd926e5c56f83753fba2df402ce5"
+  version = "v1.3.0"
 
 [[projects]]
-  digest = "1:7f769a7ea697a8e50c8a79a829f53a469e3ca7b8e314434ea9d9a25ca8401cb7"
+  digest = "1:ed4582b92b69928dec6d82f78d1ad64863b89e631217bfdc5c63b3066a053eea"
   name = "github.com/creasty/defaults"
   packages = ["."]
   pruneopts = "UT"
-  revision = "a7e48e2230891fc7456c8ab918c424c5b06c3192"
-  version = "v1.2.1"
+  revision = "edf4f6a95a3223dfff4eff2c404103e756fef68d"
+  version = "v1.3.0"
 
 [[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
@@ -72,32 +72,32 @@
   version = "v1.2.1"
 
 [[projects]]
-  digest = "1:18752d0b95816a1b777505a97f71c7467a8445b8ffb55631a7bf779f6ba4fa83"
+  digest = "1:972c2427413d41a1e06ca4897e8528e5a1622894050e2f527b38ddf0f343f759"
   name = "github.com/stretchr/testify"
   packages = ["assert"]
   pruneopts = "UT"
-  revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
-  version = "v1.2.2"
+  revision = "ffdc059bfe9ce6a4e144ba849dbedead332c6053"
+  version = "v1.3.0"
 
 [[projects]]
-  digest = "1:a95be5a656edf57b48a06335bbb627fc2eb5f37890df1183bbaab9443c43cae1"
+  branch = "v3/staging"
+  digest = "1:7f85ae1c1a9cfa4713636238472d8e9c56be62f0e8874aa237b1a331615b3f6c"
   name = "github.com/vapor-ware/synse-server-grpc"
   packages = ["go"]
   pruneopts = "UT"
-  revision = "3bc0b24b2bfbc8df1d67f02607d13380318d68ee"
-  version = "1.1.0"
+  revision = "0a5d0a3f99ceeccc505a1c71c47b497f3b8b0024"
 
 [[projects]]
   branch = "master"
-  digest = "1:3f3a05ae0b95893d90b9b3b5afdb79a9b3d96e4e36e099d841ae602e4aca0da8"
+  digest = "1:fde12c4da6237363bf36b81b59aa36a43d28061167ec4acb0d41fc49464e28b9"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
   pruneopts = "UT"
-  revision = "3d3f9f413869b949e48070b5bc593aa22cc2b8f2"
+  revision = "193df9c0f06f8bb35fba505183eaf0acc0136505"
 
 [[projects]]
   branch = "master"
-  digest = "1:6ca51c5d8a610b3da56856df7a8f8f3e075eba8d5f7a4acbadd79b2d2a368054"
+  digest = "1:fc7b6b4384e1e849d99eab58eca4f8c0a76bad4699117d5077a9a5c3c83e289e"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -109,18 +109,18 @@
     "trace",
   ]
   pruneopts = "UT"
-  revision = "adae6a3d119ae4890b46832a2e88a95adc62b8e7"
+  revision = "65e2d4e15006aab9813ff8769e768bbf4bb667a0"
 
 [[projects]]
   branch = "master"
-  digest = "1:6a875550c3b582f6c2d7e2ce44aba792511f00016d7c46b0a4fb26f730ef3058"
+  digest = "1:8975c6b66d95adc1cd08820aba7ad6b60b165725a401c4177c0eaa866170bb10"
   name = "golang.org/x/sys"
   packages = [
     "unix",
     "windows",
   ]
   pruneopts = "UT"
-  revision = "66b7b1311ac80bbafcd2daeef9a5e6e2cd1e2399"
+  revision = "3b5209105503162ded1863c307ac66fec31120dd"
 
 [[projects]]
   digest = "1:a2ab62866c75542dd18d2b069fec854577a20211d7c0ea6ae746072a1dccdd18"
@@ -155,31 +155,36 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:56b0bca90b7e5d1facf5fbdacba23e4e0ce069d25381b8e2f70ef1e7ebfb9c1a"
+  digest = "1:077c1c599507b3b3e9156d17d36e1e61928ee9b53a5b420f10f28ebd4a0b275c"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
   pruneopts = "UT"
-  revision = "b5d43981345bdb2c233eb4bf3277847b48c6fdc6"
+  revision = "4b09977fb92221987e99d190c8f88f2c92727a29"
 
 [[projects]]
-  digest = "1:c3ad9841823db6da420a5625b367913b4ff54bbe60e8e3c98bd20e243e62e2d2"
+  digest = "1:9ab5a33d8cb5c120602a34d2e985ce17956a4e8c2edce7e6961568f95e40c09a"
   name = "google.golang.org/grpc"
   packages = [
     ".",
     "balancer",
     "balancer/base",
     "balancer/roundrobin",
+    "binarylog/grpc_binarylog_v1",
     "codes",
     "connectivity",
     "credentials",
+    "credentials/internal",
     "encoding",
     "encoding/proto",
     "grpclog",
     "internal",
     "internal/backoff",
+    "internal/binarylog",
     "internal/channelz",
     "internal/envconfig",
     "internal/grpcrand",
+    "internal/grpcsync",
+    "internal/syscall",
     "internal/transport",
     "keepalive",
     "metadata",
@@ -193,16 +198,16 @@
     "tap",
   ]
   pruneopts = "UT"
-  revision = "2e463a05d100327ca47ac218281906921038fd95"
-  version = "v1.16.0"
+  revision = "a02b0774206b209466313a0b525d2c738fe407eb"
+  version = "v1.18.0"
 
 [[projects]]
-  digest = "1:342378ac4dcb378a5448dd723f0784ae519383532f5e70ade24132c4c8693202"
+  digest = "1:4d2e5a73dc1500038e504a8d78b986630e3626dc027bc030ba5c75da257cdb96"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
   pruneopts = "UT"
-  revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
-  version = "v2.2.1"
+  revision = "51d6538a90f86fe93ac480b35f37b2be17fef232"
+  version = "v2.2.2"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -46,8 +46,8 @@
   version = "1.2.2"
 
 [[constraint]]
+  branch = "v3/staging"
   name = "github.com/vapor-ware/synse-server-grpc"
-  version = "1.1.0"
 
 [[constraint]]
   branch = "master"

--- a/sdk/data_manager.go
+++ b/sdk/data_manager.go
@@ -483,7 +483,7 @@ func (manager *dataManager) write(w *WriteContext) {
 
 	device := ctx.devices[w.ID()]
 	if device == nil {
-		w.transaction.setStateError()
+		w.transaction.setStatusError()
 		msg := "no device found with ID " + w.ID()
 		w.transaction.message = msg
 		log.Error(msg)
@@ -491,7 +491,7 @@ func (manager *dataManager) write(w *WriteContext) {
 		data := decodeWriteData(w.data)
 		err := device.Write(data)
 		if err != nil {
-			w.transaction.setStateError()
+			w.transaction.setStatusError()
 			w.transaction.message = err.Error()
 			log.Errorf("[data manager] failed to write to device %v: %v", w.device, err)
 		}

--- a/sdk/health/health.go
+++ b/sdk/health/health.go
@@ -107,17 +107,20 @@ type Status struct {
 }
 
 // Encode converts the health Status into the Synse GRPC HealthCheck message.
-func (status *Status) Encode() *synse.HealthCheck {
-	s := synse.PluginHealth_OK
+func (status *Status) Encode() *synse.V3HealthCheck {
+
+	// TODO (etd): could probably just encode this directly in the Status obj
+	healthStatus := synse.HealthStatus_OK
 	if !status.Ok {
-		s = synse.PluginHealth_FAILING
+		healthStatus = synse.HealthStatus_FAILING
 	}
-	return &synse.HealthCheck{
-		Name:      status.Name,
-		Status:    s,
-		Message:   status.Message,
+
+	return &synse.V3HealthCheck{
+		Name: status.Name,
+		Status: healthStatus,
+		Message: status.Message,
 		Timestamp: status.Timestamp,
-		Type:      status.Type,
+		Type: status.Type,
 	}
 }
 

--- a/sdk/health/health_test.go
+++ b/sdk/health/health_test.go
@@ -96,7 +96,7 @@ func TestStatus_Encode(t *testing.T) {
 	}
 	out := s.Encode()
 	assert.Equal(t, "foo", out.Name)
-	assert.Equal(t, synse.PluginHealth_OK, out.Status)
+	assert.Equal(t, synse.HealthStatus_OK, out.Status)
 	assert.Equal(t, "", out.Message)
 	assert.Equal(t, "now", out.Timestamp)
 	assert.Equal(t, "test", out.Type)

--- a/sdk/models.go
+++ b/sdk/models.go
@@ -42,45 +42,49 @@ func NewReading(output *Output, value interface{}) (reading *Reading, err error)
 }
 
 // encode translates the Reading type to the corresponding gRPC Reading message.
-func (reading *Reading) encode() *synse.Reading { // nolint: gocyclo
-	r := synse.Reading{
+func (reading *Reading) encode() *synse.V3Reading { // nolint: gocyclo
+	r := synse.V3Reading{
 		Timestamp: reading.Timestamp,
 		Type:      reading.Type,
-		Info:      reading.Info,
+		Context: map[string]string{},
 		Unit:      reading.Unit.encode(),
+	}
+
+	if reading.Info != "" {
+		r.Context["info"] = reading.Info
 	}
 
 	switch t := reading.Value.(type) {
 	case string:
-		r.Value = &synse.Reading_StringValue{StringValue: t}
+		r.Value = &synse.V3Reading_StringValue{StringValue: t}
 	case bool:
-		r.Value = &synse.Reading_BoolValue{BoolValue: t}
+		r.Value = &synse.V3Reading_BoolValue{BoolValue: t}
 	case float64:
-		r.Value = &synse.Reading_Float64Value{Float64Value: t}
+		r.Value = &synse.V3Reading_Float64Value{Float64Value: t}
 	case float32:
-		r.Value = &synse.Reading_Float32Value{Float32Value: t}
+		r.Value = &synse.V3Reading_Float32Value{Float32Value: t}
 	case int64:
-		r.Value = &synse.Reading_Int64Value{Int64Value: t}
+		r.Value = &synse.V3Reading_Int64Value{Int64Value: t}
 	case int32:
-		r.Value = &synse.Reading_Int32Value{Int32Value: t}
+		r.Value = &synse.V3Reading_Int32Value{Int32Value: t}
 	case int16:
-		r.Value = &synse.Reading_Int32Value{Int32Value: int32(t)}
+		r.Value = &synse.V3Reading_Int32Value{Int32Value: int32(t)}
 	case int8:
-		r.Value = &synse.Reading_Int32Value{Int32Value: int32(t)}
+		r.Value = &synse.V3Reading_Int32Value{Int32Value: int32(t)}
 	case int:
-		r.Value = &synse.Reading_Int64Value{Int64Value: int64(t)}
+		r.Value = &synse.V3Reading_Int64Value{Int64Value: int64(t)}
 	case []byte:
-		r.Value = &synse.Reading_BytesValue{BytesValue: t}
+		r.Value = &synse.V3Reading_BytesValue{BytesValue: t}
 	case uint64:
-		r.Value = &synse.Reading_Uint64Value{Uint64Value: t}
+		r.Value = &synse.V3Reading_Uint64Value{Uint64Value: t}
 	case uint32:
-		r.Value = &synse.Reading_Uint32Value{Uint32Value: t}
+		r.Value = &synse.V3Reading_Uint32Value{Uint32Value: t}
 	case uint16:
-		r.Value = &synse.Reading_Uint32Value{Uint32Value: uint32(t)}
+		r.Value = &synse.V3Reading_Uint32Value{Uint32Value: uint32(t)}
 	case uint8:
-		r.Value = &synse.Reading_Uint32Value{Uint32Value: uint32(t)}
+		r.Value = &synse.V3Reading_Uint32Value{Uint32Value: uint32(t)}
 	case uint:
-		r.Value = &synse.Reading_Uint64Value{Uint64Value: uint64(t)}
+		r.Value = &synse.V3Reading_Uint64Value{Uint64Value: uint64(t)}
 	case nil:
 		r.Value = nil
 	default:
@@ -131,7 +135,7 @@ type WriteContext struct {
 	device      string
 	board       string
 	rack        string
-	data        *synse.WriteData
+	data        *synse.V3WriteData
 }
 
 // ID returns a compound string that can identify the resource by its
@@ -143,18 +147,18 @@ func (ctx *WriteContext) ID() string {
 
 // WriteData is an SDK alias for the Synse gRPC WriteData. This is done to
 // make writing new plugins easier.
-type WriteData synse.WriteData
+type WriteData synse.V3WriteData
 
 // encode translates the WriteData to a corresponding gRPC WriteData.
-func (w *WriteData) encode() *synse.WriteData {
-	return &synse.WriteData{
+func (w *WriteData) encode() *synse.V3WriteData {
+	return &synse.V3WriteData{
 		Data:   w.Data,
 		Action: w.Action,
 	}
 }
 
 // decodeWriteData decodes the gRPC WriteData to the SDK WriteData.
-func decodeWriteData(data *synse.WriteData) *WriteData {
+func decodeWriteData(data *synse.V3WriteData) *WriteData {
 	return &WriteData{
 		Data:   data.Data,
 		Action: data.Action,

--- a/sdk/server.go
+++ b/sdk/server.go
@@ -10,8 +10,6 @@ import (
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/vapor-ware/synse-sdk/sdk/errors"
-	"github.com/vapor-ware/synse-sdk/sdk/health"
 	"github.com/vapor-ware/synse-server-grpc/go"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -119,7 +117,7 @@ func (server *server) Serve() error {
 
 	// Create the grpc server instance, passing in any server options.
 	svr := grpc.NewServer(opts...)
-	synse.RegisterPluginServer(svr, server)
+	synse.RegisterV3PluginServer(svr, server)
 	server.grpc = svr
 
 	log.Infof("[grpc] listening on %s:%s", server.network, server.address)
@@ -225,201 +223,201 @@ func (server *server) Stop() {
 	}
 }
 
+//
+// gRPC API Routes
+//
+
 // Test is the handler for the Synse GRPC Plugin service's `Test` RPC method.
-func (server *server) Test(ctx context.Context, request *synse.Empty) (*synse.Status, error) {
-	log.WithField("request", request).Debug("[grpc] test rpc request")
-	return &synse.Status{Ok: true}, nil
+func (server *server) Test(ctx context.Context, request *synse.Empty) (*synse.V3TestStatus, error) {
+	return &synse.V3TestStatus{}, nil
+
+	//log.WithField("request", request).Debug("[grpc] test rpc request")
+	//return &synse.Status{Ok: true}, nil
 }
 
 // Version is the handler for the Synse GRPC Plugin service's `Version` RPC method.
-func (server *server) Version(ctx context.Context, request *synse.Empty) (*synse.VersionInfo, error) {
-	log.WithField("request", request).Debug("[grpc] version rpc request")
-	return version.Encode(), nil
+func (server *server) Version(ctx context.Context, request *synse.Empty) (*synse.V3Version, error) {
+	return &synse.V3Version{}, nil
+
+	//log.WithField("request", request).Debug("[grpc] version rpc request")
+	//return version.Encode(), nil
 }
 
 // Health is the handler for the Synse GRPC Plugin service's `Health` RPC method.
-func (server *server) Health(ctx context.Context, request *synse.Empty) (*synse.PluginHealth, error) {
-	log.WithField("request", request).Debug("[grpc] health rpc request")
-	statuses := health.GetStatus()
+func (server *server) Health(ctx context.Context, request *synse.Empty) (*synse.V3Health, error) {
+	return &synse.V3Health{}, nil
 
-	// First, we need to determine the overall health of the plugin.
-	// If all statuses are good, we are ok. If some are bad, we are partially
-	// degraded. If all are bad, we are failing.
-	// TODO: do we want partially degraded, or should we just consider it failing
-	total := len(statuses)
-	ok := 0
-	failing := 0
-
-	var healthChecks []*synse.HealthCheck
-	for _, status := range statuses {
-		if status.Ok {
-			ok++
-		} else {
-			failing++
-		}
-		healthChecks = append(healthChecks, status.Encode())
-	}
-
-	var pluginStatus synse.PluginHealth_Status
-	if total == ok {
-		pluginStatus = synse.PluginHealth_OK
-	} else if total == failing {
-		pluginStatus = synse.PluginHealth_FAILING
-	} else {
-		pluginStatus = synse.PluginHealth_PARTIALLY_DEGRADED
-	}
-
-	return &synse.PluginHealth{
-		Timestamp: GetCurrentTime(),
-		Status:    pluginStatus,
-		Checks:    healthChecks,
-	}, nil
-}
-
-// Capabilities is the handler for the Synse GRPC Plugin service's `Capabilities` RPC method.
-func (server *server) Capabilities(request *synse.Empty, stream synse.Plugin_CapabilitiesServer) error {
-	log.WithField("request", request).Debug("[grpc] capabilities rpc request")
-	capabilitiesMap := map[string]*synse.DeviceCapability{}
-
-	for _, device := range ctx.devices {
-		_, hasKind := capabilitiesMap[device.Kind]
-		if !hasKind {
-			var outputs []string
-			for _, o := range device.Outputs {
-				outputs = append(outputs, o.Name)
-			}
-			capabilitiesMap[device.Kind] = &synse.DeviceCapability{
-				Kind:    device.Kind,
-				Outputs: outputs,
-			}
-		}
-	}
-
-	for _, capability := range capabilitiesMap {
-		if err := stream.Send(capability); err != nil {
-			return err
-		}
-	}
-	return nil
+	//log.WithField("request", request).Debug("[grpc] health rpc request")
+	//statuses := health.GetStatus()
+	//
+	//// First, we need to determine the overall health of the plugin.
+	//// If all statuses are good, we are ok. If some are bad, we are partially
+	//// degraded. If all are bad, we are failing.
+	//// TODO: do we want partially degraded, or should we just consider it failing
+	//total := len(statuses)
+	//ok := 0
+	//failing := 0
+	//
+	//var healthChecks []*synse.HealthCheck
+	//for _, status := range statuses {
+	//	if status.Ok {
+	//		ok++
+	//	} else {
+	//		failing++
+	//	}
+	//	healthChecks = append(healthChecks, status.Encode())
+	//}
+	//
+	//var pluginStatus synse.PluginHealth_Status
+	//if total == ok {
+	//	pluginStatus = synse.PluginHealth_OK
+	//} else if total == failing {
+	//	pluginStatus = synse.PluginHealth_FAILING
+	//} else {
+	//	pluginStatus = synse.PluginHealth_PARTIALLY_DEGRADED
+	//}
+	//
+	//return &synse.PluginHealth{
+	//	Timestamp: GetCurrentTime(),
+	//	Status:    pluginStatus,
+	//	Checks:    healthChecks,
+	//}, nil
 }
 
 // Devices is the handler for the Synse GRPC Plugin service's `Devices` RPC method.
-func (server *server) Devices(request *synse.DeviceFilter, stream synse.Plugin_DevicesServer) error {
-	log.WithField("request", request).Debug("[grpc] devices rpc request")
-	var (
-		rack   = request.GetRack()
-		board  = request.GetBoard()
-		device = request.GetDevice()
-	)
-	if device != "" {
-		return fmt.Errorf("devices rpc method does not support filtering on device")
-	}
-	if rack == "" && board != "" {
-		return fmt.Errorf("filter specifies board with no rack - must specifiy rack as well")
-	}
-
-	for _, device := range ctx.devices {
-		if rack != "" {
-			if device.Location.Rack != rack {
-				continue
-			}
-			if board != "" {
-				if device.Location.Board != board {
-					continue
-				}
-			}
-		}
-		if err := stream.Send(device.encode()); err != nil {
-			return err
-		}
-	}
+func (server *server) Devices(request *synse.V3DeviceSelector, stream synse.V3Plugin_DevicesServer) error {
 	return nil
+
+	//log.WithField("request", request).Debug("[grpc] devices rpc request")
+	//var (
+	//	rack   = request.GetRack()
+	//	board  = request.GetBoard()
+	//	device = request.GetDevice()
+	//)
+	//if device != "" {
+	//	return fmt.Errorf("devices rpc method does not support filtering on device")
+	//}
+	//if rack == "" && board != "" {
+	//	return fmt.Errorf("filter specifies board with no rack - must specifiy rack as well")
+	//}
+	//
+	//for _, device := range ctx.devices {
+	//	if rack != "" {
+	//		if device.Location.Rack != rack {
+	//			continue
+	//		}
+	//		if board != "" {
+	//			if device.Location.Board != board {
+	//				continue
+	//			}
+	//		}
+	//	}
+	//	if err := stream.Send(device.encode()); err != nil {
+	//		return err
+	//	}
+	//}
+	//return nil
 }
 
-// Metainfo is the handler for the Synse GRPC Plugin service's `Metainfo` RPC method.
-func (server *server) Metainfo(ctx context.Context, request *synse.Empty) (*synse.Metadata, error) {
-	log.WithField("request", request).Debug("[grpc] metainfo rpc request")
-	return &synse.Metadata{
-		Name:        metainfo.Name,
-		Maintainer:  metainfo.Maintainer,
-		Tag:         metainfo.Tag,
-		Description: metainfo.Description,
-		Vcs:         metainfo.VCS,
-		Version:     version.Encode(),
-	}, nil
+// Metadata is the handler for the Synse GRPC Plugin service's `Metainfo` RPC method.
+func (server *server) Metadata(ctx context.Context, request *synse.Empty) (*synse.V3Metadata, error) {
+	return &synse.V3Metadata{}, nil
+
+	//log.WithField("request", request).Debug("[grpc] metainfo rpc request")
+	//return &synse.Metadata{
+	//	Name:        metainfo.Name,
+	//	Maintainer:  metainfo.Maintainer,
+	//	Tag:         metainfo.Tag,
+	//	Description: metainfo.Description,
+	//	Vcs:         metainfo.VCS,
+	//	Version:     version.Encode(),
+	//}, nil
 }
 
 // Read is the handler for the Synse GRPC Plugin service's `Read` RPC method.
-func (server *server) Read(request *synse.DeviceFilter, stream synse.Plugin_ReadServer) error {
-	log.WithField("request", request).Debug("[grpc] read rpc request")
-	responses, err := DataManager.Read(request)
-	if err != nil {
-		return err
-	}
-	for _, response := range responses {
-		if err := stream.Send(response); err != nil {
-			return err
-		}
-	}
+func (server *server) Read(request *synse.V3ReadRequest, stream synse.V3Plugin_ReadServer) error {
 	return nil
+
+	//log.WithField("request", request).Debug("[grpc] read rpc request")
+	//responses, err := DataManager.Read(request)
+	//if err != nil {
+	//	return err
+	//}
+	//for _, response := range responses {
+	//	if err := stream.Send(response); err != nil {
+	//		return err
+	//	}
+	//}
+	//return nil
 }
 
-// ReadCached is the handler for the Synse GRPC Plugin service's `ReadCached` RPC method.
-func (server *server) ReadCached(bounds *synse.Bounds, stream synse.Plugin_ReadCachedServer) error {
-	log.WithField("bounds", bounds).Debugf("[grpc] read cached rpc request")
-
-	// create a channel that will be used to collect the cached readings
-	readings := make(chan *ReadContext, 128)
-	go getReadingsFromCache(bounds.Start, bounds.End, readings)
-	for r := range readings {
-		for _, data := range r.Reading {
-			deviceReading := &synse.DeviceReading{
-				Rack:    r.Rack,
-				Board:   r.Board,
-				Device:  r.Device,
-				Reading: data.encode(),
-			}
-			if err := stream.Send(deviceReading); err != nil {
-				return err
-			}
-		}
-	}
+// ReadCache is the handler for the Synse GRPC Plugin service's `ReadCached` RPC method.
+func (server *server) ReadCache(bounds *synse.V3Bounds, stream synse.V3Plugin_ReadCacheServer) error {
 	return nil
+
+	//log.WithField("bounds", bounds).Debugf("[grpc] read cached rpc request")
+	//
+	//// create a channel that will be used to collect the cached readings
+	//readings := make(chan *ReadContext, 128)
+	//go getReadingsFromCache(bounds.Start, bounds.End, readings)
+	//for r := range readings {
+	//	for _, data := range r.Reading {
+	//		deviceReading := &synse.DeviceReading{
+	//			Rack:    r.Rack,
+	//			Board:   r.Board,
+	//			Device:  r.Device,
+	//			Reading: data.encode(),
+	//		}
+	//		if err := stream.Send(deviceReading); err != nil {
+	//			return err
+	//		}
+	//	}
+	//}
+	//return nil
 }
 
 // Write is the handler for the Synse GRPC Plugin service's `Write` RPC method.
-func (server *server) Write(ctx context.Context, request *synse.WriteInfo) (*synse.Transactions, error) {
-	log.WithField("request", request).Debug("[grpc] write rpc request")
-	transactions, err := DataManager.Write(request)
-	if err != nil {
-		return nil, err
-	}
-	return &synse.Transactions{
-		Transactions: transactions,
-	}, nil
+func (server *server) WriteAsync(ctx context.Context, request *synse.V3WritePayload) (*synse.V3WriteTransaction, error) {
+	return &synse.V3WriteTransaction{}, nil
+
+	//log.WithField("request", request).Debug("[grpc] write rpc request")
+	//transactions, err := DataManager.Write(request)
+	//if err != nil {
+	//	return nil, err
+	//}
+	//return &synse.Transactions{
+	//	Transactions: transactions,
+	//}, nil
+}
+
+
+func (server *server) WriteSync(request *synse.V3WritePayload, stream synse.V3Plugin_WriteSyncServer) error {
+	return nil
 }
 
 // Transaction is the handler for the Synse GRPC Plugin service's `Transaction` RPC method.
-func (server *server) Transaction(request *synse.TransactionFilter, stream synse.Plugin_TransactionServer) error {
-	log.WithField("request", request).Debug("[grpc] transaction rpc request")
+func (server *server) Transaction(request *synse.V3TransactionSelector, stream synse.V3Plugin_TransactionServer) error {
+	return nil
 
-	// If there is no ID with the incoming request, return all cached transactions.
-	if request.Id == "" {
-		for _, item := range transactionCache.Items() {
-			t, ok := item.Object.(*transaction)
-			if ok {
-				if err := stream.Send(t.encode()); err != nil {
-					return err
-				}
-			}
-		}
-		return nil
-	}
-
-	// Otherwise, return the transaction with the specified ID.
-	transaction := getTransaction(request.Id)
-	if transaction == nil {
-		return errors.NotFoundErr("transaction not found: %v", request.Id)
-	}
-	return stream.Send(transaction.encode())
+	//log.WithField("request", request).Debug("[grpc] transaction rpc request")
+	//
+	//// If there is no ID with the incoming request, return all cached transactions.
+	//if request.Id == "" {
+	//	for _, item := range transactionCache.Items() {
+	//		t, ok := item.Object.(*transaction)
+	//		if ok {
+	//			if err := stream.Send(t.encode()); err != nil {
+	//				return err
+	//			}
+	//		}
+	//	}
+	//	return nil
+	//}
+	//
+	//// Otherwise, return the transaction with the specified ID.
+	//transaction := getTransaction(request.Id)
+	//if transaction == nil {
+	//	return errors.NotFoundErr("transaction not found: %v", request.Id)
+	//}
+	//return stream.Send(transaction.encode())
 }

--- a/sdk/transaction_test.go
+++ b/sdk/transaction_test.go
@@ -14,8 +14,7 @@ func TestNewTransaction(t *testing.T) {
 
 	transaction := newTransaction()
 
-	assert.Equal(t, statusUnknown, transaction.status)
-	assert.Equal(t, stateOk, transaction.state)
+	assert.Equal(t, statusPending, transaction.status)
 	assert.Equal(t, transaction.created, transaction.updated)
 	assert.Equal(t, "", transaction.message)
 
@@ -35,7 +34,6 @@ func TestNewTransaction2(t *testing.T) {
 	assert.NotEqual(t, t1.id, t2.id, "two transactions should not have the same id")
 
 	assert.Equal(t, t1.status, t2.status)
-	assert.Equal(t, t1.state, t2.state)
 	assert.Equal(t, t1.message, t2.message)
 
 	tr, found := transactionCache.Get(t1.id)
@@ -63,77 +61,22 @@ func TestGetTransaction2(t *testing.T) {
 	assert.Nil(t, transaction)
 }
 
-// TestTransaction_setStateOk tests setting the state of a transaction to OK.
-func TestTransaction_setStateOk(t *testing.T) {
-	setupTransactionCache(time.Duration(600) * time.Second)
-	tr := newTransaction()
 
-	tr.state = stateError
-	assert.Equal(t, stateError, tr.state)
-
-	tr.setStateOk()
-	assert.Equal(t, stateOk, tr.state)
-}
-
-// TestTransaction_setStateOkCached tests setting the state of a cached
-// transaction to OK.
-func TestTransaction_setStateOkCached(t *testing.T) {
-	setupTransactionCache(time.Duration(600) * time.Second)
-	tr := newTransaction()
-	cached := getTransaction(tr.id)
-
-	cached.state = stateError
-	assert.Equal(t, stateError, cached.state)
-	assert.Equal(t, stateError, tr.state)
-
-	cached.setStateOk()
-	assert.Equal(t, stateOk, cached.state)
-	assert.Equal(t, stateOk, tr.state)
-}
-
-// TestTransaction_setStateErr tests setting the state of a transaction to Error.
-func TestTransaction_setStateErr(t *testing.T) {
-	setupTransactionCache(time.Duration(600) * time.Second)
-	tr := newTransaction()
-
-	tr.state = stateOk
-	assert.Equal(t, stateOk, tr.state)
-
-	tr.setStateError()
-	assert.Equal(t, stateError, tr.state)
-}
-
-// TestTransaction_setStateErrCached tests setting the state of a cached
-// transaction to Error.
-func TestTransaction_setStateErrCached(t *testing.T) {
-	setupTransactionCache(time.Duration(600) * time.Second)
-	tr := newTransaction()
-	cached := getTransaction(tr.id)
-
-	cached.state = stateOk
-	assert.Equal(t, stateOk, cached.state)
-	assert.Equal(t, stateOk, tr.state)
-
-	cached.setStateError()
-	assert.Equal(t, stateError, cached.state)
-	assert.Equal(t, stateError, tr.state)
-}
-
-// TestTransaction_setStatusUnknown tests setting the status of a transaction to Unknown.
-func TestTransaction_setStatusUnknown(t *testing.T) {
+// TestTransaction_setStatusError tests setting the status of a transaction to Error.
+func TestTransaction_setStatusError(t *testing.T) {
 	setupTransactionCache(time.Duration(600) * time.Second)
 	tr := newTransaction()
 
 	tr.status = statusDone
 	assert.Equal(t, statusDone, tr.status)
 
-	tr.setStatusUnknown()
-	assert.Equal(t, statusUnknown, tr.status)
+	tr.setStatusError()
+	assert.Equal(t, statusError, tr.status)
 }
 
-// TestTransaction_setStatusUnknownCached tests setting the status of a cached
-// transaction to Unknown.
-func TestTransaction_setStatusUnknownCached(t *testing.T) {
+// TestTransaction_setStatusErrorCached tests setting the status of a cached
+// transaction to Error.
+func TestTransaction_setStatusErrorCached(t *testing.T) {
 	setupTransactionCache(time.Duration(600) * time.Second)
 	tr := newTransaction()
 	cached := getTransaction(tr.id)
@@ -142,9 +85,9 @@ func TestTransaction_setStatusUnknownCached(t *testing.T) {
 	assert.Equal(t, statusDone, cached.status)
 	assert.Equal(t, statusDone, tr.status)
 
-	cached.setStatusUnknown()
-	assert.Equal(t, statusUnknown, cached.status)
-	assert.Equal(t, statusUnknown, tr.status)
+	cached.setStatusError()
+	assert.Equal(t, statusError, cached.status)
+	assert.Equal(t, statusError, tr.status)
 }
 
 // TestTransaction_setStatusPending tests setting the status of a transaction to Pending.
@@ -152,8 +95,8 @@ func TestTransaction_setStatusPending(t *testing.T) {
 	setupTransactionCache(time.Duration(600) * time.Second)
 	tr := newTransaction()
 
-	tr.status = statusUnknown
-	assert.Equal(t, statusUnknown, tr.status)
+	tr.status = statusDone
+	assert.Equal(t, statusDone, tr.status)
 
 	tr.setStatusPending()
 	assert.Equal(t, statusPending, tr.status)
@@ -166,9 +109,9 @@ func TestTransaction_setStatusPendingCached(t *testing.T) {
 	tr := newTransaction()
 	cached := getTransaction(tr.id)
 
-	cached.status = statusUnknown
-	assert.Equal(t, statusUnknown, cached.status)
-	assert.Equal(t, statusUnknown, tr.status)
+	cached.status = statusDone
+	assert.Equal(t, statusDone, cached.status)
+	assert.Equal(t, statusDone, tr.status)
 
 	cached.setStatusPending()
 	assert.Equal(t, statusPending, cached.status)
@@ -180,8 +123,8 @@ func TestTransaction_setStatusWriting(t *testing.T) {
 	setupTransactionCache(time.Duration(600) * time.Second)
 	tr := newTransaction()
 
-	tr.status = statusUnknown
-	assert.Equal(t, statusUnknown, tr.status)
+	tr.status = statusDone
+	assert.Equal(t, statusDone, tr.status)
 
 	tr.setStatusWriting()
 	assert.Equal(t, statusWriting, tr.status)
@@ -193,9 +136,9 @@ func TestTransaction_setStatusWritingCached(t *testing.T) {
 	tr := newTransaction()
 	cached := getTransaction(tr.id)
 
-	cached.status = statusUnknown
-	assert.Equal(t, statusUnknown, cached.status)
-	assert.Equal(t, statusUnknown, tr.status)
+	cached.status = statusDone
+	assert.Equal(t, statusDone, cached.status)
+	assert.Equal(t, statusDone, tr.status)
 
 	cached.setStatusWriting()
 	assert.Equal(t, statusWriting, cached.status)
@@ -207,8 +150,8 @@ func TestTransaction_setStatusDone(t *testing.T) {
 	setupTransactionCache(time.Duration(600) * time.Second)
 	tr := newTransaction()
 
-	tr.status = statusUnknown
-	assert.Equal(t, statusUnknown, tr.status)
+	tr.status = statusPending
+	assert.Equal(t, statusPending, tr.status)
 
 	tr.setStatusDone()
 	assert.Equal(t, statusDone, tr.status)
@@ -221,9 +164,9 @@ func TestTransaction_setStatusDoneCached(t *testing.T) {
 	tr := newTransaction()
 	cached := getTransaction(tr.id)
 
-	cached.status = statusUnknown
-	assert.Equal(t, statusUnknown, cached.status)
-	assert.Equal(t, statusUnknown, tr.status)
+	cached.status = statusPending
+	assert.Equal(t, statusPending, cached.status)
+	assert.Equal(t, statusPending, tr.status)
 
 	cached.setStatusDone()
 	assert.Equal(t, statusDone, cached.status)
@@ -238,7 +181,6 @@ func TestTransaction_encode(t *testing.T) {
 	encoded := tr.encode()
 
 	assert.Equal(t, tr.status, encoded.Status)
-	assert.Equal(t, tr.state, encoded.State)
 	assert.Equal(t, tr.created, encoded.Created)
 	assert.Equal(t, tr.updated, encoded.Updated)
 	assert.Equal(t, tr.message, encoded.Message)


### PR DESCRIPTION
#323

This PR only lays down some of the framing work around this. The build will fail as there are components that are not yet updated, as doing so would be going down a bunch of rabbit holes that would make this PR massive.

The goal here is simply to update the server function signatures and some of the v3 message types. Future PRs will add back in the functionality that was disabled here and will continue to propagate the updates appropriately.