### PR TITLE
improve plugin startup logging

### DIFF
--- a/sdk/config/config.go
+++ b/sdk/config/config.go
@@ -135,6 +135,13 @@ func (loader *Loader) AddSearchPaths(paths ...string) {
 // found, Load will return an error. If the config is optional and not found, no
 // error will be returned.
 func (loader *Loader) Load(pol policy.Policy) error {
+	log.WithFields(log.Fields{
+		"loader": loader.Name,
+		"paths":  loader.SearchPaths,
+		"name":   loader.FileName,
+		"ext":    loader.Ext,
+	}).Info("[config] loading configuration")
+
 	if err := loader.checkOverrides(); err != nil {
 		return err
 	}
@@ -314,7 +321,7 @@ func (loader *Loader) search(pol policy.Policy) error {
 			if loader.isValidFile(file) {
 				plog.WithFields(log.Fields{
 					"file": file.Name(),
-				}).Info("[config] found valid config")
+				}).Info("[config] found matching config")
 				foundInPath = true
 				fileName := filepath.Join(path, file.Name())
 				loader.files = append(loader.files, fileName)
@@ -323,7 +330,7 @@ func (loader *Loader) search(pol policy.Policy) error {
 
 		// If configuration was found in the current path, break to stop
 		// searching. We do not want to search all potential config paths
-		// if we have already found valid config.
+		// if we have already found matching config.
 		if foundInPath {
 			break
 		}

--- a/sdk/device_manager.go
+++ b/sdk/device_manager.go
@@ -87,6 +87,8 @@ func newDeviceManager(id *pluginID, handlers *PluginHandlers, policies *policy.P
 // the device config is loaded and that the config is parsed into the appropriate
 // Device models.
 func (manager *deviceManager) init() error {
+	log.Info("[device manager] initializing")
+
 	if err := manager.loadConfig(); err != nil {
 		return err
 	}
@@ -104,6 +106,7 @@ func (manager *deviceManager) init() error {
 // off here. This is just where device setup actions are executed. This should be
 // done here rather than in init.
 func (manager *deviceManager) Start(plugin *Plugin) error {
+	log.Info("[device manager] starting")
 	return manager.execDeviceSetupActions(plugin)
 }
 
@@ -222,6 +225,11 @@ func (manager *deviceManager) AddDevice(device *Device) error {
 	for _, t := range device.Tags {
 		manager.tagCache.Add(t, device)
 	}
+
+	log.WithFields(log.Fields{
+		"id":   device.id,
+		"type": device.Type,
+	}).Info("[device manager] added new device")
 
 	return nil
 }
@@ -355,8 +363,11 @@ func (manager *deviceManager) createDevices() error {
 
 	if failedLoad {
 		// fixme
+		log.Errorf("[device manager] failed to create devices from config")
 		return fmt.Errorf("failed to load devices from config")
 	}
+
+	log.WithField("devices", len(manager.devices)).Info("[device manager] created devices")
 	return nil
 }
 

--- a/sdk/plugin.go
+++ b/sdk/plugin.go
@@ -113,9 +113,10 @@ func NewPlugin(options ...PluginOption) (*Plugin, error) {
 		log.SetLevel(log.DebugLevel)
 	}
 
-	// Log the plugin metadata and version info.
+	// Log the plugin metadata, version info, and config.
 	metadata.log()
 	version.Log()
+	conf.Log()
 
 	// Initialize the plugin ID namespace.
 	id, err := newPluginID(conf.ID, &metadata)

--- a/sdk/server.go
+++ b/sdk/server.go
@@ -26,13 +26,11 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/vapor-ware/synse-sdk/sdk/utils"
-
+	log "github.com/Sirupsen/logrus"
 	"github.com/vapor-ware/synse-sdk/sdk/config"
 	"github.com/vapor-ware/synse-sdk/sdk/errors"
 	"github.com/vapor-ware/synse-sdk/sdk/health"
-
-	log "github.com/Sirupsen/logrus"
+	"github.com/vapor-ware/synse-sdk/sdk/utils"
 	"github.com/vapor-ware/synse-server-grpc/go"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -225,7 +223,15 @@ func (server *server) registerActions(plugin *Plugin) {
 // as configured via the plugin network config.
 func addTLSOptions(options *[]grpc.ServerOption, settings *config.TLSNetworkSettings) error {
 	// If there is no TLS config, there are no options to add here.
-	if settings == nil {
+	if settings == nil || settings == (&config.TLSNetworkSettings{}) {
+		log.Info("[server] tls/ssl not configured, using insecure transport")
+		return nil
+	}
+
+	// If there is no key and cert, the other options don't matter,
+	// so we have nothing to do.
+	if settings.Key == "" && settings.Cert == "" {
+		log.Info("[server] tls/ssl not configured, using insecure transport")
 		return nil
 	}
 


### PR DESCRIPTION
with the simple example plugin:
```
INFO[0000] [config] loading configuration                ext=yaml loader=plugin name=config paths="[. ./config /etc/synse/plugin/config]"
INFO[0000] [config] found valid config                   file=config.yml loader=plugin path=. policy=optional
INFO[0000] Plugin Info:                                 
INFO[0000]   Tag:         vaporio/simple-plugin         
INFO[0000]   Name:        simple plugin                 
INFO[0000]   Maintainer:  vaporio                       
INFO[0000]   VCS:                                       
INFO[0000]   Description: A simple example plugin       
INFO[0000] Version Info:                                
INFO[0000]   Plugin Version: 1.0                        
INFO[0000]   SDK Version:    3.0.0                      
INFO[0000]   Git Commit:     f8e5401                    
INFO[0000]   Git Tag:        1.2.0-33-gf8e5401          
INFO[0000]   Build Date:     2019-02-21T21:15:54        
INFO[0000]   Go Version:     go1.11.4                   
INFO[0000]   OS/Arch:        darwin/amd64               
INFO[0000] Plugin Config:                               
INFO[0000]   Version: 3                                 
INFO[0000]   Debug:   true                              
INFO[0000]   ID:                                        
INFO[0000]     UsePluginTag: true                       
INFO[0000]     UseMachineID: true                       
INFO[0000]     UseEnv:       []                         
INFO[0000]     UseCustom:    []                         
INFO[0000]   Settings:                                  
INFO[0000]     Mode: parallel                           
INFO[0000]     Listen:                                  
INFO[0000]       Disable: false                         
INFO[0000]     Read:                                    
INFO[0000]       Disable:   false                       
INFO[0000]       QueueSize: 128                         
INFO[0000]       Interval:  5s                          
INFO[0000]       Delay:     0s                          
INFO[0000]     Write:                                   
INFO[0000]       Disable:   false                       
INFO[0000]       QueueSize: 128                         
INFO[0000]       BatchSize: 128                         
INFO[0000]       Interval:  5s                          
INFO[0000]       Delay:     0s                          
INFO[0000]     Transaction:                             
INFO[0000]       TTL: 8m0s                              
INFO[0000]     Limiter:                                 
INFO[0000]       Rate:  0                               
INFO[0000]       Burst: 0                               
INFO[0000]     Cache:                                   
INFO[0000]       Enabled: false                         
INFO[0000]       TTL:     3m0s                          
INFO[0000]   Network:                                   
INFO[0000]     Type:    unix                            
INFO[0000]     Address: simple-plugin.sock              
INFO[0000]     TLS:                                     
INFO[0000]       Key:                                   
INFO[0000]       Cert:                                  
INFO[0000]       CACerts:    []                         
INFO[0000]       SkipVerify: false                      
INFO[0000]   DynamicRegistration:                       
INFO[0000]     Config: []                               
INFO[0000]   Health:                                    
INFO[0000]     HealthFile: /etc/synse/plugin/healthy    
INFO[0000]     Checks:                                  
INFO[0000]       DisableDefaults: false                 
INFO[0000] [device manager] initializing                
INFO[0000] [config] loading configuration                ext=yaml loader=device name= paths="[./config/device /etc/synse/plugin/config/device]"
INFO[0000] [config] found valid config                   file=led.yaml loader=device path=./config/device policy=required
INFO[0000] [config] found valid config                   file=test.yaml loader=device path=./config/device policy=required
DEBU[0000] [config] scanning config into struct          type="*config.Devices"
INFO[0000] [device manager] added new device             id=164bad3f-39a4-51df-b063-252c50b9aff6 type=led
INFO[0000] [device manager] added new device             id=cc22c237-68aa-57e7-b1a7-dd17c67bc1c7 type=led
INFO[0000] [device manager] added new device             id=54f07972-fc84-500e-96d9-2d2588aabe8f type=temperature
INFO[0000] [device manager] added new device             id=ac20f921-a0be-57a5-90e9-33f12b4ecb62 type=temperature
INFO[0000] [device manager] added new device             id=ab1f8f82-3cc3-5a12-bb77-d2c7e5cdfdd4 type=temperature
INFO[0000] [device manager] created devices              devices=5
DEBU[0000] [server] setting up server                   
INFO[0000] [server] tls/ssl not configured, using insecure transport 
INFO[0000] [device manager] starting                    
INFO[0000] [scheduler] starting...                      
INFO[0000] [plugin] will terminate on: [SIGTERM, SIGINT] 
INFO[0000] [scheduler] starting read scheduling          delay=0s interval=5s mode=parallel
INFO[0000] [scheduler] starting write scheduling         delay=0s interval=5s mode=parallel
DEBU[0000] [scheduler] sleeping for write interval       delay=0s interval=5s mode=parallel
INFO[0000] [scheduler] listeners will not be scheduled (no listener handlers registered) 
DEBU[0000] [scheduler] sleeping for read interval        delay=0s interval=5s mode=parallel
INFO[0000] [server] serving...                           addr=simple-plugin.sock mode=unix
```