### PR TITLE
replace device metadata with device context

### DIFF
--- a/examples/c_plugin/config/device/temperature.yaml
+++ b/examples/c_plugin/config/device/temperature.yaml
@@ -2,7 +2,7 @@ version: 3
 devices:
   - type: temperature
     handler: temperature
-    metadata:
+    context:
       model: temp2010
     instances:
       - info: Temperature Device 1

--- a/examples/device_actions/config/device/airflow.yaml
+++ b/examples/device_actions/config/device/airflow.yaml
@@ -2,7 +2,7 @@ version: 3
 devices:
   - type: airflow
     handler: airflow
-    metadata:
+    context:
       model: air8884
     instances:
       - info: Airflow Device 1

--- a/examples/device_actions/config/device/temperature.yaml
+++ b/examples/device_actions/config/device/temperature.yaml
@@ -2,7 +2,7 @@ version: 3
 devices:
   - type: temperature
     handler: temperature
-    metadata:
+    context:
       model: temp2010
     instances:
       - info: Temperature 1

--- a/examples/device_actions/plugin.go
+++ b/examples/device_actions/plugin.go
@@ -38,9 +38,9 @@ func preRunAction2(p *sdk.Plugin) error {
 func deviceSetupAction(_ *sdk.Plugin, d *sdk.Device) error {
 	logger.Debug("deviceSetupAction1 -> print device info for the given filter")
 	logger.Debug("device")
-	logger.Debugf("  id:    %v", d.GetID())
-	logger.Debugf("  type:  %v", d.Type)
-	logger.Debugf("  meta:  %v", d.Metadata)
+	logger.Debugf("  id:      %v", d.GetID())
+	logger.Debugf("  type:    %v", d.Type)
+	logger.Debugf("  context: %v", d.Context)
 	return nil
 }
 

--- a/examples/dynamic_registration/plugin.go
+++ b/examples/dynamic_registration/plugin.go
@@ -54,7 +54,7 @@ func DynamicDeviceConfig(cfg map[string]interface{}) ([]*config.DeviceProto, err
 	res := []*config.DeviceProto{
 		{
 			Type: "temperature",
-			Metadata: map[string]string{
+			Context: map[string]string{
 				"model": "temp2010",
 			},
 			Instances: []*config.DeviceInstance{

--- a/examples/health_check/config/device/test.yaml
+++ b/examples/health_check/config/device/test.yaml
@@ -2,7 +2,7 @@ version: 3
 devices:
   - type: temperature
     handler: example.temperature
-    metadata:
+    context:
       author: vaporio
     instances:
       - info: CEC Temperature 1

--- a/examples/listener/config/device/pusher.yaml
+++ b/examples/listener/config/device/pusher.yaml
@@ -2,7 +2,7 @@ version: 3
 devices:
   - type: pusher
     handler: pusher
-    metadata:
+    context:
       model: test-device
     instances:
       - info: Test Pusher Device

--- a/examples/multi_device_plugin/config/device/airflow.yaml
+++ b/examples/multi_device_plugin/config/device/airflow.yaml
@@ -2,7 +2,7 @@ version: 3
 devices:
   - type: airflow
     handler: airflow
-    metadata:
+    context:
       model: air8884
     instances:
       - info: Airflow Device 1

--- a/examples/multi_device_plugin/config/device/temperature.yaml
+++ b/examples/multi_device_plugin/config/device/temperature.yaml
@@ -2,7 +2,7 @@ version: 3
 devices:
   - type: temperature
     handler: temperature
-    metadata:
+    context:
       model: temp2010
     instances:
       - info: Temperature Device 1

--- a/examples/multi_device_plugin/config/device/voltage.yaml
+++ b/examples/multi_device_plugin/config/device/voltage.yaml
@@ -2,7 +2,7 @@ version: 3
 devices:
   - type: voltage
     handler: voltage
-    metadata:
+    context:
       model: volt1103
     instances:
       - info: Voltage Device 1

--- a/examples/simple_plugin/config/device/led.yaml
+++ b/examples/simple_plugin/config/device/led.yaml
@@ -2,7 +2,7 @@ version: 3
 devices:
   - type: led
     handler: example.led
-    metadata:
+    context:
       model: sample-led
     tags:
       - foobar/xyz:led

--- a/examples/simple_plugin/config/device/test.yaml
+++ b/examples/simple_plugin/config/device/test.yaml
@@ -2,7 +2,7 @@ version: 3
 devices:
   - type: temperature
     handler: example.temperature
-    metadata:
+    context:
       model: sample-temperature
     tags:
       - foobar/xyz:temp

--- a/sdk/config/device.go
+++ b/sdk/config/device.go
@@ -43,12 +43,6 @@ type DeviceProto struct {
 	// meaning that devices are free to define their own types.
 	Type string `yaml:"type,omitempty"`
 
-	// Metadata contains any meta-information for the device(s). There is no
-	// restriction on what data can be specified here. It is optional, so a
-	// device does not need to specify any meta-information, though it can
-	// be helpful in identifying the device or tracking information about it.
-	Metadata map[string]string `yaml:"metadata,omitempty"`
-
 	// Tags contains the set of tags to apply to each of the devices that
 	// are instances of this prototype. It is not required to define tags.
 	// All devices will get system-generated tags, so these are supplemental.

--- a/sdk/config/testdata/device/1.yaml
+++ b/sdk/config/testdata/device/1.yaml
@@ -1,7 +1,7 @@
 version: 3
 devices:
   - handler: input_register
-    metadata:
+    context:
       foo: bar
     data:
       host: 10.194.4.250

--- a/sdk/config/testdata/device/2.yaml
+++ b/sdk/config/testdata/device/2.yaml
@@ -2,7 +2,7 @@ version: 3
 devices:
   - type: temperature
     handler: max11610
-    metadata:
+    context:
       model: MAX11610
     tags:
       - something/model:max11610

--- a/sdk/device.go
+++ b/sdk/device.go
@@ -48,9 +48,6 @@ type Device struct {
 	// be used upstream to categorize the device.
 	Type string
 
-	// Metadata is arbitrary metadata that is associated with the device.
-	Metadata map[string]string
-
 	// Info is a human-readable string that provides a summary of what
 	// the device is or what it does.
 	Info string
@@ -258,7 +255,6 @@ func NewDeviceFromConfig(proto *config.DeviceProto, instance *config.DeviceInsta
 		Data:          data,
 		Context:       context,
 		Handler:       handler,
-		Metadata:      proto.Metadata,
 		Info:          instance.Info,
 		SortIndex:     instance.SortIndex,
 		ScalingFactor: scalingFactor,
@@ -308,8 +304,8 @@ func (device *Device) setAlias(conf *config.DeviceAlias) error {
 		var buf bytes.Buffer
 
 		t, err := template.New("alias").Funcs(template.FuncMap{
-			"env":  os.Getenv,
-			"meta": device.GetMetadata,
+			"env": os.Getenv,
+			"ctx": device.GetContext,
 		}).Parse(conf.Template)
 		if err != nil {
 			return err
@@ -324,9 +320,9 @@ func (device *Device) setAlias(conf *config.DeviceAlias) error {
 	return nil
 }
 
-// GetMetadata gets a value out of the device's metadata map.
-func (device *Device) GetMetadata(key string) string {
-	return device.Metadata[key]
+// GetContext gets a value out of the device's context map.
+func (device *Device) GetContext(key string) string {
+	return device.Context[key]
 }
 
 // GetHandler gets the DeviceHandler of the device.
@@ -434,7 +430,7 @@ func (device *Device) encode() *synse.V3Device {
 		Type:      device.Type,
 		Info:      device.Info,
 		Alias:     device.Alias,
-		Metadata:  device.Metadata,
+		Metadata:  device.Context,
 		SortIndex: device.SortIndex,
 		Tags:      tags,
 		Capabilities: &synse.V3DeviceCapability{

--- a/sdk/device_test.go
+++ b/sdk/device_test.go
@@ -50,9 +50,6 @@ func TestNewDeviceFromConfig(t *testing.T) {
 	// instance defines all inheritable things.
 	proto := &config.DeviceProto{
 		Type: "type1",
-		Metadata: map[string]string{
-			"a": "b",
-		},
 		Data: map[string]interface{}{
 			"port": 5000,
 		},
@@ -87,7 +84,6 @@ func TestNewDeviceFromConfig(t *testing.T) {
 	device, err := NewDeviceFromConfig(proto, instance)
 	assert.NoError(t, err)
 	assert.Equal(t, "type2", device.Type)
-	assert.Equal(t, map[string]string{"a": "b"}, device.Metadata)
 	assert.Equal(t, "testdata", device.Info)
 	assert.Equal(t, 2, len(device.Tags))
 	assert.Equal(t, map[string]interface{}{"address": "localhost", "port": 5000}, device.Data)
@@ -106,9 +102,6 @@ func TestNewDeviceFromConfig2(t *testing.T) {
 	// inherit values from the prototype.
 	proto := &config.DeviceProto{
 		Type: "type1",
-		Metadata: map[string]string{
-			"a": "b",
-		},
 		Data: map[string]interface{}{
 			"port": 5000,
 		},
@@ -138,7 +131,6 @@ func TestNewDeviceFromConfig2(t *testing.T) {
 	device, err := NewDeviceFromConfig(proto, instance)
 	assert.NoError(t, err)
 	assert.Equal(t, "type1", device.Type)
-	assert.Equal(t, map[string]string{"a": "b"}, device.Metadata)
 	assert.Equal(t, "testdata", device.Info)
 	assert.Equal(t, 2, len(device.Tags))
 	assert.Equal(t, map[string]interface{}{"address": "localhost", "port": 5000}, device.Data)
@@ -155,9 +147,6 @@ func TestNewDeviceFromConfig2(t *testing.T) {
 func TestNewDeviceFromConfig3(t *testing.T) {
 	// Test when no type is resolved, resulting in error.
 	proto := &config.DeviceProto{
-		Metadata: map[string]string{
-			"a": "b",
-		},
 		Data: map[string]interface{}{
 			"port": 5000,
 		},
@@ -189,9 +178,6 @@ func TestNewDeviceFromConfig3(t *testing.T) {
 func TestNewDeviceFromConfig4(t *testing.T) {
 	// Test inheriting from prototype when there is nothing to inherit.
 	proto := &config.DeviceProto{
-		Metadata: map[string]string{
-			"a": "b",
-		},
 		Data: map[string]interface{}{
 			"port": 5000,
 		},
@@ -215,7 +201,6 @@ func TestNewDeviceFromConfig4(t *testing.T) {
 	device, err := NewDeviceFromConfig(proto, instance)
 	assert.NoError(t, err)
 	assert.Equal(t, "type2", device.Type)
-	assert.Equal(t, map[string]string{"a": "b"}, device.Metadata)
 	assert.Equal(t, "testdata", device.Info)
 	assert.Equal(t, 2, len(device.Tags))
 	assert.Equal(t, map[string]interface{}{"address": "localhost", "port": 5000}, device.Data)
@@ -233,9 +218,6 @@ func TestNewDeviceFromConfig5a(t *testing.T) {
 	// Test disabling inheritance when there are inheritable values.
 	proto := &config.DeviceProto{
 		Type: "type1",
-		Metadata: map[string]string{
-			"a": "b",
-		},
 		Data: map[string]interface{}{
 			"port": 5000,
 		},
@@ -267,7 +249,6 @@ func TestNewDeviceFromConfig5a(t *testing.T) {
 	device, err := NewDeviceFromConfig(proto, instance)
 	assert.NoError(t, err)
 	assert.Equal(t, "type2", device.Type)
-	assert.Equal(t, map[string]string{"a": "b"}, device.Metadata)
 	assert.Equal(t, "testdata", device.Info)
 	assert.Equal(t, 1, len(device.Tags))
 	assert.Equal(t, map[string]interface{}{"address": "localhost"}, device.Data)
@@ -286,9 +267,6 @@ func TestNewDeviceFromConfig5b(t *testing.T) {
 	// defines a handler, but the instance does not.
 	proto := &config.DeviceProto{
 		Type: "type1",
-		Metadata: map[string]string{
-			"a": "b",
-		},
 		Data: map[string]interface{}{
 			"port": 5000,
 		},
@@ -314,7 +292,6 @@ func TestNewDeviceFromConfig5b(t *testing.T) {
 	device, err := NewDeviceFromConfig(proto, instance)
 	assert.NoError(t, err)
 	assert.Equal(t, "type2", device.Type)
-	assert.Equal(t, map[string]string{"a": "b"}, device.Metadata)
 	assert.Equal(t, "testdata", device.Info)
 	assert.Equal(t, 2, len(device.Tags))
 	assert.Equal(t, map[string]interface{}{"address": "localhost", "port": 5000}, device.Data)
@@ -332,9 +309,6 @@ func TestNewDeviceFromConfig6(t *testing.T) {
 	// Bad tags specified.
 	proto := &config.DeviceProto{
 		Type: "type1",
-		Metadata: map[string]string{
-			"a": "b",
-		},
 		Data: map[string]interface{}{
 			"port": 5000,
 		},
@@ -368,9 +342,6 @@ func TestNewDeviceFromConfig7(t *testing.T) {
 	// Bad alias specified.
 	proto := &config.DeviceProto{
 		Type: "type1",
-		Metadata: map[string]string{
-			"a": "b",
-		},
 		Data: map[string]interface{}{
 			"port": 5000,
 		},
@@ -404,9 +375,6 @@ func TestNewDeviceFromConfig8(t *testing.T) {
 	// Fail data map merging
 	proto := &config.DeviceProto{
 		Type: "type1",
-		Metadata: map[string]string{
-			"a": "b",
-		},
 		Data: map[string]interface{}{
 			"address": 1234,
 			"port":    5000,
@@ -442,9 +410,6 @@ func TestNewDeviceFromConfig9(t *testing.T) {
 	// Unknown output type specified
 	proto := &config.DeviceProto{
 		Type: "type1",
-		Metadata: map[string]string{
-			"a": "b",
-		},
 		Data: map[string]interface{}{
 			"port": 5000,
 		},
@@ -476,9 +441,6 @@ func TestNewDeviceFromConfig10(t *testing.T) {
 	// Unknown transformation function specified
 	proto := &config.DeviceProto{
 		Type: "type1",
-		Metadata: map[string]string{
-			"a": "b",
-		},
 		Data: map[string]interface{}{
 			"port": 5000,
 		},
@@ -510,9 +472,6 @@ func TestNewDeviceFromConfig11(t *testing.T) {
 	// Invalid scaling factor defined
 	proto := &config.DeviceProto{
 		Type: "type1",
-		Metadata: map[string]string{
-			"a": "b",
-		},
 		Data: map[string]interface{}{
 			"port": 5000,
 		},
@@ -544,9 +503,6 @@ func TestNewDeviceFromConfig12(t *testing.T) {
 	// overrides some values in the prototype context.
 	proto := &config.DeviceProto{
 		Type: "type1",
-		Metadata: map[string]string{
-			"a": "b",
-		},
 		Data: map[string]interface{}{
 			"port": 5000,
 		},
@@ -583,7 +539,6 @@ func TestNewDeviceFromConfig12(t *testing.T) {
 	device, err := NewDeviceFromConfig(proto, instance)
 	assert.NoError(t, err)
 	assert.Equal(t, "type2", device.Type)
-	assert.Equal(t, map[string]string{"a": "b"}, device.Metadata)
 	assert.Equal(t, "testdata", device.Info)
 	assert.Equal(t, 2, len(device.Tags))
 	assert.Equal(t, map[string]interface{}{"address": "localhost", "port": 5000}, device.Data)
@@ -655,17 +610,17 @@ func TestDevice_setAlias_templateOk(t *testing.T) {
 	assert.Equal(t, "testtype", device.Alias)
 }
 
-func TestDevice_GetMetadata(t *testing.T) {
+func TestDevice_GetContext(t *testing.T) {
 	device := Device{
-		Metadata: map[string]string{
+		Context: map[string]string{
 			"foo": "bar",
 			"abc": "xyz",
 		},
 	}
 
-	assert.Equal(t, "", device.GetMetadata("vapor"))
-	assert.Equal(t, "bar", device.GetMetadata("foo"))
-	assert.Equal(t, "xyz", device.GetMetadata("abc"))
+	assert.Equal(t, "", device.GetContext("vapor"))
+	assert.Equal(t, "bar", device.GetContext("foo"))
+	assert.Equal(t, "xyz", device.GetContext("abc"))
 }
 
 func TestDevice_GetHandler(t *testing.T) {
@@ -881,7 +836,7 @@ func TestDevice_IsWritable_false(t *testing.T) {
 func TestDevice_encode(t *testing.T) {
 	device := Device{
 		Type: "foo",
-		Metadata: map[string]string{
+		Context: map[string]string{
 			"abc": "123",
 		},
 		Info:    "test",
@@ -918,7 +873,7 @@ func TestDevice_encode_2(t *testing.T) {
 	// Encode when there are handler actions, but no Write handler
 	device := Device{
 		Type: "foo",
-		Metadata: map[string]string{
+		Context: map[string]string{
 			"abc": "123",
 		},
 		Info:    "test",
@@ -956,7 +911,7 @@ func TestDevice_encode_3(t *testing.T) {
 	// Encode when there are handler actions and a Write handler is specified
 	device := Device{
 		Type: "foo",
-		Metadata: map[string]string{
+		Context: map[string]string{
 			"abc": "123",
 		},
 		Info:    "test",

--- a/sdk/testdata/device/config.yml
+++ b/sdk/testdata/device/config.yml
@@ -3,7 +3,7 @@ tags:
   - etd/kind:complex
 devices:
   - handler: input_register
-    metadata:
+    context:
       foo: bar
     data:
       host: 10.194.4.250

--- a/sdk/version.go
+++ b/sdk/version.go
@@ -26,7 +26,7 @@ import (
 )
 
 // Version specifies the version of the Synse Plugin SDK.
-const Version = "3.0.0-alpha.1"
+const Version = "3.0.0-alpha.2"
 
 // version is a global reference to the pluginVersion which specifies the
 // version information for a Plugin. This is initialized on init and


### PR DESCRIPTION
This PR:
- removes the `metadata` device configuration. its role has effectively been replaced with the `context` configuration
- surface the context info to Synse Server via the gRPC API (previously where metadata was being surfaced)

The `metadata` and `context` fields were both filling similar, but slightly different roles. Metadata just stayed with the device, while Context was associated with the device and its readings. It doesn't seem like we'd want device-only metadata which isn't also part of the reading context, so the Metadata config becomes superfluous and can be replaced wholesale with the context. 