### PR TITLE
Updates to better support streaming  protocol

### DIFF
--- a/sdk/device_handler.go
+++ b/sdk/device_handler.go
@@ -46,6 +46,9 @@ type DeviceHandler struct {
 	// other handler functions (e.g. read, write) defined. The listener function
 	// will run in a separate goroutine for each device. The goroutines are started
 	// before the read/write loops.
+	//
+	// NOTE: The Listen function is deprecated and will be removed in a future version
+	// of the SDK.
 	Listen func(*Device, chan *ReadContext) error
 
 	// Actions specifies a list of the supported write actions for the handler.

--- a/sdk/plugin.go
+++ b/sdk/plugin.go
@@ -280,6 +280,11 @@ func (plugin *Plugin) AddDevice(device *Device) error {
 	return plugin.device.AddDevice(device)
 }
 
+// GetDevice gets a device from the plugin's device manager.
+func (plugin *Plugin) GetDevice(id string) *Device {
+	return plugin.device.GetDevice(id)
+}
+
 // initialize initializes the plugin and all plugin components.
 func (plugin *Plugin) initialize() error {
 	log.Info("[plugin] initializing")

--- a/sdk/plugin.go
+++ b/sdk/plugin.go
@@ -268,6 +268,18 @@ func (plugin *Plugin) RegisterDeviceSetupActions(actions ...*DeviceAction) error
 	return plugin.device.AddDeviceSetupActions(actions...)
 }
 
+// NewDevice creates a new device, using the Device handlers registered with the plugin.
+//
+// Note that this does not add the new device to the plugin.
+func (plugin *Plugin) NewDevice(proto *config.DeviceProto, instance *config.DeviceInstance) (*Device, error) {
+	return NewDeviceFromConfig(proto, instance, plugin.device.handlers)
+}
+
+// AddDevice adds a new device to the plugin's device manager.
+func (plugin *Plugin) AddDevice(device *Device) error {
+	return plugin.device.AddDevice(device)
+}
+
 // initialize initializes the plugin and all plugin components.
 func (plugin *Plugin) initialize() error {
 	log.Info("[plugin] initializing")

--- a/sdk/plugin_test.go
+++ b/sdk/plugin_test.go
@@ -768,3 +768,17 @@ func TestPlugin_AddDevice(t *testing.T) {
 	assert.Equal(t, expectedID, device.id)
 	assert.Len(t, device.Tags, 3) // two additional system-generated tags added
 }
+
+func TestPlugin_GetDevice(t *testing.T) {
+	p := Plugin{
+		device: &deviceManager{
+			devices: map[string]*Device{
+				"123": {id: "123"},
+			},
+		},
+	}
+
+	device := p.GetDevice("123")
+	assert.NotNil(t, device)
+	assert.Equal(t, "123", device.id)
+}

--- a/sdk/scheduler.go
+++ b/sdk/scheduler.go
@@ -443,6 +443,8 @@ func (scheduler *scheduler) scheduleListen() {
 		log.Info("[scheduler] listeners will not be scheduled (listening globally disabled)")
 		return
 	}
+	// DEPRECATE (etd)
+	log.Warning("[scheduler] Deprecation Warning: the SDK listener behavior for DeviceHandlers will be removed in a future release of the SDK")
 
 	if !scheduler.deviceManager.HasListenerHandlers() {
 		log.Info("[scheduler] listeners will not be scheduled (no listener handlers registered)")


### PR DESCRIPTION
This PR:
- adds deprecation notices for the DeviceHandler  `Listen` function
- adds exported `AddDevice` and `NewDevice` functions off of the plugin struct - this should  make it easier for a plugin to create/register devices at runtime.

Related: #466