### PR TITLE
add missing support for reading context

### DIFF
--- a/sdk/config/device.go
+++ b/sdk/config/device.go
@@ -71,6 +71,11 @@ type DeviceProto struct {
 	// back to the default value of 30s.
 	WriteTimeout time.Duration `yaml:"writeTimeout,omitempty"`
 
+	// Context defines any context information which should be associated
+	// with a device instance's reading(s). If specified here, all prototype
+	// instances will inherit the context, unless inheritance is disabled.
+	Context map[string]string `yaml:"context,omitempty"`
+
 	// Instances contains the data for all configured instances of the
 	// device prototype.
 	Instances []*DeviceInstance `yaml:"instances,omitempty"`
@@ -95,6 +100,11 @@ type DeviceInstance struct {
 	// is not required to define tags. All devices will get system-generated
 	// tags, so these are supplemental.
 	Tags []string `yaml:"tags,omitempty"`
+
+	// Context defines any context information which should be associated with
+	// the device instance's reading(s). Any values specified here will be
+	// applied to the reading context automatically by the SDK.
+	Context map[string]string `yaml:"context,omitempty"`
 
 	// Data contains any protocol/plugin/device-specific configuration that
 	// is associated with the device instance. It is the responsibility of the

--- a/sdk/output/output_test.go
+++ b/sdk/output/output_test.go
@@ -110,7 +110,7 @@ func TestOutput_MakeReading(t *testing.T) {
 	assert.Equal(t, o.Type, r.Type)
 	assert.Equal(t, o.Unit.Symbol, r.Unit.Symbol)
 	assert.Equal(t, o.Unit.Name, r.Unit.Name)
-	assert.Empty(t, r.Info)
+	assert.Empty(t, r.Context)
 	assert.NotEmpty(t, r.Timestamp)
 }
 
@@ -127,7 +127,7 @@ func TestOutput_MakeReading_noUnit(t *testing.T) {
 	assert.Equal(t, 3, r.Value)
 	assert.Equal(t, o.Type, r.Type)
 	assert.Nil(t, r.Unit)
-	assert.Empty(t, r.Info)
+	assert.Empty(t, r.Context)
 	assert.NotEmpty(t, r.Timestamp)
 }
 

--- a/sdk/output/reading_test.go
+++ b/sdk/output/reading_test.go
@@ -38,6 +38,39 @@ func TestReading_GetOutput_noOutput(t *testing.T) {
 	assert.Nil(t, r.GetOutput())
 }
 
+func TestReading_WithContext_noContext(t *testing.T) {
+	r := Reading{}
+	r.WithContext(map[string]string{})
+
+	assert.Empty(t, r.Context)
+}
+
+func TestReading_WithContext_newContext(t *testing.T) {
+	r := Reading{}
+	r.WithContext(map[string]string{"foo": "bar"})
+
+	assert.Equal(t, map[string]string{"foo": "bar"}, r.Context)
+}
+
+func TestReading_WithContext_noOverride(t *testing.T) {
+	r := Reading{
+		Context: map[string]string{"abc": "def"},
+	}
+	r.WithContext(map[string]string{"123": "456"})
+
+	assert.Equal(t, map[string]string{"abc": "def", "123": "456"}, r.Context)
+}
+
+func TestReading_WithContext_withOverride(t *testing.T) {
+	r := Reading{
+		Context: map[string]string{"abc": "def"},
+	}
+
+	r.WithContext(map[string]string{"abc": "456"})
+
+	assert.Equal(t, map[string]string{"abc": "456"}, r.Context)
+}
+
 func TestReading_Scale(t *testing.T) {
 	cases := []struct {
 		value    interface{}
@@ -138,7 +171,7 @@ func TestReading_Encode(t *testing.T) {
 		r := Reading{
 			Timestamp: "now",
 			Type:      "testtype",
-			Info:      "foo",
+			Context:   map[string]string{"foo": "bar"},
 			Value:     c.value,
 		}
 
@@ -149,6 +182,7 @@ func TestReading_Encode(t *testing.T) {
 		assert.Equal(t, "testtype", encoded.Type)
 		assert.Equal(t, "", encoded.Unit.Name)
 		assert.Equal(t, "", encoded.Unit.Symbol)
+		assert.Equal(t, map[string]string{"foo": "bar"}, encoded.Context)
 	}
 }
 
@@ -157,7 +191,7 @@ func TestReading_Encode2(t *testing.T) {
 	r := Reading{
 		Timestamp: "now",
 		Type:      "testtype",
-		Info:      "foo",
+		Context:   map[string]string{"foo": "bar"},
 		Value:     123,
 		Unit: &Unit{
 			Name:   "unit",
@@ -172,6 +206,7 @@ func TestReading_Encode2(t *testing.T) {
 	assert.Equal(t, "testtype", encoded.Type)
 	assert.Equal(t, "unit", encoded.Unit.Name)
 	assert.Equal(t, "u", encoded.Unit.Symbol)
+	assert.Equal(t, map[string]string{"foo": "bar"}, encoded.Context)
 }
 
 func TestReading_Encode_error(t *testing.T) {
@@ -187,7 +222,7 @@ func TestReading_Encode_error(t *testing.T) {
 		r := Reading{
 			Timestamp: "now",
 			Type:      "testtype",
-			Info:      "foo",
+			Context:   map[string]string{"foo": "bar"},
 			Value:     c.value,
 		}
 

--- a/sdk/scheduler_test.go
+++ b/sdk/scheduler_test.go
@@ -523,11 +523,14 @@ func TestScheduler_applyTransformations_noFns(t *testing.T) {
 		},
 	}
 
-	err := applyTransformations(device, rctx)
+	err := finalizeReadings(device, rctx)
 	assert.NoError(t, err)
 
 	// Verify that the reading value did not change.
 	assert.Equal(t, 2, rctx.Reading[0].Value.(int))
+
+	// Verify that no additional context was set.
+	assert.Empty(t, rctx.Reading[0].Context)
 }
 
 func TestScheduler_applyTransformations_noFns_withScale(t *testing.T) {
@@ -541,11 +544,14 @@ func TestScheduler_applyTransformations_noFns_withScale(t *testing.T) {
 		},
 	}
 
-	err := applyTransformations(device, rctx)
+	err := finalizeReadings(device, rctx)
 	assert.NoError(t, err)
 
 	// Verify that the reading value changed
 	assert.Equal(t, float64(4), rctx.Reading[0].Value.(float64))
+
+	// Verify that no additional context was set.
+	assert.Empty(t, rctx.Reading[0].Context)
 }
 
 func TestScheduler_applyTransformations_oneFnOk(t *testing.T) {
@@ -566,11 +572,14 @@ func TestScheduler_applyTransformations_oneFnOk(t *testing.T) {
 		},
 	}
 
-	err := applyTransformations(device, rctx)
+	err := finalizeReadings(device, rctx)
 	assert.NoError(t, err)
 
 	// Verify that the reading value changed.
 	assert.Equal(t, 4, rctx.Reading[0].Value.(int))
+
+	// Verify that no additional context was set.
+	assert.Empty(t, rctx.Reading[0].Context)
 }
 
 func TestScheduler_applyTransformations_oneFnOk_withScale(t *testing.T) {
@@ -591,11 +600,14 @@ func TestScheduler_applyTransformations_oneFnOk_withScale(t *testing.T) {
 		},
 	}
 
-	err := applyTransformations(device, rctx)
+	err := finalizeReadings(device, rctx)
 	assert.NoError(t, err)
 
 	// Verify that the reading value changed.
 	assert.Equal(t, float64(8), rctx.Reading[0].Value.(float64))
+
+	// Verify that no additional context was set.
+	assert.Empty(t, rctx.Reading[0].Context)
 }
 
 func TestScheduler_applyTransformations_multipleFnsOk(t *testing.T) {
@@ -622,11 +634,14 @@ func TestScheduler_applyTransformations_multipleFnsOk(t *testing.T) {
 		},
 	}
 
-	err := applyTransformations(device, rctx)
+	err := finalizeReadings(device, rctx)
 	assert.NoError(t, err)
 
 	// Verify that the reading value changed.
 	assert.Equal(t, 7, rctx.Reading[0].Value.(int))
+
+	// Verify that no additional context was set.
+	assert.Empty(t, rctx.Reading[0].Context)
 }
 
 func TestScheduler_applyTransformations_multipleFnsOk_withScale(t *testing.T) {
@@ -653,11 +668,14 @@ func TestScheduler_applyTransformations_multipleFnsOk_withScale(t *testing.T) {
 		},
 	}
 
-	err := applyTransformations(device, rctx)
+	err := finalizeReadings(device, rctx)
 	assert.NoError(t, err)
 
 	// Verify that the reading value changed.
 	assert.Equal(t, float64(14), rctx.Reading[0].Value.(float64))
+
+	// Verify that no additional context was set.
+	assert.Empty(t, rctx.Reading[0].Context)
 }
 
 func TestScheduler_applyTransformations_oneFnErr(t *testing.T) {
@@ -678,11 +696,14 @@ func TestScheduler_applyTransformations_oneFnErr(t *testing.T) {
 		},
 	}
 
-	err := applyTransformations(device, rctx)
+	err := finalizeReadings(device, rctx)
 	assert.Error(t, err)
 
 	// Verify that the reading value did not change.
 	assert.Equal(t, 2, rctx.Reading[0].Value.(int))
+
+	// Verify that no additional context was set.
+	assert.Empty(t, rctx.Reading[0].Context)
 }
 
 func TestScheduler_applyTransformations_oneFnErr_withScale(t *testing.T) {
@@ -703,11 +724,14 @@ func TestScheduler_applyTransformations_oneFnErr_withScale(t *testing.T) {
 		},
 	}
 
-	err := applyTransformations(device, rctx)
+	err := finalizeReadings(device, rctx)
 	assert.Error(t, err)
 
 	// Verify that the reading value did not change.
 	assert.Equal(t, 2, rctx.Reading[0].Value.(int))
+
+	// Verify that no additional context was set.
+	assert.Empty(t, rctx.Reading[0].Context)
 }
 
 func TestScheduler_applyTransformations_multipleFnsErr(t *testing.T) {
@@ -734,13 +758,16 @@ func TestScheduler_applyTransformations_multipleFnsErr(t *testing.T) {
 		},
 	}
 
-	err := applyTransformations(device, rctx)
+	err := finalizeReadings(device, rctx)
 	assert.Error(t, err)
 
 	// Verify that the reading value changed. It should change because the first
 	// fn was applied successfully. It is up to the upstream caller to check the
 	// error and make sure all transforms succeed before using the value.
 	assert.Equal(t, 4, rctx.Reading[0].Value.(int))
+
+	// Verify that no additional context was set.
+	assert.Empty(t, rctx.Reading[0].Context)
 }
 
 func TestScheduler_applyTransformations_multipleFnsErr_withScale(t *testing.T) {
@@ -767,13 +794,16 @@ func TestScheduler_applyTransformations_multipleFnsErr_withScale(t *testing.T) {
 		},
 	}
 
-	err := applyTransformations(device, rctx)
+	err := finalizeReadings(device, rctx)
 	assert.Error(t, err)
 
 	// Verify that the reading value changed. It should change because the first
 	// fn was applied successfully. It is up to the upstream caller to check the
 	// error and make sure all transforms succeed before using the value.
 	assert.Equal(t, 4, rctx.Reading[0].Value.(int))
+
+	// Verify that no additional context was set.
+	assert.Empty(t, rctx.Reading[0].Context)
 }
 
 func TestScheduler_applyTransformations_oneFnOk_withScaleErr(t *testing.T) {
@@ -794,10 +824,82 @@ func TestScheduler_applyTransformations_oneFnOk_withScaleErr(t *testing.T) {
 		},
 	}
 
-	err := applyTransformations(device, rctx)
+	err := finalizeReadings(device, rctx)
 	assert.Error(t, err)
 
 	// Verify that the reading value changed. It should change because the
 	// transform fn ran, but the scaling fn should not have run.
 	assert.Equal(t, 4, rctx.Reading[0].Value.(int))
+
+	// Verify that no additional context was set.
+	assert.Empty(t, rctx.Reading[0].Context)
+}
+
+func TestScheduler_finalizeReadings_withContext(t *testing.T) {
+	device := &Device{
+		Context:       map[string]string{"foo": "bar"},
+		ScalingFactor: 1,
+	}
+	rctx := &ReadContext{
+		Reading: []*output.Reading{
+			{Value: 2},
+		},
+	}
+
+	err := finalizeReadings(device, rctx)
+	assert.NoError(t, err)
+
+	// Verify that the reading value did not change.
+	assert.Equal(t, 2, rctx.Reading[0].Value.(int))
+
+	// Verify that the deice context was set.
+	assert.Equal(t, map[string]string{"foo": "bar"}, rctx.Reading[0].Context)
+}
+
+func TestScheduler_finalizeReadings_withContextAugment(t *testing.T) {
+	device := &Device{
+		Context:       map[string]string{"foo": "bar"},
+		ScalingFactor: 1,
+	}
+	rctx := &ReadContext{
+		Reading: []*output.Reading{
+			{
+				Value:   2,
+				Context: map[string]string{"abc": "def"},
+			},
+		},
+	}
+
+	err := finalizeReadings(device, rctx)
+	assert.NoError(t, err)
+
+	// Verify that the reading value did not change.
+	assert.Equal(t, 2, rctx.Reading[0].Value.(int))
+
+	// Verify that the deice context was set.
+	assert.Equal(t, map[string]string{"foo": "bar", "abc": "def"}, rctx.Reading[0].Context)
+}
+
+func TestScheduler_finalizeReadings_withContextOverride(t *testing.T) {
+	device := &Device{
+		Context:       map[string]string{"foo": "bar"},
+		ScalingFactor: 1,
+	}
+	rctx := &ReadContext{
+		Reading: []*output.Reading{
+			{
+				Value:   2,
+				Context: map[string]string{"foo": "123"},
+			},
+		},
+	}
+
+	err := finalizeReadings(device, rctx)
+	assert.NoError(t, err)
+
+	// Verify that the reading value did not change.
+	assert.Equal(t, 2, rctx.Reading[0].Value.(int))
+
+	// Verify that the deice context was set.
+	assert.Equal(t, map[string]string{"foo": "bar"}, rctx.Reading[0].Context)
 }


### PR DESCRIPTION
This PR:
- allows reading context data to be specified in device configuration
- simplifies the API around adding reading context 
- adds and updates tests
- removes the "info" field from a reading, since that was essentially just a stand-in for the reading context.