### PR TITLE
bugfix: update device builder to copy prototype map to prevent it from being mutated

### DIFF
--- a/sdk/device.go
+++ b/sdk/device.go
@@ -124,19 +124,25 @@ func NewDeviceFromConfig(proto *config.DeviceProto, instance *config.DeviceInsta
 	// Define variable for the Device fields that can be inherited from the
 	// device prototype configuration.
 	var (
-		data         map[string]interface{}
-		context      map[string]string
+		data         = map[string]interface{}{}
+		context      = map[string]string{}
 		tags         []string
 		handler      string
 		deviceType   string
 		writeTimeout time.Duration
 	)
 
-	// If inheritance is enabled, use the prototype defined value as the base.
+	// If inheritance is enabled, use the prototype defined value as the base. For
+	// map and slice types, we need to make a copy so we do not mutate the prototype
+	// values for other instances built off the same prototype.
 	if !instance.DisableInheritance {
-		data = proto.Data
-		context = proto.Context
-		tags = proto.Tags
+		for k, v := range proto.Data {
+			data[k] = v
+		}
+		for k, v := range proto.Context {
+			context[k] = v
+		}
+		tags = append(tags, proto.Tags...)
 		handler = proto.Handler
 		deviceType = proto.Type
 		writeTimeout = proto.WriteTimeout


### PR DESCRIPTION
This PR:
- fixes a bug in the `NewDeviceFromConfig` builder which, when property inheritance is enabled, merged into the prototype maps (data, context), mutating the state for any future instances that are built off of the same prototype. This fix copies the prototype maps to ensure the actual prototype state is not mutated.
- adds regression test for the bug

shoutout to @KylerBurke for finding the bug! :bug: