### PR TITLE
Configuration logging updates

### DIFF
--- a/sdk/config/config.go
+++ b/sdk/config/config.go
@@ -167,6 +167,14 @@ func (loader *Loader) Load(pol policy.Policy) error {
 		return err
 	}
 
+	log.WithFields(log.Fields{
+		"loader": loader.Name,
+		"paths":  loader.SearchPaths,
+		"name":   loader.FileName,
+		"ext":    loader.Ext,
+		"policy": loader.policy,
+		"data":   loader.merged,
+	}).Info("[config] successfully loaded configuration data")
 	return nil
 }
 
@@ -396,7 +404,7 @@ func (loader *Loader) read(pol policy.Policy) error {
 	}
 
 	for _, path := range loader.files {
-		log.WithField("file", path).Debug("[config] reading config file")
+		log.WithField("file", path).Info("[config] reading config file")
 		data, err := ioutil.ReadFile(path)
 		if err != nil {
 			log.WithField("error", err).Error("[config] failed to read file")
@@ -412,6 +420,10 @@ func (loader *Loader) read(pol policy.Policy) error {
 				log.WithField("error", err).Error("[config] failed to unmarshal config data")
 				return err
 			}
+			log.WithFields(log.Fields{
+				"file": path,
+				"data": res,
+			}).Debug("[config] loaded configuration from file")
 			loader.data = append(loader.data, res)
 		default:
 			log.WithField("ext", loader.Ext).Error("[config] unsupported file format")

--- a/sdk/config/config.go
+++ b/sdk/config/config.go
@@ -31,6 +31,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	sdkError "github.com/vapor-ware/synse-sdk/sdk/errors"
 	"github.com/vapor-ware/synse-sdk/sdk/policy"
+	"github.com/vapor-ware/synse-sdk/sdk/utils"
 	"gopkg.in/yaml.v2"
 )
 
@@ -173,7 +174,7 @@ func (loader *Loader) Load(pol policy.Policy) error {
 		"name":   loader.FileName,
 		"ext":    loader.Ext,
 		"policy": loader.policy,
-		"data":   loader.merged,
+		"data":   utils.RedactPasswords(loader.merged),
 	}).Info("[config] successfully loaded configuration data")
 	return nil
 }
@@ -422,7 +423,7 @@ func (loader *Loader) read(pol policy.Policy) error {
 			}
 			log.WithFields(log.Fields{
 				"file": path,
-				"data": res,
+				"data": utils.RedactPasswords(res),
 			}).Debug("[config] loaded configuration from file")
 			loader.data = append(loader.data, res)
 		default:

--- a/sdk/utils/redact_test.go
+++ b/sdk/utils/redact_test.go
@@ -23,7 +23,6 @@ import (
 )
 
 func TestRedactPasswords(t *testing.T) {
-
 	var nilMap map[string]interface{}
 	var nilSlice []interface{}
 
@@ -100,27 +99,27 @@ func TestRedactPasswords(t *testing.T) {
 		{
 			name:     "slice of map with no password",
 			input:    []map[string]interface{}{{"key": "value"}},
-			expected: []interface{}{map[string]interface{}{"key": "value"}},
+			expected: []map[string]interface{}{{"key": "value"}},
 		},
 		{
 			name:     "slice of map with key pass, value string",
 			input:    []map[string]interface{}{{"key": "value", "pass": "foobar"}},
-			expected: []interface{}{map[string]interface{}{"key": "value", "pass": "REDACTED"}},
+			expected: []map[string]interface{}{{"key": "value", "pass": "REDACTED"}},
 		},
 		{
 			name:     "slice of map with key PASS, value int",
 			input:    []map[string]interface{}{{"key": "value", "PASS": 123}},
-			expected: []interface{}{map[string]interface{}{"key": "value", "PASS": "REDACTED"}},
+			expected: []map[string]interface{}{{"key": "value", "PASS": "REDACTED"}},
 		},
 		{
 			name:     "slice of map with key Password, value string",
 			input:    []map[string]interface{}{{"key": "value", "Password": "password"}},
-			expected: []interface{}{map[string]interface{}{"key": "value", "Password": "REDACTED"}},
+			expected: []map[string]interface{}{{"key": "value", "Password": "REDACTED"}},
 		},
 		{
 			name:     "slice of map with key authenticationPassphrase, value string",
 			input:    []map[string]interface{}{{"key": "value", "authenticationPassphrase": "password"}},
-			expected: []interface{}{map[string]interface{}{"key": "value", "authenticationPassphrase": "REDACTED"}},
+			expected: []map[string]interface{}{{"key": "value", "authenticationPassphrase": "REDACTED"}},
 		},
 		{
 			name:     "map with empty slice",
@@ -135,12 +134,12 @@ func TestRedactPasswords(t *testing.T) {
 		{
 			name:     "map with nil slice",
 			input:    map[string]interface{}{"key": nilSlice},
-			expected: map[string]interface{}{"key": nilSlice},
+			expected: map[string]interface{}{"key": []interface{}{}},
 		},
 		{
 			name:     "map with nil map",
 			input:    map[string]interface{}{"key": nilMap},
-			expected: map[string]interface{}{"key": nilMap},
+			expected: map[string]interface{}{"key": map[string]interface{}{}},
 		},
 		{
 			name:     "slice with no maps",
@@ -175,7 +174,7 @@ func TestRedactPasswords(t *testing.T) {
 		{
 			name:     "slice with empty slice",
 			input:    []interface{}{[]interface{}{}},
-			expected: []interface{}{nilSlice},
+			expected: []interface{}{[]interface{}{}},
 		},
 		{
 			name:     "slice with nil map",
@@ -185,7 +184,7 @@ func TestRedactPasswords(t *testing.T) {
 		{
 			name:     "slice with nil slice",
 			input:    []interface{}{nilSlice},
-			expected: []interface{}{nilSlice},
+			expected: []interface{}{[]interface{}{}},
 		},
 	}
 	for _, test := range tests {
@@ -230,12 +229,12 @@ func TestRedactPasswords_NoMutate_2(t *testing.T) {
 		},
 	}
 
-	expected := []interface{}{
-		map[string]interface{}{
+	expected := []map[string]interface{}{
+		{
 			"key":  "value",
 			"pass": "REDACTED",
 		},
-		map[string]interface{}{
+		{
 			"key":      "value",
 			"password": "REDACTED",
 		},


### PR DESCRIPTION
This PR:
- updates the RedactPasswords utility to make it a bit more flexible in the inputs it can handle
- logs out plugin and device configurations

related to #453 

an example of what these changes look like:
```
INFO[0000] [config] loading configuration                ext=yaml loader=plugin name=config paths="[. ./config /etc/synse/plugin/config]" policy=optional
INFO[0000] [config] found matching config                file=config.yml loader=plugin path=. policy=optional
INFO[0000] [config] reading config file                  file=config.yml
INFO[0000] [config] successfully loaded configuration data  data="map[debug:true dynamicRegistration:map[config:[map[port:1234 somethingPassphrase:REDACTED]]] health:map[healthFile:] metrics:map[enabled:true] network:map[address::5001 type:tcp] settings:map[read:map[interval:5s] transaction:map[ttl:8m] write:map[interval:5s]] version:3]" ext=yaml loader=plugin name=config paths="[. ./config /etc/synse/plugin/config]" policy=optional
INFO[0000] Plugin Info:                                 
INFO[0000]   Tag:         vaporio/multi-device-plugin   
INFO[0000]   Name:        multi device plugin           
INFO[0000]   Maintainer:  vaporio                       
INFO[0000]   VCS:                                       
INFO[0000]   Description: An example plugin that demonstrates registering multiple devices 
INFO[0000] Version Info:                                
INFO[0000]   Plugin Version: 1.0                        
INFO[0000]   SDK Version:    3.0.0-alpha.3              
INFO[0000]   Git Commit:     ebe6989                    
INFO[0000]   Git Tag:        3.0.0-alpha.1-20-gebe6989  
INFO[0000]   Build Date:     2020-02-28T18:07:47        
INFO[0000]   Go Version:     go1.13.5                   
INFO[0000]   OS/Arch:        darwin/amd64               
INFO[0000] Plugin Config:                               
INFO[0000]   Version: 3                                 
INFO[0000]   Debug:   true                              
INFO[0000]   ID:                                        
INFO[0000]     UsePluginTag: true                       
INFO[0000]     UseMachineID: false                      
INFO[0000]     UseEnv:       []                         
INFO[0000]     UseCustom:    []                         
INFO[0000]   Metrics:                                   
INFO[0000]     Enabled: true                            
INFO[0000]   Settings:                                  
INFO[0000]     Mode: parallel                           
INFO[0000]     Listen:                                  
INFO[0000]       Disable: false                         
INFO[0000]     Read:                                    
INFO[0000]       Disable:   false                       
INFO[0000]       QueueSize: 128                         
INFO[0000]       Interval:  5s                          
INFO[0000]       Delay:     0s                          
INFO[0000]     Write:                                   
INFO[0000]       Disable:   false                       
INFO[0000]       QueueSize: 128                         
INFO[0000]       BatchSize: 128                         
INFO[0000]       Interval:  5s                          
INFO[0000]       Delay:     0s                          
INFO[0000]     Transaction:                             
INFO[0000]       TTL: 8m0s                              
INFO[0000]     Limiter:                                 
INFO[0000]       Rate:  0                               
INFO[0000]       Burst: 0                               
INFO[0000]     Cache:                                   
INFO[0000]       Enabled: false                         
INFO[0000]       TTL:     3m0s                          
INFO[0000]   Network:                                   
INFO[0000]     Type:    tcp                             
INFO[0000]     Address: :5001                           
INFO[0000]     TLS:                                     
INFO[0000]       Key:                                   
INFO[0000]       Cert:                                  
INFO[0000]       CACerts:    []                         
INFO[0000]       SkipVerify: false                      
INFO[0000]   Health:                                    
INFO[0000]     HealthFile:                              
INFO[0000]     UpdateInterval: 30s                      
INFO[0000]   DynamicRegistration:                       
INFO[0000]     Config: [map[port:1234 somethingPassphrase:REDACTED]] 
DEBU[0000] [id] using plugin tag as uuid component       tag=vaporio/multi-device-plugin
INFO[0000] [id] generated plugin id namespace            id=a1bc10f9-fa7c-5275-91b3-28363505f405
INFO[0000] [plugin] initializing                        
INFO[0000] [device manager] initializing                
INFO[0000] [config] loading configuration                ext=yaml loader=device name= paths="[./config/device /etc/synse/plugin/config/device]" policy=required
INFO[0000] [config] found matching config                file=airflow.yaml loader=device path=./config/device policy=required
INFO[0000] [config] found matching config                file=temperature.yaml loader=device path=./config/device policy=required
INFO[0000] [config] found matching config                file=voltage.yaml loader=device path=./config/device policy=required
INFO[0000] [config] reading config file                  file=config/device/airflow.yaml
DEBU[0000] [config] loaded configuration from file       data="map[devices:[map[context:map[model:air8884] handler:airflow instances:[map[data:map[id:1] info:Airflow Device 1] map[data:map[id:2] info:Airflow Device 2] map[data:map[id:3] info:Airflow Device 3]] type:airflow]] version:3]" file=config/device/airflow.yaml
INFO[0000] [config] reading config file                  file=config/device/temperature.yaml
DEBU[0000] [config] loaded configuration from file       data="map[devices:[map[context:map[model:temp2010 password:REDACTED] handler:temperature instances:[map[data:map[id:1] info:Temperature Device 1] map[data:map[id:2] info:Temperature Device 2] map[data:map[id:3] info:Temperature Device 3]] type:temperature]] version:3]" file=config/device/temperature.yaml
INFO[0000] [config] reading config file                  file=config/device/voltage.yaml
DEBU[0000] [config] loaded configuration from file       data="map[devices:[map[context:map[model:volt1103] handler:voltage instances:[map[data:map[id:1] info:Voltage Device 1] map[data:map[id:2] info:Voltage Device 2] map[data:map[id:3] info:Voltage Device 3]] type:voltage]] version:3]" file=config/device/voltage.yaml
DEBU[0000] [config] merging configuration sources       
INFO[0000] [config] successfully loaded configuration data  data="map[devices:[map[context:map[model:air8884] handler:airflow instances:[map[data:map[id:1] info:Airflow Device 1] map[data:map[id:2] info:Airflow Device 2] map[data:map[id:3] info:Airflow Device 3]] type:airflow] map[context:map[model:temp2010 password:REDACTED] handler:temperature instances:[map[data:map[id:1] info:Temperature Device 1] map[data:map[id:2] info:Temperature Device 2] map[data:map[id:3] info:Temperature Device 3]] type:temperature] map[context:map[model:volt1103] handler:voltage instances:[map[data:map[id:1] info:Voltage Device 1] map[data:map[id:2] info:Voltage Device 2] map[data:map[id:3] info:Voltage Device 3]] type:voltage]] version:3]" ext=yaml loader=device name= paths="[./config/device /etc/synse/plugin/config/device]" policy=required
DEBU[0000] [config] scanning config into struct          type="*config.Devices"
...
```