### PR TITLE
 Device in read and write contexts rather than device id.

### DIFF
--- a/sdk/models.go
+++ b/sdk/models.go
@@ -31,7 +31,7 @@ import (
 // Note that the collection of readings in a single ReadContext would correspond
 // to a single Read request.
 type ReadContext struct {
-	Device  string
+	Device  *Device
 	Reading []*output.Reading
 }
 
@@ -39,7 +39,7 @@ type ReadContext struct {
 // device and corresponding readings.
 func NewReadContext(device *Device, readings []*output.Reading) *ReadContext {
 	return &ReadContext{
-		Device:  device.id, // fixme: should we just store the pointer to the device instead??
+		Device:  device,
 		Reading: readings,
 	}
 }
@@ -47,7 +47,7 @@ func NewReadContext(device *Device, readings []*output.Reading) *ReadContext {
 // WriteContext describes a single write transaction.
 type WriteContext struct {
 	transaction *transaction
-	device      string
+	device      *Device
 	data        *synse.V3WriteData
 }
 

--- a/sdk/models_test.go
+++ b/sdk/models_test.go
@@ -25,9 +25,10 @@ import (
 )
 
 func TestNewReadContext(t *testing.T) {
-	r := NewReadContext(&Device{id: "123"}, []*output.Reading{{Value: 1}})
+	device := &Device{id: "123"}
+	r := NewReadContext(device, []*output.Reading{{Value: 1}})
 
-	assert.Equal(t, "123", r.Device)
+	assert.Equal(t, device, r.Device)
 	assert.Len(t, r.Reading, 1)
 }
 

--- a/sdk/plugin.go
+++ b/sdk/plugin.go
@@ -161,11 +161,12 @@ func NewPlugin(options ...PluginOption) (*Plugin, error) {
 
 	// Initialize the plugin components. The order in which components are initialized
 	// is important, since a dependency chain exists between some components. In particular:
+	// * the state manager requires the device manager.
 	// * the scheduler requires the device manager and state manager
 	// * the server requires the device manager, state manager, scheduler, and health manager
 	p.health = health.NewManager(p.config.Health)
-	p.state = newStateManager(p.config.Settings)
 	p.device = newDeviceManager(&p)
+	p.state = newStateManager(p.config.Settings, p.device)
 	p.scheduler = newScheduler(&p)
 	p.server = newServer(&p)
 

--- a/sdk/scheduler_test.go
+++ b/sdk/scheduler_test.go
@@ -193,7 +193,7 @@ func TestScheduler_Write(t *testing.T) {
 	// Verify that the write was put in the write queue.
 	w, isOpen := <-s.writeChan
 	assert.True(t, isOpen)
-	assert.Equal(t, "test-1", w.device)
+	assert.Equal(t, dev, w.device)
 }
 
 func TestScheduler_WriteAndWait_nilDevice(t *testing.T) {
@@ -255,7 +255,7 @@ func TestScheduler_WriteAndWait(t *testing.T) {
 		// Verify that the write was put in the write queue.
 		w, isOpen := <-s.writeChan
 		assert.True(t, isOpen)
-		assert.Equal(t, "test-1", w.device)
+		assert.Equal(t, dev, w.device)
 
 		// Close the transaction to unblock
 		close(w.transaction.done)
@@ -341,7 +341,7 @@ func TestScheduler_scheduleReads(t *testing.T) {
 
 	reading, isOpen := <-s.stateManager.readChan
 	assert.True(t, isOpen)
-	assert.Equal(t, "123", reading.Device)
+	assert.Equal(t, s.deviceManager.GetDevice("123"), reading.Device)
 }
 
 func TestScheduler_scheduleWrites_writeDisabled(t *testing.T) {
@@ -423,7 +423,7 @@ func TestScheduler_scheduleWrites(t *testing.T) {
 
 	wctx := &WriteContext{
 		txn,
-		"123",
+		s.deviceManager.GetDevice("123"),
 		&synse.V3WriteData{Action: "test"},
 	}
 	s.writeChan <- wctx
@@ -469,7 +469,7 @@ func TestScheduler_scheduleListen(t *testing.T) {
 	handler := &DeviceHandler{
 		Name: "test",
 		Listen: func(device *Device, contexts chan *ReadContext) error {
-			contexts <- &ReadContext{Device: device.id}
+			contexts <- &ReadContext{Device: device}
 			return nil
 		},
 	}
@@ -504,7 +504,7 @@ func TestScheduler_scheduleListen(t *testing.T) {
 
 	reading, isOpen := <-s.stateManager.readChan
 	assert.True(t, isOpen)
-	assert.Equal(t, "123", reading.Device)
+	assert.Equal(t, s.deviceManager.GetDevice("123"), reading.Device)
 }
 
 func TestScheduler_applyTransformations_NoTransformers(t *testing.T) {

--- a/sdk/server.go
+++ b/sdk/server.go
@@ -470,7 +470,7 @@ func (server *server) ReadCache(request *synse.V3Bounds, stream synse.V3Plugin_R
 
 	// Encode and stream the readings back to the client.
 	for r := range readings {
-		device := server.deviceManager.GetDevice(r.Device)
+		device := server.deviceManager.GetDevice(r.Device.id)
 		for _, data := range r.Reading {
 			reading := data.Encode()
 			if device != nil {
@@ -532,7 +532,7 @@ func (server *server) ReadStream(request *synse.V3StreamRequest, stream synse.V3
 
 	log.Info("[server] streaming readings from device manager")
 	for r := range s.readings {
-		device := server.deviceManager.GetDevice(r.Device)
+		device := server.deviceManager.GetDevice(r.Device.id)
 		for _, data := range r.Reading {
 			reading := data.Encode()
 			if device != nil {

--- a/sdk/server_test.go
+++ b/sdk/server_test.go
@@ -317,19 +317,21 @@ func TestServer_Devices(t *testing.T) {
 	// Get devices when there is no selector set. In this case, it should
 	// return the devices in the system namespace.
 	handler := &DeviceHandler{Name: "foo"}
-	s := server{
-		deviceManager: &deviceManager{
-			tagCache: &TagCache{
-				cache: map[string]map[string]map[string][]*Device{
-					"system": {"": {"foo": {&Device{id: "12345", handler: handler}}}},
-					"other":  {"": {"bar": {&Device{id: "67890", handler: handler}}}},
-				},
+	deviceManager := &deviceManager{
+		tagCache: &TagCache{
+			cache: map[string]map[string]map[string][]*Device{
+				"system": {"": {"foo": {&Device{id: "12345", handler: handler}}}},
+				"other":  {"": {"bar": {&Device{id: "67890", handler: handler}}}},
 			},
-			aliasCache: NewAliasCache(),
 		},
+		aliasCache: NewAliasCache(),
+	}
+	s := server{
+		deviceManager: deviceManager,
 		stateManager: &stateManager{
-			readings:     map[string][]*output.Reading{},
-			readingsLock: &sync.RWMutex{},
+			deviceManager: deviceManager,
+			readings:      map[string][]*output.Reading{},
+			readingsLock:  &sync.RWMutex{},
 		},
 		id: &pluginID{
 			uuid: uuid.New(),
@@ -360,17 +362,20 @@ func TestServer_Devices2(t *testing.T) {
 		Name: "test-output-1",
 		Type: "test",
 	}
-	s := server{
-		deviceManager: &deviceManager{
-			tagCache: &TagCache{
-				cache: map[string]map[string]map[string][]*Device{
-					"default": {"": {"foo": {&Device{id: "12345", handler: handler}}}},
-					"other":   {"": {"bar": {&Device{id: "67890", handler: handler}}}},
-				},
+	deviceManager := &deviceManager{
+		tagCache: &TagCache{
+			cache: map[string]map[string]map[string][]*Device{
+				"default": {"": {"foo": {&Device{id: "12345", handler: handler}}}},
+				"other":   {"": {"bar": {&Device{id: "67890", handler: handler}}}},
 			},
-			aliasCache: NewAliasCache(),
 		},
+		aliasCache: NewAliasCache(),
+	}
+
+	s := server{
+		deviceManager: deviceManager,
 		stateManager: &stateManager{
+			deviceManager: deviceManager,
 			readings: map[string][]*output.Reading{
 				"67890": {o.MakeReading(1)},
 			},
@@ -394,19 +399,21 @@ func TestServer_Devices2(t *testing.T) {
 func TestServer_Devices3A(t *testing.T) {
 	// Get devices when there is an ID tag selector set, but no match
 	handler := &DeviceHandler{Name: "foo"}
-	s := server{
-		deviceManager: &deviceManager{
-			tagCache: &TagCache{
-				cache: map[string]map[string]map[string][]*Device{
-					"default": {"": {"foo": {&Device{id: "12345", handler: handler}}}},
-					"other":   {"": {"bar": {&Device{id: "67890", handler: handler}}}},
-				},
+	deviceManager := &deviceManager{
+		tagCache: &TagCache{
+			cache: map[string]map[string]map[string][]*Device{
+				"default": {"": {"foo": {&Device{id: "12345", handler: handler}}}},
+				"other":   {"": {"bar": {&Device{id: "67890", handler: handler}}}},
 			},
-			aliasCache: NewAliasCache(),
 		},
+		aliasCache: NewAliasCache(),
+	}
+	s := server{
+		deviceManager: deviceManager,
 		stateManager: &stateManager{
-			readings:     map[string][]*output.Reading{},
-			readingsLock: &sync.RWMutex{},
+			deviceManager: deviceManager,
+			readings:      map[string][]*output.Reading{},
+			readingsLock:  &sync.RWMutex{},
 		},
 		id: &pluginID{
 			uuid: uuid.New(),
@@ -423,19 +430,21 @@ func TestServer_Devices3A(t *testing.T) {
 func TestServer_Devices3B(t *testing.T) {
 	// Get devices when there is a tag selector set, but no match
 	handler := &DeviceHandler{Name: "foo"}
-	s := server{
-		deviceManager: &deviceManager{
-			tagCache: &TagCache{
-				cache: map[string]map[string]map[string][]*Device{
-					"default": {"": {"foo": {&Device{id: "12345", handler: handler}}}},
-					"other":   {"": {"bar": {&Device{id: "67890", handler: handler}}}},
-				},
+	deviceManager := &deviceManager{
+		tagCache: &TagCache{
+			cache: map[string]map[string]map[string][]*Device{
+				"default": {"": {"foo": {&Device{id: "12345", handler: handler}}}},
+				"other":   {"": {"bar": {&Device{id: "67890", handler: handler}}}},
 			},
-			aliasCache: NewAliasCache(),
 		},
+		aliasCache: NewAliasCache(),
+	}
+	s := server{
+		deviceManager: deviceManager,
 		stateManager: &stateManager{
-			readings:     map[string][]*output.Reading{},
-			readingsLock: &sync.RWMutex{},
+			deviceManager: deviceManager,
+			readings:      map[string][]*output.Reading{},
+			readingsLock:  &sync.RWMutex{},
 		},
 		id: &pluginID{
 			uuid: uuid.New(),
@@ -469,21 +478,23 @@ func TestServer_Devices4(t *testing.T) {
 		Name: "test-output-1",
 		Type: "test",
 	}
-	s := server{
-		deviceManager: &deviceManager{
-			tagCache: &TagCache{
-				cache: map[string]map[string]map[string][]*Device{
-					"system": {
-						"": {
-							"foo": {&Device{id: "12345", handler: handler1}},
-							"bar": {&Device{id: "67890", handler: handler2}},
-						},
+	deviceManager := &deviceManager{
+		tagCache: &TagCache{
+			cache: map[string]map[string]map[string][]*Device{
+				"system": {
+					"": {
+						"foo": {&Device{id: "12345", handler: handler1}},
+						"bar": {&Device{id: "67890", handler: handler2}},
 					},
 				},
 			},
-			aliasCache: NewAliasCache(),
 		},
+		aliasCache: NewAliasCache(),
+	}
+	s := server{
+		deviceManager: deviceManager,
 		stateManager: &stateManager{
+			deviceManager: deviceManager,
 			readings: map[string][]*output.Reading{
 				"67890": {o.MakeReading(1)},
 			},
@@ -535,16 +546,18 @@ func TestServer_Devices5(t *testing.T) {
 		Name: "test-output-1",
 		Type: "test",
 	}
-	s := server{
-		deviceManager: &deviceManager{
-			tagCache: &TagCache{
-				cache: map[string]map[string]map[string][]*Device{
-					"default": {"": {"foo": {&Device{id: "12345", handler: handler1}}}},
-				},
+	deviceManager := &deviceManager{
+		tagCache: &TagCache{
+			cache: map[string]map[string]map[string][]*Device{
+				"default": {"": {"foo": {&Device{id: "12345", handler: handler1}}}},
 			},
-			aliasCache: NewAliasCache(),
 		},
+		aliasCache: NewAliasCache(),
+	}
+	s := server{
+		deviceManager: deviceManager,
 		stateManager: &stateManager{
+			deviceManager: deviceManager,
 			readings: map[string][]*output.Reading{
 				"12345": {o.MakeReading(1)},
 			},
@@ -589,16 +602,18 @@ func TestServer_Devices6(t *testing.T) {
 		Name: "test-output-1",
 		Type: "test",
 	}
-	s := server{
-		deviceManager: &deviceManager{
-			tagCache: &TagCache{
-				cache: map[string]map[string]map[string][]*Device{
-					"default": {"": {"foo": {&Device{id: "12345", handler: handler1}}}},
-				},
+	deviceManager := &deviceManager{
+		tagCache: &TagCache{
+			cache: map[string]map[string]map[string][]*Device{
+				"default": {"": {"foo": {&Device{id: "12345", handler: handler1}}}},
 			},
-			aliasCache: NewAliasCache(),
 		},
+		aliasCache: NewAliasCache(),
+	}
+	s := server{
+		deviceManager: deviceManager,
 		stateManager: &stateManager{
+			deviceManager: deviceManager,
 			readings: map[string][]*output.Reading{
 				"12345": {o.MakeReading(1)},
 			},
@@ -645,16 +660,18 @@ func TestServer_Devices7(t *testing.T) {
 		Name: "test-output-1",
 		Type: "test",
 	}
-	s := server{
-		deviceManager: &deviceManager{
-			tagCache: &TagCache{
-				cache: map[string]map[string]map[string][]*Device{
-					"default": {"": {"foo": {&Device{id: "12345", handler: handler1}}}},
-				},
+	deviceManager := &deviceManager{
+		tagCache: &TagCache{
+			cache: map[string]map[string]map[string][]*Device{
+				"default": {"": {"foo": {&Device{id: "12345", handler: handler1}}}},
 			},
-			aliasCache: NewAliasCache(),
 		},
+		aliasCache: NewAliasCache(),
+	}
+	s := server{
+		deviceManager: deviceManager,
 		stateManager: &stateManager{
+			deviceManager: deviceManager,
 			readings: map[string][]*output.Reading{
 				"12345": {o.MakeReading(1)},
 			},
@@ -689,18 +706,20 @@ func TestServer_Devices_error(t *testing.T) {
 	// Get devices when there is no selector set. In this case, it should
 	// return the devices in the system namespace.
 	handler := &DeviceHandler{Name: "foo"}
-	s := server{
-		deviceManager: &deviceManager{
-			tagCache: &TagCache{
-				cache: map[string]map[string]map[string][]*Device{
-					"system": {"": {"foo": {&Device{id: "12345", handler: handler}}}},
-					"other":  {"": {"bar": {&Device{id: "67890", handler: handler}}}},
-				},
+	deviceManager := &deviceManager{
+		tagCache: &TagCache{
+			cache: map[string]map[string]map[string][]*Device{
+				"system": {"": {"foo": {&Device{id: "12345", handler: handler}}}},
+				"other":  {"": {"bar": {&Device{id: "67890", handler: handler}}}},
 			},
 		},
+	}
+	s := server{
+		deviceManager: deviceManager,
 		stateManager: &stateManager{
-			readings:     map[string][]*output.Reading{},
-			readingsLock: &sync.RWMutex{},
+			deviceManager: deviceManager,
+			readings:      map[string][]*output.Reading{},
+			readingsLock:  &sync.RWMutex{},
 		},
 		id: &pluginID{
 			uuid: uuid.New(),
@@ -742,19 +761,21 @@ func TestServer_Read(t *testing.T) {
 		Type: "foo",
 	}
 
-	s := server{
-		meta: &PluginMetadata{Name: "test", Maintainer: "vaporio"},
-		deviceManager: &deviceManager{
-			tagCache: &TagCache{
-				cache: map[string]map[string]map[string][]*Device{
-					"system": {"": {"foo": {&Device{id: "12345", Type: "foo"}}}},
-					"other":  {"": {"bar": {&Device{id: "67890", Type: "bar"}}}},
-				},
+	deviceManager := &deviceManager{
+		tagCache: &TagCache{
+			cache: map[string]map[string]map[string][]*Device{
+				"system": {"": {"foo": {&Device{id: "12345", Type: "foo"}}}},
+				"other":  {"": {"bar": {&Device{id: "67890", Type: "bar"}}}},
 			},
-			aliasCache: NewAliasCache(),
 		},
+		aliasCache: NewAliasCache(),
+	}
+	s := server{
+		meta:          &PluginMetadata{Name: "test", Maintainer: "vaporio"},
+		deviceManager: deviceManager,
 		stateManager: &stateManager{
-			readingsLock: &sync.RWMutex{},
+			deviceManager: deviceManager,
+			readingsLock:  &sync.RWMutex{},
 			readings: map[string][]*output.Reading{
 				"12345": {o.MakeReading(1)},
 				"67890": {o.MakeReading(2)},
@@ -778,20 +799,22 @@ func TestServer_Read2(t *testing.T) {
 		Name: "test",
 		Type: "foo",
 	}
+	deviceManager := &deviceManager{
+		tagCache: &TagCache{
+			cache: map[string]map[string]map[string][]*Device{
+				"default": {"": {"foo": {&Device{id: "12345", Type: "foo"}}}},
+				"other":   {"": {"bar": {&Device{id: "67890", Type: "bar"}}}},
+			},
+		},
+		aliasCache: NewAliasCache(),
+	}
 
 	s := server{
-		meta: &PluginMetadata{Name: "test", Maintainer: "vaporio"},
-		deviceManager: &deviceManager{
-			tagCache: &TagCache{
-				cache: map[string]map[string]map[string][]*Device{
-					"default": {"": {"foo": {&Device{id: "12345", Type: "foo"}}}},
-					"other":   {"": {"bar": {&Device{id: "67890", Type: "bar"}}}},
-				},
-			},
-			aliasCache: NewAliasCache(),
-		},
+		meta:          &PluginMetadata{Name: "test", Maintainer: "vaporio"},
+		deviceManager: deviceManager,
 		stateManager: &stateManager{
-			readingsLock: &sync.RWMutex{},
+			deviceManager: deviceManager,
+			readingsLock:  &sync.RWMutex{},
 			readings: map[string][]*output.Reading{
 				"12345": {o.MakeReading(1)},
 				"67890": {o.MakeReading(2)},
@@ -819,20 +842,22 @@ func TestServer_Read_error(t *testing.T) {
 		Name: "test",
 		Type: "foo",
 	}
+	deviceManager := &deviceManager{
+		tagCache: &TagCache{
+			cache: map[string]map[string]map[string][]*Device{
+				"default": {"": {"foo": {&Device{id: "12345", Type: "foo"}}}},
+				"other":   {"": {"bar": {&Device{id: "67890", Type: "bar"}}}},
+			},
+		},
+		aliasCache: NewAliasCache(),
+	}
 
 	s := server{
-		meta: &PluginMetadata{Name: "test", Maintainer: "vaporio"},
-		deviceManager: &deviceManager{
-			tagCache: &TagCache{
-				cache: map[string]map[string]map[string][]*Device{
-					"default": {"": {"foo": {&Device{id: "12345", Type: "foo"}}}},
-					"other":   {"": {"bar": {&Device{id: "67890", Type: "bar"}}}},
-				},
-			},
-			aliasCache: NewAliasCache(),
-		},
+		meta:          &PluginMetadata{Name: "test", Maintainer: "vaporio"},
+		deviceManager: deviceManager,
 		stateManager: &stateManager{
-			readingsLock: &sync.RWMutex{},
+			deviceManager: deviceManager,
+			readingsLock:  &sync.RWMutex{},
 			readings: map[string][]*output.Reading{
 				"12345": {o.MakeReading(1)},
 				"67890": {o.MakeReading(2)},
@@ -858,10 +883,20 @@ func TestServer_ReadCache(t *testing.T) {
 		Name: "test",
 		Type: "foo",
 	}
+	// We need devices in here with the same ids as readings below so that the
+	// server can get them from the device manager when creating a ReadContext.
+	deviceManager := &deviceManager{
+		devices: map[string]*Device{
+			"12345": &Device{id: "12345"},
+			"67890": &Device{id: "67890"},
+			"abcde": &Device{id: "abcde"},
+		},
+	}
 
 	s := server{
 		stateManager: &stateManager{
-			readingsLock: &sync.RWMutex{},
+			deviceManager: deviceManager,
+			readingsLock:  &sync.RWMutex{},
 			config: &config.PluginSettings{
 				Cache: &config.CacheSettings{
 					Enabled: false,
@@ -873,9 +908,7 @@ func TestServer_ReadCache(t *testing.T) {
 				"abcde": {o.MakeReading(3)},
 			},
 		},
-		deviceManager: &deviceManager{
-			devices: map[string]*Device{},
-		},
+		deviceManager: deviceManager,
 	}
 	bounds := &synse.V3Bounds{}
 	mock := test.NewMockReadCachedStream()
@@ -890,10 +923,20 @@ func TestServer_ReadCache_error(t *testing.T) {
 		Name: "test",
 		Type: "foo",
 	}
+	// We need devices in here with the same ids as readings below so that the
+	// server can get them from the device manager when creating a ReadContext.
+	deviceManager := &deviceManager{
+		devices: map[string]*Device{
+			"12345": &Device{id: "12345"},
+			"67890": &Device{id: "67890"},
+			"abcde": &Device{id: "abcde"},
+		},
+	}
 
 	s := server{
 		stateManager: &stateManager{
-			readingsLock: &sync.RWMutex{},
+			deviceManager: deviceManager,
+			readingsLock:  &sync.RWMutex{},
 			config: &config.PluginSettings{
 				Cache: &config.CacheSettings{
 					Enabled: false,
@@ -905,9 +948,7 @@ func TestServer_ReadCache_error(t *testing.T) {
 				"abcde": {o.MakeReading(3)},
 			},
 		},
-		deviceManager: &deviceManager{
-			devices: map[string]*Device{},
-		},
+		deviceManager: deviceManager,
 	}
 	bounds := &synse.V3Bounds{}
 	mock := &test.MockReadCachedStreamErr{}
@@ -921,10 +962,15 @@ func TestServer_ReadStream_noDeviceMatchID(t *testing.T) {
 		Name: "test",
 		Type: "foo",
 	}
+	deviceManager := &deviceManager{
+		devices:    map[string]*Device{},
+		aliasCache: NewAliasCache(),
+	}
 
 	s := server{
 		stateManager: &stateManager{
-			readingsLock: &sync.RWMutex{},
+			deviceManager: deviceManager,
+			readingsLock:  &sync.RWMutex{},
 			config: &config.PluginSettings{
 				Cache: &config.CacheSettings{
 					Enabled: false,
@@ -936,10 +982,7 @@ func TestServer_ReadStream_noDeviceMatchID(t *testing.T) {
 				"abcde": {o.MakeReading(3)},
 			},
 		},
-		deviceManager: &deviceManager{
-			devices:    map[string]*Device{},
-			aliasCache: NewAliasCache(),
-		},
+		deviceManager: deviceManager,
 	}
 
 	req := &synse.V3StreamRequest{
@@ -959,10 +1002,16 @@ func TestServer_ReadStream_noDeviceMatchTag(t *testing.T) {
 		Name: "test",
 		Type: "foo",
 	}
+	deviceManager := &deviceManager{
+		devices:    map[string]*Device{},
+		aliasCache: NewAliasCache(),
+		tagCache:   NewTagCache(),
+	}
 
 	s := server{
 		stateManager: &stateManager{
-			readingsLock: &sync.RWMutex{},
+			deviceManager: deviceManager,
+			readingsLock:  &sync.RWMutex{},
 			config: &config.PluginSettings{
 				Cache: &config.CacheSettings{
 					Enabled: false,
@@ -974,11 +1023,7 @@ func TestServer_ReadStream_noDeviceMatchTag(t *testing.T) {
 				"abcde": {o.MakeReading(3)},
 			},
 		},
-		deviceManager: &deviceManager{
-			devices:    map[string]*Device{},
-			aliasCache: NewAliasCache(),
-			tagCache:   NewTagCache(),
-		},
+		deviceManager: deviceManager,
 	}
 
 	req := &synse.V3StreamRequest{
@@ -1002,17 +1047,19 @@ func TestServer_WriteAsync(t *testing.T) {
 			return nil
 		},
 	}
-	s := server{
-		deviceManager: &deviceManager{
-			devices: map[string]*Device{
-				"1234": {id: "1234", handler: &handler},
-			},
-			aliasCache: NewAliasCache(),
+	deviceManager := &deviceManager{
+		devices: map[string]*Device{
+			"1234": {id: "1234", handler: &handler},
 		},
+		aliasCache: NewAliasCache(),
+	}
+	s := server{
+		deviceManager: deviceManager,
 		scheduler: &scheduler{
 			writeChan: make(chan *WriteContext, 2),
 			stateManager: &stateManager{
-				transactions: cache.New(1*time.Minute, 2*time.Minute),
+				deviceManager: deviceManager,
+				transactions:  cache.New(1*time.Minute, 2*time.Minute),
 			},
 		},
 	}
@@ -1038,19 +1085,22 @@ func TestServer_WriteAsync_noSelector(t *testing.T) {
 			return nil
 		},
 	}
-	s := server{
-		deviceManager: &deviceManager{
-			tagCache: &TagCache{
-				cache: map[string]map[string]map[string][]*Device{
-					"system": {"id": {"1234": {{id: "1234", handler: &handler}}}},
-				},
+	deviceManager := &deviceManager{
+		tagCache: &TagCache{
+			cache: map[string]map[string]map[string][]*Device{
+				"system": {"id": {"1234": {{id: "1234", handler: &handler}}}},
 			},
-			aliasCache: NewAliasCache(),
 		},
+		aliasCache: NewAliasCache(),
+	}
+	s := server{
+		deviceManager: deviceManager,
 		scheduler: &scheduler{
-			writeChan: make(chan *WriteContext, 2),
+			deviceManager: deviceManager,
+			writeChan:     make(chan *WriteContext, 2),
 			stateManager: &stateManager{
-				transactions: cache.New(1*time.Minute, 2*time.Minute),
+				deviceManager: deviceManager,
+				transactions:  cache.New(1*time.Minute, 2*time.Minute),
 			},
 		},
 	}
@@ -1075,19 +1125,21 @@ func TestServer_WriteAsync_noDevice(t *testing.T) {
 			return nil
 		},
 	}
-	s := server{
-		deviceManager: &deviceManager{
-			tagCache: &TagCache{
-				cache: map[string]map[string]map[string][]*Device{
-					"system": {"id": {"1234": {{id: "1234", handler: &handler}}}},
-				},
+	deviceManager := &deviceManager{
+		tagCache: &TagCache{
+			cache: map[string]map[string]map[string][]*Device{
+				"system": {"id": {"1234": {{id: "1234", handler: &handler}}}},
 			},
-			aliasCache: NewAliasCache(),
 		},
+		aliasCache: NewAliasCache(),
+	}
+	s := server{
+		deviceManager: deviceManager,
 		scheduler: &scheduler{
 			writeChan: make(chan *WriteContext, 2),
 			stateManager: &stateManager{
-				transactions: cache.New(1*time.Minute, 2*time.Minute),
+				deviceManager: deviceManager,
+				transactions:  cache.New(1*time.Minute, 2*time.Minute),
 			},
 		},
 	}
@@ -1110,19 +1162,21 @@ func TestServer_WriteAsync_noDevice(t *testing.T) {
 
 func TestServer_WriteAsync_failedWrite(t *testing.T) {
 	handler := DeviceHandler{}
-	s := server{
-		deviceManager: &deviceManager{
-			tagCache: &TagCache{
-				cache: map[string]map[string]map[string][]*Device{
-					"system": {"id": {"1234": {{id: "1234", handler: &handler}}}},
-				},
+	deviceManager := &deviceManager{
+		tagCache: &TagCache{
+			cache: map[string]map[string]map[string][]*Device{
+				"system": {"id": {"1234": {{id: "1234", handler: &handler}}}},
 			},
-			aliasCache: NewAliasCache(),
 		},
+		aliasCache: NewAliasCache(),
+	}
+	s := server{
+		deviceManager: deviceManager,
 		scheduler: &scheduler{
 			writeChan: make(chan *WriteContext, 2),
 			stateManager: &stateManager{
-				transactions: cache.New(1*time.Minute, 2*time.Minute),
+				deviceManager: deviceManager,
+				transactions:  cache.New(1*time.Minute, 2*time.Minute),
 			},
 		},
 	}
@@ -1148,19 +1202,21 @@ func TestServer_WriteAsync_error(t *testing.T) {
 			return nil
 		},
 	}
-	s := server{
-		deviceManager: &deviceManager{
-			tagCache: &TagCache{
-				cache: map[string]map[string]map[string][]*Device{
-					"system": {"id": {"1234": {{id: "1234", handler: &handler}}}},
-				},
+	deviceManager := &deviceManager{
+		tagCache: &TagCache{
+			cache: map[string]map[string]map[string][]*Device{
+				"system": {"id": {"1234": {{id: "1234", handler: &handler}}}},
 			},
-			aliasCache: NewAliasCache(),
 		},
+		aliasCache: NewAliasCache(),
+	}
+	s := server{
+		deviceManager: deviceManager,
 		scheduler: &scheduler{
 			writeChan: make(chan *WriteContext, 2),
 			stateManager: &stateManager{
-				transactions: cache.New(1*time.Minute, 2*time.Minute),
+				deviceManager: deviceManager,
+				transactions:  cache.New(1*time.Minute, 2*time.Minute),
 			},
 		},
 	}
@@ -1185,22 +1241,24 @@ func TestServer_WriteSync(t *testing.T) {
 			return nil
 		},
 	}
-	s := server{
-		deviceManager: &deviceManager{
-			//tagCache: &TagCache{
-			//	cache: map[string]map[string]map[string][]*Device{
-			//		"system": {"id": {"1234": {{id: "1234", handler: &handler}}}},
-			//	},
-			//},
-			devices: map[string]*Device{
-				"1234": {id: "1234", handler: &handler},
-			},
-			aliasCache: NewAliasCache(),
+	deviceManager := &deviceManager{
+		//tagCache: &TagCache{
+		//	cache: map[string]map[string]map[string][]*Device{
+		//		"system": {"id": {"1234": {{id: "1234", handler: &handler}}}},
+		//	},
+		//},
+		devices: map[string]*Device{
+			"1234": {id: "1234", handler: &handler},
 		},
+		aliasCache: NewAliasCache(),
+	}
+	s := server{
+		deviceManager: deviceManager,
 		scheduler: &scheduler{
 			writeChan: make(chan *WriteContext, 2),
 			stateManager: &stateManager{
-				transactions: cache.New(1*time.Minute, 2*time.Minute),
+				deviceManager: deviceManager,
+				transactions:  cache.New(1*time.Minute, 2*time.Minute),
 			},
 		},
 	}
@@ -1237,19 +1295,21 @@ func TestServer_WriteSync_noSelector(t *testing.T) {
 			return nil
 		},
 	}
-	s := server{
-		deviceManager: &deviceManager{
-			tagCache: &TagCache{
-				cache: map[string]map[string]map[string][]*Device{
-					"system": {"id": {"1234": {{id: "1234", handler: &handler}}}},
-				},
+	deviceManager := &deviceManager{
+		tagCache: &TagCache{
+			cache: map[string]map[string]map[string][]*Device{
+				"system": {"id": {"1234": {{id: "1234", handler: &handler}}}},
 			},
-			aliasCache: NewAliasCache(),
 		},
+		aliasCache: NewAliasCache(),
+	}
+	s := server{
+		deviceManager: deviceManager,
 		scheduler: &scheduler{
 			writeChan: make(chan *WriteContext, 2),
 			stateManager: &stateManager{
-				transactions: cache.New(1*time.Minute, 2*time.Minute),
+				deviceManager: deviceManager,
+				transactions:  cache.New(1*time.Minute, 2*time.Minute),
 			},
 		},
 	}
@@ -1285,19 +1345,21 @@ func TestServer_WriteSync_noDevice(t *testing.T) {
 			return nil
 		},
 	}
-	s := server{
-		deviceManager: &deviceManager{
-			tagCache: &TagCache{
-				cache: map[string]map[string]map[string][]*Device{
-					"system": {"id": {"1234": {{id: "1234", handler: &handler}}}},
-				},
+	deviceManager := &deviceManager{
+		tagCache: &TagCache{
+			cache: map[string]map[string]map[string][]*Device{
+				"system": {"id": {"1234": {{id: "1234", handler: &handler}}}},
 			},
-			aliasCache: NewAliasCache(),
 		},
+		aliasCache: NewAliasCache(),
+	}
+	s := server{
+		deviceManager: deviceManager,
 		scheduler: &scheduler{
 			writeChan: make(chan *WriteContext, 2),
 			stateManager: &stateManager{
-				transactions: cache.New(1*time.Minute, 2*time.Minute),
+				deviceManager: deviceManager,
+				transactions:  cache.New(1*time.Minute, 2*time.Minute),
 			},
 		},
 	}
@@ -1331,19 +1393,21 @@ func TestServer_WriteSync_noDevice(t *testing.T) {
 
 func TestServer_WriteSync_failedWrite(t *testing.T) {
 	handler := DeviceHandler{}
-	s := server{
-		deviceManager: &deviceManager{
-			tagCache: &TagCache{
-				cache: map[string]map[string]map[string][]*Device{
-					"system": {"id": {"1234": {{id: "1234", handler: &handler}}}},
-				},
+	deviceManager := &deviceManager{
+		tagCache: &TagCache{
+			cache: map[string]map[string]map[string][]*Device{
+				"system": {"id": {"1234": {{id: "1234", handler: &handler}}}},
 			},
-			aliasCache: NewAliasCache(),
 		},
+		aliasCache: NewAliasCache(),
+	}
+	s := server{
+		deviceManager: deviceManager,
 		scheduler: &scheduler{
 			writeChan: make(chan *WriteContext, 2),
 			stateManager: &stateManager{
-				transactions: cache.New(1*time.Minute, 2*time.Minute),
+				deviceManager: deviceManager,
+				transactions:  cache.New(1*time.Minute, 2*time.Minute),
 			},
 		},
 	}
@@ -1380,19 +1444,21 @@ func TestServer_WriteSync_error(t *testing.T) {
 			return nil
 		},
 	}
-	s := server{
-		deviceManager: &deviceManager{
-			tagCache: &TagCache{
-				cache: map[string]map[string]map[string][]*Device{
-					"system": {"id": {"1234": {{id: "1234", handler: &handler}}}},
-				},
+	deviceManager := &deviceManager{
+		tagCache: &TagCache{
+			cache: map[string]map[string]map[string][]*Device{
+				"system": {"id": {"1234": {{id: "1234", handler: &handler}}}},
 			},
-			aliasCache: NewAliasCache(),
 		},
+		aliasCache: NewAliasCache(),
+	}
+	s := server{
+		deviceManager: deviceManager,
 		scheduler: &scheduler{
 			writeChan: make(chan *WriteContext, 2),
 			stateManager: &stateManager{
-				transactions: cache.New(1*time.Minute, 2*time.Minute),
+				deviceManager: deviceManager,
+				transactions:  cache.New(1*time.Minute, 2*time.Minute),
 			},
 		},
 	}

--- a/sdk/stream.go
+++ b/sdk/stream.go
@@ -54,8 +54,8 @@ func (s *ReadStream) listen() {
 		}
 
 		for _, id := range s.filter {
-			if r.Device == id {
-				log.WithField("device", r.Device).Debug("collecting reading")
+			if r.Device.id == id {
+				log.WithField("device", r.Device.id).Debug("collecting reading")
 				if s.closing {
 					return
 				}

--- a/sdk/stream_test.go
+++ b/sdk/stream_test.go
@@ -86,19 +86,19 @@ func TestReadStream_listen_withFilter(t *testing.T) {
 	// Create read contexts to send to the stream.
 	ctxs := []*ReadContext{
 		{
-			Device:  "11111",
+			Device:  &Device{id: "11111"},
 			Reading: []*output.Reading{{Value: 1}},
 		},
 		{
-			Device:  "22222",
+			Device:  &Device{id: "22222"},
 			Reading: []*output.Reading{{Value: 1}},
 		},
 		{
-			Device:  "12345",
+			Device:  &Device{id: "12345"},
 			Reading: []*output.Reading{{Value: 1}},
 		},
 		{
-			Device:  "54321",
+			Device:  &Device{id: "54321"},
 			Reading: []*output.Reading{{Value: 1}},
 		},
 	}
@@ -129,8 +129,8 @@ func TestReadStream_listen_withFilter(t *testing.T) {
 
 	// Ensure that only the devices specified by the match filter were collected.
 	assert.Len(t, readings, 2)
-	assert.Equal(t, "11111", readings[0].Device)
-	assert.Equal(t, "12345", readings[1].Device)
+	assert.Equal(t, "11111", readings[0].Device.id)
+	assert.Equal(t, "12345", readings[1].Device.id)
 
 	// We did not call close(), so the stream should not be in the closing state
 	assert.False(t, s.closing)
@@ -148,19 +148,19 @@ func TestReadStream_listen_noFilter(t *testing.T) {
 	// Create read contexts to send to the stream.
 	ctxs := []*ReadContext{
 		{
-			Device:  "11111",
+			Device:  &Device{id: "11111"},
 			Reading: []*output.Reading{{Value: 1}},
 		},
 		{
-			Device:  "22222",
+			Device:  &Device{id: "22222"},
 			Reading: []*output.Reading{{Value: 1}},
 		},
 		{
-			Device:  "12345",
+			Device:  &Device{id: "12345"},
 			Reading: []*output.Reading{{Value: 1}},
 		},
 		{
-			Device:  "54321",
+			Device:  &Device{id: "54321"},
 			Reading: []*output.Reading{{Value: 1}},
 		},
 	}
@@ -191,10 +191,10 @@ func TestReadStream_listen_noFilter(t *testing.T) {
 
 	// Ensure that all devices were collected since there is no filter.
 	assert.Len(t, readings, 4)
-	assert.Equal(t, "11111", readings[0].Device)
-	assert.Equal(t, "22222", readings[1].Device)
-	assert.Equal(t, "12345", readings[2].Device)
-	assert.Equal(t, "54321", readings[3].Device)
+	assert.Equal(t, "11111", readings[0].Device.id)
+	assert.Equal(t, "22222", readings[1].Device.id)
+	assert.Equal(t, "12345", readings[2].Device.id)
+	assert.Equal(t, "54321", readings[3].Device.id)
 
 	// We did not call close(), so the stream should not be in the closing state
 	assert.False(t, s.closing)
@@ -212,19 +212,19 @@ func TestReadStream_listen_close(t *testing.T) {
 	// Create read contexts to send to the stream.
 	ctxs := []*ReadContext{
 		{
-			Device:  "11111",
+			Device:  &Device{id: "11111"},
 			Reading: []*output.Reading{{Value: 1}},
 		},
 		{
-			Device:  "22222",
+			Device:  &Device{id: "22222"},
 			Reading: []*output.Reading{{Value: 1}},
 		},
 		{
-			Device:  "12345",
+			Device:  &Device{id: "12345"},
 			Reading: []*output.Reading{{Value: 1}},
 		},
 		{
-			Device:  "54321",
+			Device:  &Device{id: "54321"},
 			Reading: []*output.Reading{{Value: 1}},
 		},
 	}

--- a/sdk/version.go
+++ b/sdk/version.go
@@ -26,7 +26,7 @@ import (
 )
 
 // Version specifies the version of the Synse Plugin SDK.
-const Version = "2.0.0"
+const Version = "2.0.1"
 
 // version is a global reference to the pluginVersion which specifies the
 // version information for a Plugin. This is initialized on init and


### PR DESCRIPTION
- Main change is in models.go
- Changed the stateManager to have deviceManager as a member because the deviceManager manages devices and the stateManager needs access to them to create ReadContexts.
- Test changes to keep them running.

Putting this PR up to get the okay on it prior to making changes to the plugins. Will not merge w/o associated plugin PRs / SDK release / deployment changes.

Fixes: https://github.com/vapor-ware/synse-sdk/issues/462