### PR TITLE
fix logging bug, fix go1.13 testing bug, bump version

### DIFF
--- a/sdk/config/plugin.go
+++ b/sdk/config/plugin.go
@@ -60,6 +60,7 @@ func (conf *Plugin) Log() {
 		log.Infof("  Version: %d", conf.Version)
 		log.Infof("  Debug:   %v", conf.Debug)
 		conf.ID.Log()
+		conf.Metrics.Log()
 		conf.Settings.Log()
 		conf.Network.Log()
 		conf.Health.Log()

--- a/sdk/plugin.go
+++ b/sdk/plugin.go
@@ -53,9 +53,6 @@ func init() {
 	flag.BoolVar(&flagDebug, "debug", false, "enable debug logging")
 	flag.BoolVar(&flagVersion, "version", false, "print the plugin version information")
 	flag.BoolVar(&flagDryRun, "dry-run", false, "run only the setup actions to verify functionality and configuration")
-
-	flag.Parse()
-	handleRunOptions()
 }
 
 // PluginAction defines an action that can be run before or after the main
@@ -96,6 +93,12 @@ type Plugin struct {
 // or invalid, this will fail. All other Plugin component initialization
 // is deferred until Run is called.
 func NewPlugin(options ...PluginOption) (*Plugin, error) {
+
+	// These used to be called in the init() fn. As of go1.13, there is an issue with
+	// parsing flags in init() when running tests. https://github.com/golang/go/issues/31859
+	flag.Parse()
+	handleRunOptions()
+
 	// Since this is essentially the entry point for the plugin and setup actions
 	// occur as part of plugin construction, we want to set the log level as early
 	// as possible. If the debug flag is set, set the level to debug.

--- a/sdk/version.go
+++ b/sdk/version.go
@@ -26,7 +26,7 @@ import (
 )
 
 // Version specifies the version of the Synse Plugin SDK.
-const Version = "3.0.0-alpha.2"
+const Version = "3.0.0-alpha.3"
 
 // version is a global reference to the pluginVersion which specifies the
 // version information for a Plugin. This is initialized on init and


### PR DESCRIPTION
This PR:
- fixes a bug where metrics config wasn't being logged out
- adds a fix for a go1.13 bug where parsing custom flags in `init()` causes `go test` to not work correctly
- bumps SDK version to `3.0.0-alpha.3`