### PR TITLE
normalize logging import name

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,14 +2,6 @@
 
 
 [[projects]]
-  digest = "1:e4c72127d910a96daf869a44f3dd563b86dbe6931a172863a0e99c5ff04b59e4"
-  name = "github.com/Sirupsen/logrus"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "dae0fa8d5b0c810a8ab733fbd5510c7cae84eca4"
-  version = "v1.4.0"
-
-[[projects]]
   digest = "1:ed4582b92b69928dec6d82f78d1ad64863b89e631217bfdc5c63b3066a053eea"
   name = "github.com/creasty/defaults"
   packages = ["."]
@@ -104,6 +96,14 @@
   version = "v1.2.1"
 
 [[projects]]
+  digest = "1:e4c72127d910a96daf869a44f3dd563b86dbe6931a172863a0e99c5ff04b59e4"
+  name = "github.com/sirupsen/logrus"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "dae0fa8d5b0c810a8ab733fbd5510c7cae84eca4"
+  version = "v1.4.0"
+
+[[projects]]
   digest = "1:972c2427413d41a1e06ca4897e8528e5a1622894050e2f527b38ddf0f343f759"
   name = "github.com/stretchr/testify"
   packages = ["assert"]
@@ -141,11 +141,11 @@
     "trace",
   ]
   pruneopts = "UT"
-  revision = "1272bf9dcd53ea65c09668fb4c76e65deb740072"
+  revision = "addf6b3196f61cd44ce5a76657913698c73479d0"
 
 [[projects]]
   branch = "master"
-  digest = "1:386f073c0c9da0f3f50a31966cb491f65cf5e8ecec31240b78ba696f9ab521ca"
+  digest = "1:48c1fcb1095744e8ec994c0bb07de536c80004d1388c205e72777ac260582d7a"
   name = "golang.org/x/sys"
   packages = [
     "unix",
@@ -153,7 +153,7 @@
     "windows/registry",
   ]
   pruneopts = "UT"
-  revision = "f7bb7a8bee54210937e93ec56d007d892c1f0580"
+  revision = "f49334f85ddcf0f08d7fb6dd7363e9e6d6b777eb"
 
 [[projects]]
   digest = "1:a2ab62866c75542dd18d2b069fec854577a20211d7c0ea6ae746072a1dccdd18"
@@ -192,7 +192,7 @@
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
   pruneopts = "UT"
-  revision = "5fe7a883aa19554f42890211544aa549836af7b7"
+  revision = "e79c0c59cdb5e117ef82a6f885294df3d74065d5"
 
 [[projects]]
   digest = "1:c00eb80d7b152379c3e94c38d82b29deca98b1d0f53e4e20362589b7fcbffa07"
@@ -246,7 +246,6 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
-    "github.com/Sirupsen/logrus",
     "github.com/creasty/defaults",
     "github.com/denisbrodbeck/machineid",
     "github.com/google/uuid",
@@ -254,6 +253,7 @@
     "github.com/mitchellh/mapstructure",
     "github.com/patrickmn/go-cache",
     "github.com/rs/xid",
+    "github.com/sirupsen/logrus",
     "github.com/stretchr/testify/assert",
     "github.com/vapor-ware/synse-server-grpc/go",
     "golang.org/x/net/context",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,11 +24,6 @@
 #   go-tests = true
 #   unused-packages = true
 
-
-[[constraint]]
-  name = "github.com/Sirupsen/logrus"
-  version = "1.1.1"
-
 [[constraint]]
   name = "github.com/creasty/defaults"
   version = "1.2.1"

--- a/examples/device_actions/plugin.go
+++ b/examples/device_actions/plugin.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	logger "github.com/Sirupsen/logrus"
+	logger "github.com/sirupsen/logrus"
 	"github.com/vapor-ware/synse-sdk/examples/device_actions/devices"
 	"github.com/vapor-ware/synse-sdk/sdk"
 )

--- a/examples/health_check/plugin.go
+++ b/examples/health_check/plugin.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/vapor-ware/synse-sdk/sdk"
 	"github.com/vapor-ware/synse-sdk/sdk/health"
 	"github.com/vapor-ware/synse-sdk/sdk/output"

--- a/sdk/config/config.go
+++ b/sdk/config/config.go
@@ -24,10 +24,10 @@ import (
 	"reflect"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/creasty/defaults"
 	"github.com/imdario/mergo"
 	"github.com/mitchellh/mapstructure"
+	log "github.com/sirupsen/logrus"
 	"github.com/vapor-ware/synse-sdk/sdk/errors"
 	"github.com/vapor-ware/synse-sdk/sdk/policy"
 	"gopkg.in/yaml.v2"

--- a/sdk/config/plugin.go
+++ b/sdk/config/plugin.go
@@ -19,7 +19,7 @@ package config
 import (
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 // Plugin contains the configuration for a Synse Plugin.

--- a/sdk/device.go
+++ b/sdk/device.go
@@ -23,8 +23,8 @@ import (
 	"text/template"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/imdario/mergo"
+	log "github.com/sirupsen/logrus"
 	"github.com/vapor-ware/synse-sdk/sdk/config"
 	"github.com/vapor-ware/synse-sdk/sdk/errors"
 	"github.com/vapor-ware/synse-sdk/sdk/utils"

--- a/sdk/device_manager.go
+++ b/sdk/device_manager.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/vapor-ware/synse-sdk/sdk/config"
 	"github.com/vapor-ware/synse-sdk/sdk/errors"
 	"github.com/vapor-ware/synse-sdk/sdk/policy"

--- a/sdk/health/manager.go
+++ b/sdk/health/manager.go
@@ -23,7 +23,7 @@ import (
 	"path/filepath"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/vapor-ware/synse-sdk/sdk/config"
 	"github.com/vapor-ware/synse-sdk/sdk/utils"
 )

--- a/sdk/meta.go
+++ b/sdk/meta.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"text/template"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	synse "github.com/vapor-ware/synse-server-grpc/go"
 )
 

--- a/sdk/plugin.go
+++ b/sdk/plugin.go
@@ -23,7 +23,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/vapor-ware/synse-sdk/sdk/config"
 	"github.com/vapor-ware/synse-sdk/sdk/errors"
 	"github.com/vapor-ware/synse-sdk/sdk/health"

--- a/sdk/plugin_handlers.go
+++ b/sdk/plugin_handlers.go
@@ -21,7 +21,7 @@ import (
 	"reflect"
 	"sort"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/vapor-ware/synse-sdk/sdk/config"
 )
 

--- a/sdk/plugin_test.go
+++ b/sdk/plugin_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/vapor-ware/synse-sdk/sdk/output"
 
 	"github.com/vapor-ware/synse-sdk/sdk/health"

--- a/sdk/scheduler.go
+++ b/sdk/scheduler.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/vapor-ware/synse-sdk/sdk/config"
 	"github.com/vapor-ware/synse-sdk/sdk/errors"
 	"github.com/vapor-ware/synse-sdk/sdk/health"

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -12,7 +12,7 @@ todo: overview of the SDK arch/flow.
 package sdk
 
 import (
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 func init() {

--- a/sdk/server.go
+++ b/sdk/server.go
@@ -26,7 +26,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/vapor-ware/synse-sdk/sdk/config"
 	"github.com/vapor-ware/synse-sdk/sdk/errors"
 	"github.com/vapor-ware/synse-sdk/sdk/health"

--- a/sdk/state_manager.go
+++ b/sdk/state_manager.go
@@ -21,8 +21,8 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/patrickmn/go-cache"
+	log "github.com/sirupsen/logrus"
 	"github.com/vapor-ware/synse-sdk/sdk/config"
 	"github.com/vapor-ware/synse-sdk/sdk/health"
 	"github.com/vapor-ware/synse-sdk/sdk/output"

--- a/sdk/tag.go
+++ b/sdk/tag.go
@@ -21,7 +21,7 @@ import (
 	"regexp"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	synse "github.com/vapor-ware/synse-server-grpc/go"
 )
 

--- a/sdk/transaction.go
+++ b/sdk/transaction.go
@@ -19,8 +19,8 @@ package sdk
 import (
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/rs/xid"
+	log "github.com/sirupsen/logrus"
 	"github.com/vapor-ware/synse-sdk/sdk/utils"
 	synse "github.com/vapor-ware/synse-server-grpc/go"
 )

--- a/sdk/utils/time.go
+++ b/sdk/utils/time.go
@@ -19,7 +19,7 @@ package utils
 import (
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 // GetCurrentTime return the current time (time.Now()), with location set to UTC,

--- a/sdk/version.go
+++ b/sdk/version.go
@@ -21,7 +21,7 @@ import (
 	"runtime"
 	"text/template"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	synse "github.com/vapor-ware/synse-server-grpc/go"
 )
 


### PR DESCRIPTION
it is the current best practice to import logrus with lowercase `Sirupsen`. this is a nice to have, as the built-in vendoring solution for go will trip up if it is specified as capitalized and will not follow the redirect.

while not critical for us right now, as we still use dep, we may move away from that when it is deprecated, and other plugin authors may prefer to use the built-in vendoring.