### PR TITLE
add prometheus exporter for basic plugin application metrics

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,14 @@
 
 
 [[projects]]
+  digest = "1:d6afaeed1502aa28e80a4ed0981d570ad91b2579193404256ce672ed0a609e0d"
+  name = "github.com/beorn7/perks"
+  packages = ["quantile"]
+  pruneopts = "UT"
+  revision = "4b2b341e8d7715fae06375aa633dbb6e91b3fb46"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:ed4582b92b69928dec6d82f78d1ad64863b89e631217bfdc5c63b3066a053eea"
   name = "github.com/creasty/defaults"
   packages = ["."]
@@ -64,6 +72,14 @@
   version = "v1.0.2"
 
 [[projects]]
+  digest = "1:ff5ebae34cfbf047d505ee150de27e60570e8c394b3b8fdbb720ff6ac71985fc"
+  name = "github.com/matttproud/golang_protobuf_extensions"
+  packages = ["pbutil"]
+  pruneopts = "UT"
+  revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
+  version = "v1.0.1"
+
+[[projects]]
   digest = "1:53bc4cd4914cd7cd52139990d5170d6dc99067ae31c56530621b18b35fc30318"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
@@ -86,6 +102,46 @@
   pruneopts = "UT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
+
+[[projects]]
+  digest = "1:93a746f1060a8acbcf69344862b2ceced80f854170e1caae089b2834c5fbf7f4"
+  name = "github.com/prometheus/client_golang"
+  packages = [
+    "prometheus",
+    "prometheus/internal",
+    "prometheus/promhttp",
+  ]
+  pruneopts = "UT"
+  revision = "505eaef017263e299324067d40ca2c48f6a2cf50"
+  version = "v0.9.2"
+
+[[projects]]
+  branch = "master"
+  digest = "1:2d5cd61daa5565187e1d96bae64dbbc6080dacf741448e9629c64fd93203b0d4"
+  name = "github.com/prometheus/client_model"
+  packages = ["go"]
+  pruneopts = "UT"
+  revision = "fd36f4220a901265f90734c3183c5f0c91daa0b8"
+
+[[projects]]
+  digest = "1:35cf6bdf68db765988baa9c4f10cc5d7dda1126a54bd62e252dbcd0b1fc8da90"
+  name = "github.com/prometheus/common"
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model",
+  ]
+  pruneopts = "UT"
+  revision = "a82f4c12f983cc2649298185f296632953e50d3e"
+  version = "v0.3.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:2ea45e71e0198d6b989ed6302cc4f72a83be1e7d6469d08a59e56a2c447aea55"
+  name = "github.com/prometheus/procfs"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "87a4384529e0652f5035fb5cc8095faf73ea9b0b"
 
 [[projects]]
   digest = "1:fd61cf4ae1953d55df708acb6b91492d538f49c305b364a014049914495db426"
@@ -239,6 +295,7 @@
     "github.com/imdario/mergo",
     "github.com/mitchellh/mapstructure",
     "github.com/patrickmn/go-cache",
+    "github.com/prometheus/client_golang/prometheus/promhttp",
     "github.com/sirupsen/logrus",
     "github.com/stretchr/testify/assert",
     "github.com/vapor-ware/synse-server-grpc/go",

--- a/examples/multi_device_plugin/config.yml
+++ b/examples/multi_device_plugin/config.yml
@@ -1,5 +1,7 @@
 version: 3
 debug: true
+metrics:
+  enabled: true
 network:
   type: tcp
   address: ":5001"

--- a/sdk/config/plugin.go
+++ b/sdk/config/plugin.go
@@ -34,6 +34,9 @@ type Plugin struct {
 	// ID specifies the options for generating a plugin namespace ID.
 	ID *IDSettings `default:"{}" yaml:"id,omitempty"`
 
+	// Metrics specifies the options for exposing application metrics.
+	Metrics *MetricsSettings `default:"{}" yaml:"metrics,omitempty"`
+
 	// Settings specifies how the plugin should run.
 	Settings *PluginSettings `default:"{}" yaml:"settings,omitempty"`
 
@@ -96,6 +99,22 @@ func (conf *IDSettings) Log() {
 		log.Infof("    UseMachineID: %v", conf.UseMachineID)
 		log.Infof("    UseEnv:       %v", conf.UseEnv)
 		log.Infof("    UseCustom:    %v", conf.UseCustom)
+	}
+}
+
+// MetricsSettings are the settings around exposing application metrics.
+type MetricsSettings struct {
+	// Enabled sets whether the application should report metrics or not.
+	Enabled bool `yaml:"enabled,omitempty"`
+}
+
+// Log logs out the config at INFO level.
+func (conf *MetricsSettings) Log() {
+	if conf == nil {
+		log.Info("  Metrics: nil")
+	} else {
+		log.Infof("  Metrics:")
+		log.Infof("    Enabled: %v", conf.Enabled)
 	}
 }
 

--- a/sdk/config/plugin_test.go
+++ b/sdk/config/plugin_test.go
@@ -47,6 +47,16 @@ func TestIDSettings_Log(t *testing.T) {
 	c.Log()
 }
 
+func TestMetricsSettings_Log_nil(t *testing.T) {
+	var c *MetricsSettings
+	c.Log()
+}
+
+func TestMetricsSettings_Log(t *testing.T) {
+	c := MetricsSettings{}
+	c.Log()
+}
+
 func TestPluginSettings_Log_nil(t *testing.T) {
 	var c *PluginSettings
 	c.Log()
@@ -141,6 +151,7 @@ func TestDynamicRegistrationSettings_Log_nil(t *testing.T) {
 	var c *DynamicRegistrationSettings
 	c.Log()
 }
+
 func TestDynamicRegistrationSettings_Log(t *testing.T) {
 	c := DynamicRegistrationSettings{}
 	c.Log()
@@ -159,6 +170,7 @@ func TestHealthCheckSettings_Log_nil(t *testing.T) {
 	var c *HealthCheckSettings
 	c.Log()
 }
+
 func TestHealthCheckSettings_Log(t *testing.T) {
 	c := HealthCheckSettings{}
 	c.Log()

--- a/sdk/metrics.go
+++ b/sdk/metrics.go
@@ -1,0 +1,43 @@
+// Synse SDK
+// Copyright (c) 2019 Vapor IO
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package sdk
+
+import (
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	log "github.com/sirupsen/logrus"
+)
+
+// exposeMetrics exposes Prometheus application metrics via HTTP. It starts
+// an HTTP server on the default metrics port (2112) and exposes the /metrics
+// endpoint.
+//
+// The caller of this function is responsible for ensuring that the plugin
+// has metrics enabled via the plugin configuration.
+//
+// This function blocks on ListenAndServe, so the caller should run this
+// as a goroutine.
+func exposeMetrics() {
+	log.Info("[metrics] exposing prometheus metrics on :2112/metrics")
+
+	http.Handle("/metrics", promhttp.Handler())
+	err := http.ListenAndServe(":2112", nil)
+	if err != nil {
+		log.Fatalf("[metrics] failed to serve metrics endpoint: %v", err)
+	}
+}

--- a/sdk/plugin.go
+++ b/sdk/plugin.go
@@ -275,6 +275,12 @@ func (plugin *Plugin) initialize() error {
 func (plugin *Plugin) run() error {
 	log.Info("[plugin] running")
 
+	// Start the Prometheus metrics exporter, if metrics are enabled for
+	// the plugin. This is a blocking function so it must be called in a goroutine.
+	if plugin.config.Metrics.Enabled {
+		go exposeMetrics()
+	}
+
 	// Start the plugin components. Order matters here.
 	if err := plugin.device.Start(plugin); err != nil {
 		return err


### PR DESCRIPTION
fixes #415 

This PR adds very basic support for exposing application metrics with Prometheus. It just uses the default metrics for the time being. If we want, we can look into adding more metrics in the future (e.g. number of grpc requests, number of reads, number of writes, ...)