### PR TITLE
fix test failure in CI

### DIFF
--- a/sdk/scheduler_test.go
+++ b/sdk/scheduler_test.go
@@ -424,7 +424,7 @@ func TestScheduler_scheduleWrites(t *testing.T) {
 	s.writeChan <- wctx
 
 	txn.wait()
-	assert.Equal(t, synse.WriteStatus_DONE, txn.status)
+	assert.Equal(t, synse.WriteStatus_DONE, txn.status, txn.message)
 }
 
 func TestScheduler_scheduleListen_listenDisabled(t *testing.T) {

--- a/sdk/scheduler_test.go
+++ b/sdk/scheduler_test.go
@@ -400,6 +400,7 @@ func TestScheduler_scheduleWrites(t *testing.T) {
 				"123": {
 					id:            "123",
 					handler:       handler,
+					WriteTimeout:  1 * time.Second,
 					ScalingFactor: 1,
 				},
 			},


### PR DESCRIPTION
fixes a test failure that showed up in CI, but not locally. this was due to the write timeout not being set on the device used for the test, so the write terminated early in error, when it was expected to complete in success state.