### PR TITLE
update metadata and device response to provide plugin id

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -113,11 +113,11 @@
 
 [[projects]]
   branch = "v3/staging"
-  digest = "1:a2f2b268785d6354cf3c501dcde39275dad3a9b4f37c5ff1b0c8d73a9d61dcdb"
+  digest = "1:6d9ca8b731aa3670630134b156c462d0708e1e4ea6e503c7416ff140b22e57ac"
   name = "github.com/vapor-ware/synse-server-grpc"
   packages = ["go"]
   pruneopts = "UT"
-  revision = "667a84247b384bc508fd826c8ab928d7b7dbb0e9"
+  revision = "90934b70a0d7e957ade7d72ed52832c5ffbfd73d"
 
 [[projects]]
   branch = "master"

--- a/sdk/server.go
+++ b/sdk/server.go
@@ -425,8 +425,6 @@ func (server *server) Metadata(ctx context.Context, request *synse.Empty) (*syns
 	}).Info("[grpc] processing request")
 	m := server.meta.encode()
 	m.Id = server.id.uuid.String()
-
-	log.WithField("m", m).Info(">>> METADATA")
 	return m, nil
 }
 

--- a/sdk/server_test.go
+++ b/sdk/server_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/patrickmn/go-cache"
 	"github.com/stretchr/testify/assert"
 	"github.com/vapor-ware/synse-sdk/internal/test"
@@ -317,7 +318,6 @@ func TestServer_Devices(t *testing.T) {
 	// return the devices in the system namespace.
 	handler := &DeviceHandler{Name: "foo"}
 	s := server{
-		meta: &PluginMetadata{Name: "test", Maintainer: "vaporio"},
 		deviceManager: &deviceManager{
 			tagCache: &TagCache{
 				cache: map[string]map[string]map[string][]*Device{
@@ -329,6 +329,9 @@ func TestServer_Devices(t *testing.T) {
 		stateManager: &stateManager{
 			readings:     map[string][]*output.Reading{},
 			readingsLock: &sync.RWMutex{},
+		},
+		id: &pluginID{
+			uuid: uuid.New(),
 		},
 	}
 	req := &synse.V3DeviceSelector{}
@@ -348,7 +351,6 @@ func TestServer_Devices2(t *testing.T) {
 		Type: "test",
 	}
 	s := server{
-		meta: &PluginMetadata{Name: "test", Maintainer: "vaporio"},
 		deviceManager: &deviceManager{
 			tagCache: &TagCache{
 				cache: map[string]map[string]map[string][]*Device{
@@ -362,6 +364,9 @@ func TestServer_Devices2(t *testing.T) {
 				"67890": {o.MakeReading(1)},
 			},
 			readingsLock: &sync.RWMutex{},
+		},
+		id: &pluginID{
+			uuid: uuid.New(),
 		},
 	}
 	req := &synse.V3DeviceSelector{Tags: []*synse.V3Tag{
@@ -379,7 +384,6 @@ func TestServer_Devices3(t *testing.T) {
 	// Get devices when there is a tag selector set, but no match
 	handler := &DeviceHandler{Name: "foo"}
 	s := server{
-		meta: &PluginMetadata{Name: "test", Maintainer: "vaporio"},
 		deviceManager: &deviceManager{
 			tagCache: &TagCache{
 				cache: map[string]map[string]map[string][]*Device{
@@ -391,6 +395,9 @@ func TestServer_Devices3(t *testing.T) {
 		stateManager: &stateManager{
 			readings:     map[string][]*output.Reading{},
 			readingsLock: &sync.RWMutex{},
+		},
+		id: &pluginID{
+			uuid: uuid.New(),
 		},
 	}
 	req := &synse.V3DeviceSelector{Id: "abcdef"}
@@ -406,7 +413,6 @@ func TestServer_Devices_error(t *testing.T) {
 	// return the devices in the system namespace.
 	handler := &DeviceHandler{Name: "foo"}
 	s := server{
-		meta: &PluginMetadata{Name: "test", Maintainer: "vaporio"},
 		deviceManager: &deviceManager{
 			tagCache: &TagCache{
 				cache: map[string]map[string]map[string][]*Device{
@@ -419,6 +425,9 @@ func TestServer_Devices_error(t *testing.T) {
 			readings:     map[string][]*output.Reading{},
 			readingsLock: &sync.RWMutex{},
 		},
+		id: &pluginID{
+			uuid: uuid.New(),
+		},
 	}
 	req := &synse.V3DeviceSelector{}
 	mock := &test.MockDevicesStreamErr{}
@@ -428,8 +437,12 @@ func TestServer_Devices_error(t *testing.T) {
 }
 
 func TestServer_Metadata(t *testing.T) {
+	pid := uuid.New()
 	s := server{
 		meta: &PluginMetadata{Name: "test", Maintainer: "vaporio", Description: "desc"},
+		id: &pluginID{
+			uuid: pid,
+		},
 	}
 
 	req := &synse.Empty{}
@@ -441,6 +454,7 @@ func TestServer_Metadata(t *testing.T) {
 	assert.Equal(t, "vaporio", resp.Maintainer)
 	assert.Equal(t, "desc", resp.Description)
 	assert.Equal(t, "", resp.Vcs)
+	assert.Equal(t, pid.String(), resp.Id)
 }
 
 func TestServer_Read(t *testing.T) {


### PR DESCRIPTION
this PR makes changes to the SDK corresponding to the gRPC changes here: https://github.com/vapor-ware/synse-server-grpc/pull/48

providing the plugin ID via the gRPC API makes it easier for Synse Server to identify plugins and mitigates the need for additional plugin->device mapping 