### PR TITLE
add check for stream closing

### DIFF
--- a/sdk/server.go
+++ b/sdk/server.go
@@ -519,6 +519,10 @@ func (server *server) ReadStream(request *synse.V3StreamRequest, stream synse.V3
 	}
 
 	s := newReadStream(filter)
+	log.WithFields(log.Fields{
+		"id":     s.id,
+		"filter": s.filter,
+	}).Debug("[server] created new stream for readings")
 	server.stateManager.addStream(s)
 	defer func() {
 		server.stateManager.removeStream(s.id)

--- a/sdk/state_manager.go
+++ b/sdk/state_manager.go
@@ -78,6 +78,7 @@ func (manager *stateManager) Start() {
 
 // addStream adds a new stream for the stateManager to send reading data to.
 func (manager *stateManager) addStream(stream ReadStream) {
+	log.WithField("id", stream.id).Debug("[state manager] adding stream")
 	manager.streamLock.Lock()
 	defer manager.streamLock.Unlock()
 
@@ -86,6 +87,7 @@ func (manager *stateManager) addStream(stream ReadStream) {
 
 // removeStream removes a stream which the stateManager was sending data to.
 func (manager *stateManager) removeStream(id uuid.UUID) {
+	log.WithField("id", id).Debug("[state manager] removing stream")
 	manager.streamLock.Lock()
 	defer manager.streamLock.Unlock()
 


### PR DESCRIPTION
This PR:
- fixes a bug where a read stream listener would continue to write on a channel as it is being closed, causing a panic
- adds additional logging
- updates/adds tests

fixes #439 