### PR TITLE
update apply/scale transform config for ordering and flexibility

### DIFF
--- a/sdk/config/device_test.go
+++ b/sdk/config/device_test.go
@@ -1,0 +1,49 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTransformConfig_Validate_Ok(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  TransformConfig
+	}{
+		{
+			name: "empty config",
+			cfg:  TransformConfig{},
+		},
+		{
+			name: "only apply",
+			cfg: TransformConfig{
+				Apply: "testing",
+			},
+		},
+		{
+			name: "only scale",
+			cfg: TransformConfig{
+				Scale: "testing",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.cfg.Validate()
+			assert.NoError(t, err, test.name)
+		})
+	}
+}
+
+func TestTransformConfig_Validate_Error(t *testing.T) {
+	cfg := TransformConfig{
+		Apply: "testing",
+		Scale: "testing",
+	}
+
+	err := cfg.Validate()
+	assert.Error(t, err)
+	assert.Equal(t, ErrInvalidTransform, err)
+}

--- a/sdk/device_test.go
+++ b/sdk/device_test.go
@@ -85,7 +85,10 @@ func TestNewDeviceFromConfig(t *testing.T) {
 		Alias: &config.DeviceAlias{
 			Name: "foo",
 		},
-		ScalingFactor:      "2",
+		Transforms: []*config.TransformConfig{
+			{Scale: "2"},
+			{Apply: "FtoC"},
+		},
 		WriteTimeout:       5 * time.Second,
 		DisableInheritance: false,
 	}
@@ -100,10 +103,11 @@ func TestNewDeviceFromConfig(t *testing.T) {
 	assert.Equal(t, "testhandler2", device.Handler)
 	assert.Equal(t, int32(1), device.SortIndex)
 	assert.Equal(t, "foo", device.Alias)
-	assert.Equal(t, float64(2), device.ScalingFactor)
+	assert.Equal(t, 2, len(device.Transforms))
+	assert.Equal(t, "scale [2]", device.Transforms[0].Name())
+	assert.Equal(t, "apply [FtoC]", device.Transforms[1].Name())
 	assert.Equal(t, 5*time.Second, device.WriteTimeout)
 	assert.Equal(t, "temperature", device.Output)
-	assert.Equal(t, 0, len(device.fns))
 }
 
 func TestNewDeviceFromConfig2(t *testing.T) {
@@ -120,6 +124,10 @@ func TestNewDeviceFromConfig2(t *testing.T) {
 		Tags:         []string{"default/foo"},
 		Handler:      "testhandler",
 		WriteTimeout: 3 * time.Second,
+		Transforms: []*config.TransformConfig{
+			{Scale: "2"},
+			{Apply: "FtoC"},
+		},
 	}
 	instance := &config.DeviceInstance{
 		Info: "testdata",
@@ -128,12 +136,10 @@ func TestNewDeviceFromConfig2(t *testing.T) {
 			"address": "localhost",
 		},
 		Output:    "temperature",
-		Apply:     []string{"FtoC"},
 		SortIndex: 1,
 		Alias: &config.DeviceAlias{
 			Name: "foo",
 		},
-		ScalingFactor:      "2e3",
 		DisableInheritance: false,
 	}
 
@@ -147,10 +153,11 @@ func TestNewDeviceFromConfig2(t *testing.T) {
 	assert.Equal(t, "testhandler", device.Handler)
 	assert.Equal(t, int32(1), device.SortIndex)
 	assert.Equal(t, "foo", device.Alias)
-	assert.Equal(t, float64(2000), device.ScalingFactor)
 	assert.Equal(t, 3*time.Second, device.WriteTimeout)
 	assert.Equal(t, "temperature", device.Output)
-	assert.Equal(t, 1, len(device.fns))
+	assert.Equal(t, 2, len(device.Transforms))
+	assert.Equal(t, "scale [2]", device.Transforms[0].Name())
+	assert.Equal(t, "apply [FtoC]", device.Transforms[1].Name())
 }
 
 func TestNewDeviceFromConfig3(t *testing.T) {
@@ -174,7 +181,6 @@ func TestNewDeviceFromConfig3(t *testing.T) {
 		Alias: &config.DeviceAlias{
 			Name: "foo",
 		},
-		ScalingFactor:      "2",
 		WriteTimeout:       5 * time.Second,
 		DisableInheritance: false,
 	}
@@ -203,7 +209,6 @@ func TestNewDeviceFromConfig4(t *testing.T) {
 		Alias: &config.DeviceAlias{
 			Name: "foo",
 		},
-		ScalingFactor:      "1e-2",
 		DisableInheritance: false,
 	}
 
@@ -217,10 +222,9 @@ func TestNewDeviceFromConfig4(t *testing.T) {
 	assert.Equal(t, "type2", device.Handler)
 	assert.Equal(t, int32(1), device.SortIndex)
 	assert.Equal(t, "foo", device.Alias)
-	assert.Equal(t, 0.01, device.ScalingFactor)
 	assert.Equal(t, 30*time.Second, device.WriteTimeout) // takes the default value
 	assert.Equal(t, "", device.Output)
-	assert.Equal(t, 0, len(device.fns))
+	assert.Equal(t, 0, len(device.Transforms))
 }
 
 func TestNewDeviceFromConfig5a(t *testing.T) {
@@ -236,6 +240,10 @@ func TestNewDeviceFromConfig5a(t *testing.T) {
 		Tags:         []string{"default/foo"},
 		Handler:      "testhandler",
 		WriteTimeout: 3 * time.Second,
+		Transforms: []*config.TransformConfig{
+			{Scale: "2"},
+			{Apply: "FtoC"},
+		},
 	}
 	instance := &config.DeviceInstance{
 		Type: "type2",
@@ -251,7 +259,6 @@ func TestNewDeviceFromConfig5a(t *testing.T) {
 		Alias: &config.DeviceAlias{
 			Name: "foo",
 		},
-		ScalingFactor:      "2",
 		DisableInheritance: true,
 	}
 
@@ -265,10 +272,9 @@ func TestNewDeviceFromConfig5a(t *testing.T) {
 	assert.Equal(t, "type2", device.Handler) // inheritance disabled, does not get proto handler
 	assert.Equal(t, int32(1), device.SortIndex)
 	assert.Equal(t, "foo", device.Alias)
-	assert.Equal(t, float64(2), device.ScalingFactor)
 	assert.Equal(t, 30*time.Second, device.WriteTimeout) // takes the default value
 	assert.Equal(t, "", device.Output)
-	assert.Equal(t, 0, len(device.fns))
+	assert.Equal(t, 0, len(device.Transforms))
 }
 
 func TestNewDeviceFromConfig5b(t *testing.T) {
@@ -294,7 +300,6 @@ func TestNewDeviceFromConfig5b(t *testing.T) {
 		Alias: &config.DeviceAlias{
 			Name: "foo",
 		},
-		ScalingFactor:      "2",
 		DisableInheritance: false,
 	}
 
@@ -308,10 +313,9 @@ func TestNewDeviceFromConfig5b(t *testing.T) {
 	assert.Equal(t, "testhandler", device.Handler) // inheritance enabled, gets proto handler
 	assert.Equal(t, int32(1), device.SortIndex)
 	assert.Equal(t, "foo", device.Alias)
-	assert.Equal(t, float64(2), device.ScalingFactor)
 	assert.Equal(t, 3*time.Second, device.WriteTimeout) // takes the proto value
 	assert.Equal(t, "", device.Output)
-	assert.Equal(t, 0, len(device.fns))
+	assert.Equal(t, 0, len(device.Transforms))
 }
 
 func TestNewDeviceFromConfig6(t *testing.T) {
@@ -337,7 +341,6 @@ func TestNewDeviceFromConfig6(t *testing.T) {
 		Alias: &config.DeviceAlias{
 			Name: "foo",
 		},
-		ScalingFactor:      "2",
 		WriteTimeout:       5 * time.Second,
 		DisableInheritance: false,
 	}
@@ -370,7 +373,6 @@ func TestNewDeviceFromConfig7(t *testing.T) {
 		Alias: &config.DeviceAlias{
 			Template: "foo.{{.NotAField}}",
 		},
-		ScalingFactor:      "2",
 		WriteTimeout:       5 * time.Second,
 		DisableInheritance: false,
 	}
@@ -405,7 +407,6 @@ func TestNewDeviceFromConfig8(t *testing.T) {
 		Alias: &config.DeviceAlias{
 			Name: "foo",
 		},
-		ScalingFactor:      "2",
 		WriteTimeout:       5 * time.Second,
 		DisableInheritance: false,
 	}
@@ -436,7 +437,6 @@ func TestNewDeviceFromConfig9(t *testing.T) {
 		SortIndex:          1,
 		Handler:            "testhandler2",
 		Output:             "unknown-output-name",
-		ScalingFactor:      "2",
 		WriteTimeout:       5 * time.Second,
 		DisableInheritance: false,
 	}
@@ -447,38 +447,63 @@ func TestNewDeviceFromConfig9(t *testing.T) {
 }
 
 func TestNewDeviceFromConfig10(t *testing.T) {
-	// Unknown transformation function specified
+	// Proto and instance both define transformers - ensure they merge correctly.
 	proto := &config.DeviceProto{
 		Type: "type1",
 		Data: map[string]interface{}{
 			"port": 5000,
 		},
+		Context: map[string]string{
+			"foo": "bar",
+		},
 		Tags:         []string{"default/foo"},
 		Handler:      "testhandler",
 		WriteTimeout: 3 * time.Second,
+		Transforms: []*config.TransformConfig{
+			{Apply: "FtoC"},
+			{Scale: "3"},
+		},
 	}
 	instance := &config.DeviceInstance{
-		Type: "type2",
 		Info: "testdata",
 		Tags: []string{"vapor/io"},
 		Data: map[string]interface{}{
 			"address": "localhost",
 		},
-		SortIndex:          1,
-		Handler:            "testhandler2",
-		Apply:              []string{"unknown-fn"},
-		ScalingFactor:      "2",
-		WriteTimeout:       5 * time.Second,
+		Output:    "temperature",
+		SortIndex: 1,
+		Alias: &config.DeviceAlias{
+			Name: "foo",
+		},
 		DisableInheritance: false,
+		Transforms: []*config.TransformConfig{
+			{Scale: "2"},
+			{Apply: "FtoC"},
+		},
 	}
 
 	device, err := NewDeviceFromConfig(proto, instance, testHandlers)
-	assert.Error(t, err)
-	assert.Nil(t, device)
+	assert.NoError(t, err)
+	assert.Equal(t, "type1", device.Type)
+	assert.Equal(t, "testdata", device.Info)
+	assert.Equal(t, 2, len(device.Tags))
+	assert.Equal(t, map[string]interface{}{"address": "localhost", "port": 5000}, device.Data)
+	assert.Equal(t, map[string]string{"foo": "bar"}, device.Context)
+	assert.Equal(t, "testhandler", device.Handler)
+	assert.Equal(t, int32(1), device.SortIndex)
+	assert.Equal(t, "foo", device.Alias)
+	assert.Equal(t, 3*time.Second, device.WriteTimeout)
+	assert.Equal(t, "temperature", device.Output)
+
+	assert.Equal(t, 4, len(device.Transforms))
+	assert.Equal(t, "apply [FtoC]", device.Transforms[0].Name())
+	assert.Equal(t, "scale [3]", device.Transforms[1].Name())
+	assert.Equal(t, "scale [2]", device.Transforms[2].Name())
+	assert.Equal(t, "apply [FtoC]", device.Transforms[3].Name())
 }
 
-func TestNewDeviceFromConfig11(t *testing.T) {
-	// Invalid scaling factor defined
+func TestNewDeviceFromConfig11a(t *testing.T) {
+	// Invalid instance transformer config provided (specified multiple operations)
 	proto := &config.DeviceProto{
 		Type: "type1",
 		Data: map[string]interface{}{
@@ -495,16 +520,52 @@ func TestNewDeviceFromConfig11(t *testing.T) {
 		Data: map[string]interface{}{
 			"address": "localhost",
 		},
-		SortIndex:          1,
-		Handler:            "testhandler2",
-		ScalingFactor:      "bad scaling factor",
+		SortIndex: 1,
+		Handler:   "testhandler2",
+		Transforms: []*config.TransformConfig{{
+			Apply: "FtoC",
+			Scale: "2",
+		}},
 		WriteTimeout:       5 * time.Second,
 		DisableInheritance: false,
 	}
 
 	device, err := NewDeviceFromConfig(proto, instance, testHandlers)
-	assert.Error(t, err)
 	assert.Nil(t, device)
+	assert.Error(t, err)
+}
+
+func TestNewDeviceFromConfig11b(t *testing.T) {
+	// Invalid prototype transformer config provided (specified multiple operations)
+	proto := &config.DeviceProto{
+		Type: "type1",
+		Data: map[string]interface{}{
+			"port": 5000,
+		},
+		Tags:         []string{"default/foo"},
+		Handler:      "testhandler",
+		WriteTimeout: 3 * time.Second,
+		Transforms: []*config.TransformConfig{{
+			Apply: "FtoC",
+			Scale: "2",
+		}},
+	}
+	instance := &config.DeviceInstance{
+		Type: "type2",
+		Info: "testdata",
+		Tags: []string{"vapor/io"},
+		Data: map[string]interface{}{
+			"address": "localhost",
+		},
+		SortIndex:          1,
+		Handler:            "testhandler2",
+		WriteTimeout:       5 * time.Second,
+		DisableInheritance: false,
+	}
+
+	device, err := NewDeviceFromConfig(proto, instance, testHandlers)
+	assert.Nil(t, device)
+	assert.Error(t, err)
 }
 
 func TestNewDeviceFromConfig12(t *testing.T) {
@@ -540,7 +601,6 @@ func TestNewDeviceFromConfig12(t *testing.T) {
 		Alias: &config.DeviceAlias{
 			Name: "foo",
 		},
-		ScalingFactor:      "2",
 		WriteTimeout:       5 * time.Second,
 		DisableInheritance: false,
 	}
@@ -555,10 +615,9 @@ func TestNewDeviceFromConfig12(t *testing.T) {
 	assert.Equal(t, "testhandler2", device.Handler)
 	assert.Equal(t, int32(1), device.SortIndex)
 	assert.Equal(t, "foo", device.Alias)
-	assert.Equal(t, float64(2), device.ScalingFactor)
 	assert.Equal(t, 5*time.Second, device.WriteTimeout)
 	assert.Equal(t, "temperature", device.Output)
-	assert.Equal(t, 0, len(device.fns))
+	assert.Equal(t, 0, len(device.Transforms))
 }
 
 func TestNewDeviceFromConfig13(t *testing.T) {
@@ -599,7 +658,6 @@ func TestNewDeviceFromConfig13(t *testing.T) {
 		Alias: &config.DeviceAlias{
 			Name: "foo",
 		},
-		ScalingFactor:      "2",
 		WriteTimeout:       5 * time.Second,
 		DisableInheritance: false,
 	}
@@ -626,7 +684,6 @@ func TestNewDeviceFromConfig13(t *testing.T) {
 		Alias: &config.DeviceAlias{
 			Name: "bar",
 		},
-		ScalingFactor:      "2",
 		WriteTimeout:       5 * time.Second,
 		DisableInheritance: false,
 	}
@@ -651,10 +708,9 @@ func TestNewDeviceFromConfig13(t *testing.T) {
 	assert.Equal(t, "testhandler2", dev1.Handler)
 	assert.Equal(t, int32(1), dev1.SortIndex)
 	assert.Equal(t, "foo", dev1.Alias)
-	assert.Equal(t, float64(2), dev1.ScalingFactor)
 	assert.Equal(t, 5*time.Second, dev1.WriteTimeout)
 	assert.Equal(t, "temperature", dev1.Output)
-	assert.Equal(t, 0, len(dev1.fns))
+	assert.Equal(t, 0, len(dev1.Transforms))
 	for i, tag := range dev1.Tags {
 		assert.Equal(t, dev1ExpectedTags[i], tag)
 	}
@@ -670,10 +726,9 @@ func TestNewDeviceFromConfig13(t *testing.T) {
 	assert.Equal(t, "testhandler2", dev2.Handler)
 	assert.Equal(t, int32(2), dev2.SortIndex)
 	assert.Equal(t, "bar", dev2.Alias)
-	assert.Equal(t, float64(2), dev2.ScalingFactor)
 	assert.Equal(t, 5*time.Second, dev2.WriteTimeout)
 	assert.Equal(t, "temperature", dev2.Output)
-	assert.Equal(t, 0, len(dev2.fns))
+	assert.Equal(t, 0, len(dev2.Transforms))
 	for i, tag := range dev2.Tags {
 		assert.Equal(t, dev2ExpectedTags[i], tag)
 	}
@@ -732,7 +787,6 @@ func TestNewDeviceFromConfig15(t *testing.T) {
 		Alias: &config.DeviceAlias{
 			Name: "foo",
 		},
-		ScalingFactor:      "2",
 		WriteTimeout:       5 * time.Second,
 		DisableInheritance: false,
 	}
@@ -767,10 +821,9 @@ func TestNewDeviceFromConfig15(t *testing.T) {
 	assert.Equal(t, "testhandler2", device.Handler)
 	assert.Equal(t, int32(1), device.SortIndex)
 	assert.Equal(t, "foo", device.Alias)
-	assert.Equal(t, float64(2), device.ScalingFactor)
 	assert.Equal(t, 5*time.Second, device.WriteTimeout)
 	assert.Equal(t, "temperature", device.Output)
-	assert.Equal(t, 0, len(device.fns))
+	assert.Equal(t, 0, len(device.Transforms))
 }
 
 func TestDevice_setAlias_noConf(t *testing.T) {

--- a/sdk/transform.go
+++ b/sdk/transform.go
@@ -1,0 +1,146 @@
+package sdk
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/vapor-ware/synse-sdk/sdk/config"
+	"github.com/vapor-ware/synse-sdk/sdk/funcs"
+	"github.com/vapor-ware/synse-sdk/sdk/output"
+)
+
+// Errors relating to Transformer creation and application.
+var (
+	ErrNilTransformConfig = errors.New("cannot create transformer: nil config")
+	ErrUnknownTransformFn = errors.New("unknown transform apply function specified")
+)
+
+// A Transformer is something which transforms a device's raw reading value(s).
+// This transformation is typically a scaling or type conversion. This is generally
+// used more for general-purpose plugins where the device handler is not specific
+// to the device/output and the reading value may need to be coerced into a desired
+// output.
+type Transformer interface {
+
+	// Apply the transformation to the given reading value.
+	Apply(reading *output.Reading) error
+
+	// Get the name of the transformer.
+	Name() string
+}
+
+// ApplyTransformer is a device reading Transformer which applies pre-defined
+// functions to a device's reading(s).
+type ApplyTransformer struct {
+	Func *funcs.Func
+}
+
+// NewApplyTransformer creates a new device reading Transformer which is used
+// to apply pre-defined functions to a device's reading(s). The SDK has some
+// built-in functions in the 'funcs' package. A plugin may also register its
+// own. Functions are referenced by name.
+func NewApplyTransformer(fn string) (*ApplyTransformer, error) {
+	f := funcs.Get(fn)
+	if f == nil {
+		log.WithFields(log.Fields{
+			"fn": fn,
+		}).Error("[transform] unknown transform function specified")
+		return nil, ErrUnknownTransformFn
+	}
+
+	return &ApplyTransformer{
+		Func: f,
+	}, nil
+}
+
+// Apply the transformer function to the given reading value.
+func (t *ApplyTransformer) Apply(reading *output.Reading) error {
+	val, err := t.Func.Call(reading.Value)
+	if err != nil {
+		return err
+	}
+	reading.Value = val
+	return nil
+}
+
+// Name returns a human-readable name for the apply transformer.
+func (t *ApplyTransformer) Name() string {
+	return fmt.Sprintf("apply [%v]", t.Func.Name)
+}
+
+// ScaleTransformer is a device reading transformer which scales a device's
+// reading(s) by a multiplicative factor.
+type ScaleTransformer struct {
+	Factor float64
+}
+
+// NewScaleTransformer creates a new device reading Transformer which is used
+// to scale readings by a multiplicative factor.
+//
+// The scaling factor is specified as a string, but should resolve to a numeric.
+// By  default, it will have a value of 1 (e.g. no-op). Negative values and
+// fractional values are supported. This can be the value itself, e.g. "0.01",
+// or a mathematical representation of the value, e.g. "1e-2". Dividing is the same
+// as multiplying by a fraction (e.g. "/ 2" == "* 0.5").
+func NewScaleTransformer(factor string) (*ScaleTransformer, error) {
+	var scaleBy float64 = 1
+	var err error
+
+	if factor != "" {
+		scaleBy, err = strconv.ParseFloat(factor, 64)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"factor": factor,
+				"error":  err,
+			}).Error("[transform] failed to create scale transformer: bad factor")
+			return nil, err
+		}
+	}
+
+	return &ScaleTransformer{
+		Factor: scaleBy,
+	}, nil
+}
+
+// Apply the transformer scaling factor to the given reading value.
+func (t *ScaleTransformer) Apply(reading *output.Reading) error {
+	if t.Factor == 1 {
+		// Nothing to scale.
+		return nil
+	}
+	return reading.Scale(t.Factor)
+}
+
+// Name returns a human-readable name for the scale transformer.
+func (t *ScaleTransformer) Name() string {
+	return fmt.Sprintf("scale [%v]", t.Factor)
+}
+
+// NewTransformer creates a new device reading Transformer from the provided
+// TransformConfig. If the configuration is incorrect or specifies unsupported
+// values, an error is returned.
+func NewTransformer(cfg *config.TransformConfig) (Transformer, error) {
+	if cfg == nil {
+		return nil, ErrNilTransformConfig
+	}
+
+	log.WithFields(log.Fields{
+		"apply": cfg.Apply,
+		"scale": cfg.Scale,
+	}).Debug("[transform] creating new device reading transformer")
+
+	// Verify the config is valid and does not contain multiple operations.
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	if cfg.Apply != "" {
+		return NewApplyTransformer(cfg.Apply)
+	} else if cfg.Scale != "" {
+		return NewScaleTransformer(cfg.Scale)
+	} else {
+		return nil, errors.New("no transformer operation configured")
+	}
+}

--- a/sdk/transform_test.go
+++ b/sdk/transform_test.go
@@ -1,0 +1,164 @@
+package sdk
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vapor-ware/synse-sdk/sdk/config"
+	"github.com/vapor-ware/synse-sdk/sdk/funcs"
+	"github.com/vapor-ware/synse-sdk/sdk/output"
+)
+
+func TestNewApplyTransformer(t *testing.T) {
+	transformer, err := NewApplyTransformer("FtoC")
+	assert.NoError(t, err)
+	assert.NotNil(t, transformer)
+	assert.Equal(t, &funcs.FtoC, transformer.Func)
+}
+
+func TestNewApplyTransformer_Error(t *testing.T) {
+	transformer, err := NewApplyTransformer("does not exist")
+	assert.Error(t, err)
+	assert.Equal(t, ErrUnknownTransformFn, err)
+	assert.Nil(t, transformer)
+}
+
+func TestApplyTransformer_Apply(t *testing.T) {
+	transformer := ApplyTransformer{
+		Func: &funcs.Func{
+			Name: "test func",
+			Fn: func(value interface{}) (interface{}, error) {
+				return value.(int) * 2, nil
+			},
+		},
+	}
+
+	reading := output.Reading{Value: 2}
+	err := transformer.Apply(&reading)
+	assert.NoError(t, err)
+	assert.Equal(t, 4, reading.Value)
+}
+
+func TestApplyTransformer_Apply_Error(t *testing.T) {
+	transformer := ApplyTransformer{
+		Func: &funcs.Func{
+			Name: "test func",
+			Fn: func(value interface{}) (interface{}, error) {
+				return nil, fmt.Errorf("err")
+			},
+		},
+	}
+
+	reading := output.Reading{Value: 2}
+	err := transformer.Apply(&reading)
+	assert.Error(t, err)
+	assert.Equal(t, 2, reading.Value)
+}
+
+func TestApplyTransformer_Name(t *testing.T) {
+	transformer := ApplyTransformer{
+		Func: &funcs.Func{
+			Name: "test func",
+			Fn: func(value interface{}) (interface{}, error) {
+				return nil, fmt.Errorf("err")
+			},
+		},
+	}
+
+	assert.Equal(t, "apply [test func]", transformer.Name())
+}
+
+func TestNewScaleTransformer(t *testing.T) {
+	transformer, err := NewScaleTransformer("2")
+	assert.NoError(t, err)
+	assert.NotNil(t, transformer)
+	assert.Equal(t, float64(2), transformer.Factor)
+}
+
+func TestNewScaleTransformer_Error(t *testing.T) {
+	transformer, err := NewScaleTransformer("not a factor")
+	assert.Error(t, err)
+	assert.Nil(t, transformer)
+}
+
+func TestScaleTransformer_Apply(t *testing.T) {
+	transformer := ScaleTransformer{
+		Factor: 2,
+	}
+
+	reading := output.Reading{Value: 2}
+	err := transformer.Apply(&reading)
+	assert.NoError(t, err)
+	assert.Equal(t, float64(4), reading.Value)
+}
+
+func TestScaleTransformer_Apply_NoOp(t *testing.T) {
+	transformer := ScaleTransformer{
+		Factor: 1,
+	}
+
+	reading := output.Reading{Value: 2}
+	err := transformer.Apply(&reading)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, reading.Value)
+}
+
+func TestScaleTransformer_Apply_Error(t *testing.T) {
+	transformer := ScaleTransformer{
+		Factor: 0,
+	}
+
+	reading := output.Reading{Value: 2}
+	err := transformer.Apply(&reading)
+	assert.Error(t, err)
+	assert.Equal(t, 2, reading.Value)
+}
+
+func TestScaleTransformer_Name(t *testing.T) {
+	transformer := ScaleTransformer{
+		Factor: 3,
+	}
+
+	assert.Equal(t, "scale [3]", transformer.Name())
+}
+
+func TestNewTransformer_NilConfig(t *testing.T) {
+	transformer, err := NewTransformer(nil)
+	assert.Error(t, err)
+	assert.Equal(t, ErrNilTransformConfig, err)
+	assert.Nil(t, transformer)
+}
+
+func TestNewTransformer_InvalidConfig(t *testing.T) {
+	transformer, err := NewTransformer(&config.TransformConfig{
+		Scale: "2",
+		Apply: "FtoC",
+	})
+	assert.Error(t, err)
+	assert.Nil(t, transformer)
+}
+
+func TestNewTransformer_Scale(t *testing.T) {
+	transformer, err := NewTransformer(&config.TransformConfig{
+		Scale: "3",
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, transformer)
+	assert.Equal(t, "scale [3]", transformer.Name())
+}
+
+func TestNewTransformer_Apply(t *testing.T) {
+	transformer, err := NewTransformer(&config.TransformConfig{
+		Apply: "FtoC",
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, transformer)
+	assert.Equal(t, "apply [FtoC]", transformer.Name())
+}
+
+func TestNewTransformer_NoTransforms(t *testing.T) {
+	transformer, err := NewTransformer(&config.TransformConfig{})
+	assert.Error(t, err)
+	assert.Nil(t, transformer)
+}


### PR DESCRIPTION
This PR:
- changes the device config
    - removes instance ScalingFactor config
    - removes instance Apply config
    - adds Transformers config which allows specifying multiple scales/apply transforms in an ordered list
- adds and updates tests

With this, a config snippet like:
```yaml
devices:
- type: foo
  instances:
    - info: Device 1
      scalingFactor: 0.1
      apply:
        - FtoC
```
becomes
```yaml
devices:
- type: foo
  instances:
    - info: Device 1
      transforms:
      - scale: 0.1
      - apply: FtoC
```

this allows you to specify order because it is a list, so if you want to apply before scale, 
```yaml
devices:
- type: foo
  instances:
    - info: Device 1
      transforms:
      - apply: FtoC
      - scale: 0.1
```

fixes #449