### PR TITLE
add support for device alias lookups

### DIFF
--- a/sdk/alias.go
+++ b/sdk/alias.go
@@ -1,0 +1,63 @@
+// Synse SDK
+// Copyright (c) 2019 Vapor IO
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package sdk
+
+import (
+	"errors"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// AliasCache is a cache which is used to lookup devices based on any
+// aliases registered by the device.
+type AliasCache struct {
+	// cache is a simple map which serves as the lookup table for device
+	// aliases. Since device aliases will not change for the duration of
+	// the plugin run (as they are statically configured), this does
+	// not need any form of invalidation.
+	cache map[string]*Device
+}
+
+// NewAliasCache creates a new AliasCache instance.
+func NewAliasCache() *AliasCache {
+	return &AliasCache{
+		cache: make(map[string]*Device),
+	}
+}
+
+// Add adds a device alias mapping to the cache.
+func (cache *AliasCache) Add(alias string, device *Device) error {
+	// If the alias already exists, return an error. It is up to the
+	// configurer to ensure all aliased devices have unique aliases for
+	// the plugin.
+	if _, ok := cache.cache[alias]; ok {
+		log.WithFields(log.Fields{
+			"alias":  alias,
+			"device": device.GetID(),
+		}).Error("[alias] alias already exists")
+		return errors.New("duplicate device alias detected")
+	}
+
+	cache.cache[alias] = device
+	return nil
+}
+
+// Get gets the device associated with the specified alias. If the given
+// alias is not associated with a device, this returns nil.
+func (cache *AliasCache) Get(alias string) *Device {
+	return cache.cache[alias]
+}

--- a/sdk/alias_test.go
+++ b/sdk/alias_test.go
@@ -1,0 +1,78 @@
+// Synse SDK
+// Copyright (c) 2019 Vapor IO
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package sdk
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewAliasCache(t *testing.T) {
+	c := NewAliasCache()
+	assert.Empty(t, c.cache)
+}
+
+func TestAliasCache_Add_new(t *testing.T) {
+	c := AliasCache{
+		cache: map[string]*Device{},
+	}
+
+	err := c.Add("alias-1", &Device{id: "123"})
+	assert.NoError(t, err)
+	assert.Len(t, c.cache, 1)
+	assert.Contains(t, c.cache, "alias-1")
+}
+
+func TestAliasCache_Add_conflict(t *testing.T) {
+	c := AliasCache{
+		cache: map[string]*Device{
+			"alias-1": {id: "123"},
+		},
+	}
+
+	err := c.Add("alias-1", &Device{id: "456"})
+	assert.Error(t, err)
+	assert.Len(t, c.cache, 1)
+	assert.Contains(t, c.cache, "alias-1")
+	assert.Equal(t, c.cache["alias-1"].id, "123")
+}
+
+func TestAliasCache_Get_match(t *testing.T) {
+	c := AliasCache{
+		cache: map[string]*Device{
+			"alias-1": {id: "123"},
+			"alias-2": {id: "456"},
+		},
+	}
+
+	device := c.Get("alias-1")
+	assert.NotNil(t, device)
+	assert.Equal(t, "123", device.id)
+}
+
+func TestAliasCache_Get_noMatch(t *testing.T) {
+	c := AliasCache{
+		cache: map[string]*Device{
+			"alias-1": {id: "123"},
+			"alias-2": {id: "456"},
+		},
+	}
+
+	device := c.Get("alias-unknown")
+	assert.Nil(t, device)
+}


### PR DESCRIPTION
fixes #414 

adds an AliasCache to the device manager. When devices are registered with the manager, it maps tha alias to the device. 

When resolving a device via Selector, it will check if the specified ID corresponds to a device. If not, it will try to use that ID as the alias key for lookups. This means anything calling the gRPC API can use device ID / device alias interchangeably.
