### PR TITLE
bugfix: add missing type check for redacting dynamic config

### DIFF
--- a/sdk/config/plugin_test.go
+++ b/sdk/config/plugin_test.go
@@ -16,7 +16,13 @@
 
 package config
 
-import "testing"
+import (
+	"bytes"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
 
 //
 // Unless there are updates done to the logger such that we can
@@ -148,13 +154,41 @@ func TestTLSNetworkSettings_Log(t *testing.T) {
 }
 
 func TestDynamicRegistrationSettings_Log_nil(t *testing.T) {
+	out := bytes.Buffer{}
+	log.SetOutput(&out)
+
 	var c *DynamicRegistrationSettings
 	c.Log()
+
+	assert.Contains(t, out.String(), "msg=\"  DynamicRegistration: nil\"\n")
 }
 
 func TestDynamicRegistrationSettings_Log(t *testing.T) {
+	out := bytes.Buffer{}
+	log.SetOutput(&out)
+
 	c := DynamicRegistrationSettings{}
 	c.Log()
+
+	assert.Contains(t, out.String(), "msg=\"  DynamicRegistration:\"\n")
+	assert.Contains(t, out.String(), "msg=\"    Config: []\"\n")
+}
+
+func TestDynamicRegistrationSettings_Log_withPass(t *testing.T) {
+	out := bytes.Buffer{}
+	log.SetOutput(&out)
+
+	c := DynamicRegistrationSettings{
+		Config: []map[string]interface{}{
+			{
+				"authenticationPassphrase": "foobar",
+			},
+		},
+	}
+	c.Log()
+
+	assert.Contains(t, out.String(), "msg=\"  DynamicRegistration:\"\n")
+	assert.Contains(t, out.String(), "msg=\"    Config: [map[authenticationPassphrase:REDACTED]]\"\n")
 }
 
 func TestHealthSettings_Log_nil(t *testing.T) {

--- a/sdk/utils/redact.go
+++ b/sdk/utils/redact.go
@@ -48,6 +48,14 @@ func RedactPasswords(m interface{}) interface{} {
 		traverseSlice(redacted)
 		return redacted
 
+	case []map[string]interface{}:
+		var redacted []interface{}
+		for _, v := range m.([]map[string]interface{}) {
+			redacted = append(redacted, v)
+		}
+		traverseSlice(redacted)
+		return redacted
+
 	default:
 		return m
 	}

--- a/sdk/utils/redact_test.go
+++ b/sdk/utils/redact_test.go
@@ -68,6 +68,11 @@ func TestRedactPasswords(t *testing.T) {
 			expected: map[string]interface{}{"key": "value", "Password": "REDACTED"},
 		},
 		{
+			name:     "map with key authenticationPassphrase, value string",
+			input:    map[string]interface{}{"key": "value", "authenticationPassphrase": "password"},
+			expected: map[string]interface{}{"key": "value", "authenticationPassphrase": "REDACTED"},
+		},
+		{
 			name:     "map with key User Password, value map",
 			input:    map[string]interface{}{"key": "value", "User Password": map[string]interface{}{"foo": "bar"}},
 			expected: map[string]interface{}{"key": "value", "User Password": "REDACTED"},
@@ -91,6 +96,31 @@ func TestRedactPasswords(t *testing.T) {
 			name:     "map with nested slice with nested map with password",
 			input:    map[string]interface{}{"foo": []interface{}{map[string]interface{}{"pass": "foo", "other": "bar"}}},
 			expected: map[string]interface{}{"foo": []interface{}{map[string]interface{}{"pass": "REDACTED", "other": "bar"}}},
+		},
+		{
+			name:     "slice of map with no password",
+			input:    []map[string]interface{}{{"key": "value"}},
+			expected: []interface{}{map[string]interface{}{"key": "value"}},
+		},
+		{
+			name:     "slice of map with key pass, value string",
+			input:    []map[string]interface{}{{"key": "value", "pass": "foobar"}},
+			expected: []interface{}{map[string]interface{}{"key": "value", "pass": "REDACTED"}},
+		},
+		{
+			name:     "slice of map with key PASS, value int",
+			input:    []map[string]interface{}{{"key": "value", "PASS": 123}},
+			expected: []interface{}{map[string]interface{}{"key": "value", "PASS": "REDACTED"}},
+		},
+		{
+			name:     "slice of map with key Password, value string",
+			input:    []map[string]interface{}{{"key": "value", "Password": "password"}},
+			expected: []interface{}{map[string]interface{}{"key": "value", "Password": "REDACTED"}},
+		},
+		{
+			name:     "slice of map with key authenticationPassphrase, value string",
+			input:    []map[string]interface{}{{"key": "value", "authenticationPassphrase": "password"}},
+			expected: []interface{}{map[string]interface{}{"key": "value", "authenticationPassphrase": "REDACTED"}},
 		},
 		{
 			name:     "map with empty slice",


### PR DESCRIPTION
This PR:
- fixes a bug where the dynamic config wasn't being password redacted properly.

related: https://github.com/vapor-ware/synse-snmp-plugin/issues/45