### PR TITLE
honor custom transaction IDs supplied by the caller

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -88,14 +88,6 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:2e76a73cb51f42d63a2a1a85b3dc5731fd4faf6821b434bd0ef2c099186031d6"
-  name = "github.com/rs/xid"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "15d26544def341f036c5f8dca987a4cbe575032c"
-  version = "v1.2.1"
-
-[[projects]]
   digest = "1:fd61cf4ae1953d55df708acb6b91492d538f49c305b364a014049914495db426"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
@@ -244,7 +236,6 @@
     "github.com/imdario/mergo",
     "github.com/mitchellh/mapstructure",
     "github.com/patrickmn/go-cache",
-    "github.com/rs/xid",
     "github.com/sirupsen/logrus",
     "github.com/stretchr/testify/assert",
     "github.com/vapor-ware/synse-server-grpc/go",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -33,10 +33,6 @@
   version = "2.1.0"
 
 [[constraint]]
-  name = "github.com/rs/xid"
-  version = "1.2.1"
-
-[[constraint]]
   name = "github.com/stretchr/testify"
   version = "1.2.2"
 

--- a/sdk/scheduler_test.go
+++ b/sdk/scheduler_test.go
@@ -422,7 +422,9 @@ func TestScheduler_scheduleWrites(t *testing.T) {
 	go s.scheduleWrites()
 	defer close(s.stop)
 
-	txn := s.stateManager.newTransaction(10 * time.Minute)
+	txn, err := s.stateManager.newTransaction(10*time.Minute, "")
+	assert.NoError(t, err)
+
 	wctx := &WriteContext{
 		txn,
 		"123",

--- a/sdk/server_test.go
+++ b/sdk/server_test.go
@@ -1052,7 +1052,8 @@ func TestServer_Transaction_oneIDExists(t *testing.T) {
 		},
 	}
 
-	txn := s.stateManager.newTransaction(1 * time.Minute)
+	txn, err := s.stateManager.newTransaction(1*time.Minute, "")
+	assert.NoError(t, err)
 
 	req := &synse.V3TransactionSelector{Id: txn.id}
 	resp, err := s.Transaction(context.Background(), req)
@@ -1084,13 +1085,16 @@ func TestServer_Transactions(t *testing.T) {
 		},
 	}
 
-	txn1 := s.stateManager.newTransaction(1 * time.Minute)
-	txn2 := s.stateManager.newTransaction(1 * time.Minute)
-	txn3 := s.stateManager.newTransaction(1 * time.Minute)
+	txn1, err := s.stateManager.newTransaction(1*time.Minute, "")
+	assert.NoError(t, err)
+	txn2, err := s.stateManager.newTransaction(1*time.Minute, "")
+	assert.NoError(t, err)
+	txn3, err := s.stateManager.newTransaction(1*time.Minute, "")
+	assert.NoError(t, err)
 
 	req := &synse.Empty{}
 	mock := test.NewMockTransactionsStream()
-	err := s.Transactions(req, mock)
+	err = s.Transactions(req, mock)
 
 	assert.NoError(t, err)
 	assert.Len(t, mock.Results, 3)
@@ -1106,13 +1110,16 @@ func TestServer_Transactions_error(t *testing.T) {
 		},
 	}
 
-	_ = s.stateManager.newTransaction(1 * time.Minute)
-	_ = s.stateManager.newTransaction(1 * time.Minute)
-	_ = s.stateManager.newTransaction(1 * time.Minute)
+	_, err := s.stateManager.newTransaction(1*time.Minute, "")
+	assert.NoError(t, err)
+	_, err = s.stateManager.newTransaction(1*time.Minute, "")
+	assert.NoError(t, err)
+	_, err = s.stateManager.newTransaction(1*time.Minute, "")
+	assert.NoError(t, err)
 
 	req := &synse.Empty{}
 	mock := &test.MockTransactionStreamErr{}
-	err := s.Transactions(req, mock)
+	err = s.Transactions(req, mock)
 
 	assert.Error(t, err)
 }

--- a/sdk/state_manager.go
+++ b/sdk/state_manager.go
@@ -255,10 +255,14 @@ func (manager *stateManager) GetReadings() map[string][]*output.Reading {
 }
 
 // newTransaction creates a new transaction and adds it to the transaction cache.
-func (manager *stateManager) newTransaction(timeout time.Duration) *transaction {
-	t := newTransaction(timeout)
+func (manager *stateManager) newTransaction(timeout time.Duration, customID string) (*transaction, error) {
+	t := newTransaction(timeout, customID)
+	_, exists := manager.transactions.Get(t.id)
+	if exists {
+		return nil, fmt.Errorf("transaction with ID %s already exists", t.id)
+	}
 	manager.transactions.Set(t.id, t, cache.DefaultExpiration)
-	return t
+	return t, nil
 }
 
 // getTransaction gets the transaction with the specified ID from the transaction cache.

--- a/sdk/transaction.go
+++ b/sdk/transaction.go
@@ -19,7 +19,7 @@ package sdk
 import (
 	"time"
 
-	"github.com/rs/xid"
+	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 	"github.com/vapor-ware/synse-sdk/sdk/utils"
 	synse "github.com/vapor-ware/synse-server-grpc/go"
@@ -45,10 +45,16 @@ type transaction struct {
 }
 
 // newTransaction creates a new transaction instance.
-func newTransaction(timeout time.Duration) *transaction {
+func newTransaction(timeout time.Duration, customID string) *transaction {
 	now := utils.GetCurrentTime()
+
+	var transactionID = customID
+	if transactionID == "" {
+		transactionID = uuid.New().String()
+	}
+
 	return &transaction{
-		id:      xid.New().String(),
+		id:      transactionID,
 		status:  statusPending,
 		created: now,
 		updated: now,

--- a/sdk/transaction_test.go
+++ b/sdk/transaction_test.go
@@ -28,19 +28,18 @@ var defaultTimeout = 5 * time.Second
 // TestNewTransaction tests creating a new transaction and getting
 // it back out from the cache.
 func TestNewTransaction(t *testing.T) {
-	transaction := newTransaction(defaultTimeout)
+	transaction := newTransaction(defaultTimeout, "")
 
 	assert.Equal(t, statusPending, transaction.status)
 	assert.Equal(t, transaction.created, transaction.updated)
 	assert.Equal(t, "", transaction.message)
-
 }
 
 // TestNewTransaction2 tests creating new transactions and getting
 // them back out from the cache.
 func TestNewTransaction2(t *testing.T) {
-	t1 := newTransaction(defaultTimeout)
-	t2 := newTransaction(defaultTimeout)
+	t1 := newTransaction(defaultTimeout, "")
+	t2 := newTransaction(defaultTimeout, "")
 
 	assert.NotEqual(t, t1.id, t2.id, "two transactions should not have the same id")
 
@@ -48,9 +47,39 @@ func TestNewTransaction2(t *testing.T) {
 	assert.Equal(t, t1.message, t2.message)
 }
 
+// TestNewTransaction3 tests creating a new transaction with a custom ID.
+func TestNewTransaction3(t *testing.T) {
+	txn := newTransaction(defaultTimeout, "abc123")
+
+	assert.Equal(t, statusPending, txn.status)
+	assert.Equal(t, txn.created, txn.updated)
+	assert.Equal(t, "", txn.message)
+	assert.Equal(t, defaultTimeout, txn.timeout)
+	assert.Equal(t, "abc123", txn.id)
+}
+
+// TestNewTransaction4 tests creating multiple new transactions with the same custom ID.
+// It is not the onus of the constructor to ensure IDs are unique -- that is left to
+// whatever puts the transaction in the cache.
+func TestNewTransaction4(t *testing.T) {
+	t1 := newTransaction(defaultTimeout, "abc123")
+	t2 := newTransaction(defaultTimeout, "abc123")
+
+	assert.Equal(t, statusPending, t1.status)
+	assert.Equal(t, t1.created, t1.updated)
+	assert.Equal(t, "", t1.message)
+	assert.Equal(t, defaultTimeout, t1.timeout)
+	assert.Equal(t, "abc123", t1.id)
+
+	assert.Equal(t, t1.status, t2.status)
+	assert.Equal(t, t1.message, t2.message)
+	assert.Equal(t, t1.timeout, t2.timeout)
+	assert.Equal(t, t1.id, t2.id)
+}
+
 // TestTransaction_setStatusError tests setting the status of a transaction to Error.
 func TestTransaction_setStatusError(t *testing.T) {
-	tr := newTransaction(defaultTimeout)
+	tr := newTransaction(defaultTimeout, "")
 
 	tr.status = statusDone
 	assert.Equal(t, statusDone, tr.status)
@@ -61,7 +90,7 @@ func TestTransaction_setStatusError(t *testing.T) {
 
 // TestTransaction_setStatusPending tests setting the status of a transaction to Pending.
 func TestTransaction_setStatusPending(t *testing.T) {
-	tr := newTransaction(defaultTimeout)
+	tr := newTransaction(defaultTimeout, "")
 
 	tr.status = statusDone
 	assert.Equal(t, statusDone, tr.status)
@@ -72,7 +101,7 @@ func TestTransaction_setStatusPending(t *testing.T) {
 
 // TestTransaction_setStatusWriting tests setting the status of a transaction to Writing.
 func TestTransaction_setStatusWriting(t *testing.T) {
-	tr := newTransaction(defaultTimeout)
+	tr := newTransaction(defaultTimeout, "")
 
 	tr.status = statusDone
 	assert.Equal(t, statusDone, tr.status)
@@ -83,7 +112,7 @@ func TestTransaction_setStatusWriting(t *testing.T) {
 
 // TestTransaction_setStatusDone tests setting the status of a transaction to Done.
 func TestTransaction_setStatusDone(t *testing.T) {
-	tr := newTransaction(defaultTimeout)
+	tr := newTransaction(defaultTimeout, "")
 
 	tr.status = statusPending
 	assert.Equal(t, statusPending, tr.status)
@@ -95,7 +124,7 @@ func TestTransaction_setStatusDone(t *testing.T) {
 // TestTransaction_encode tests encoding an SDK transaction into the
 // gRPC transaction struct.
 func TestTransaction_encode(t *testing.T) {
-	tr := newTransaction(defaultTimeout)
+	tr := newTransaction(defaultTimeout, "")
 	encoded := tr.encode()
 
 	assert.Equal(t, tr.status, encoded.Status)


### PR DESCRIPTION
updates the method to create a new transaction to use a custom transaction ID if specified. propagates an error if a transaction with that ID already exists. adds and updates tests.