### PR TITLE
feat: expose function to generate device ID

### DIFF
--- a/sdk/device_manager.go
+++ b/sdk/device_manager.go
@@ -19,7 +19,6 @@ package sdk
 import (
 	"errors"
 	"fmt"
-	"strings"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/vapor-ware/synse-sdk/sdk/config"
@@ -78,6 +77,8 @@ type deviceManager struct {
 	setupActions   []*DeviceAction
 	devices        map[string]*Device
 	handlers       map[string]*DeviceHandler
+
+	p *Plugin
 }
 
 // newDeviceManager creates a new DeviceManager.
@@ -96,6 +97,7 @@ func newDeviceManager(plugin *Plugin) *deviceManager {
 		aliasCache:     NewAliasCache(),
 		devices:        make(map[string]*Device),
 		handlers:       make(map[string]*DeviceHandler),
+		p:              plugin,
 	}
 }
 
@@ -355,17 +357,7 @@ func (manager *deviceManager) AddDevice(device *Device) error {
 	// If the device ID has not already been set, generate it and set
 	// it before adding it to the deviceManager.
 	if device.id == "" {
-		// todo: see about cleaning this up/making it its own fn so it can be reused.
-		component := manager.pluginHandlers.DeviceIdentifier(device.Data)
-		name := strings.Join([]string{
-			device.Type,
-			device.Handler,
-			component,
-		}, ".")
-		device.idName = name
-
-		deviceID := manager.id.NewNamespacedID(name)
-		device.id = deviceID
+		manager.p.GenerateDeviceID(device)
 	}
 
 	// Check if the Device ID collides with an existing device.

--- a/sdk/device_manager_test.go
+++ b/sdk/device_manager_test.go
@@ -811,15 +811,20 @@ func TestDeviceManager_AddDevice_aliasExists(t *testing.T) {
 
 func TestDeviceManager_AddDevice(t *testing.T) {
 	handler := DeviceHandler{Name: "foo"}
+	pid := &pluginID{uuid: uuid.NewSHA1(uuid.NameSpaceDNS, []byte("test"))}
 	m := deviceManager{
 		aliasCache:     NewAliasCache(),
 		tagCache:       NewTagCache(),
-		id:             &pluginID{uuid: uuid.NewSHA1(uuid.NameSpaceDNS, []byte("test"))},
+		id:             pid,
 		pluginHandlers: NewDefaultPluginHandlers(),
 		handlers: map[string]*DeviceHandler{
 			"foo": &handler,
 		},
 		devices: map[string]*Device{},
+		p: &Plugin{
+			id:             pid,
+			pluginHandlers: NewDefaultPluginHandlers(),
+		},
 	}
 	device := Device{
 		Type:    "testtype",
@@ -1137,15 +1142,20 @@ func TestDeviceManager_createDevices_ok(t *testing.T) {
 			},
 		},
 	}
+	pid := &pluginID{uuid: uuid.NewSHA1(uuid.NameSpaceDNS, []byte("test"))}
 	m := deviceManager{
 		config:         cfg,
 		tagCache:       NewTagCache(),
 		pluginHandlers: NewDefaultPluginHandlers(),
-		id:             &pluginID{uuid: uuid.NewSHA1(uuid.NameSpaceDNS, []byte("test"))},
+		id:             pid,
 		handlers: map[string]*DeviceHandler{
 			"foo": {Name: "foo"},
 		},
 		devices: map[string]*Device{},
+		p: &Plugin{
+			id:             pid,
+			pluginHandlers: NewDefaultPluginHandlers(),
+		},
 	}
 
 	err := m.createDevices()

--- a/sdk/plugin.go
+++ b/sdk/plugin.go
@@ -23,6 +23,7 @@ import (
 	_ "net/http/pprof" // Allows plugin profiling via pprof
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	log "github.com/sirupsen/logrus"
@@ -283,6 +284,23 @@ func (plugin *Plugin) AddDevice(device *Device) error {
 // GetDevice gets a device from the plugin's device manager.
 func (plugin *Plugin) GetDevice(id string) *Device {
 	return plugin.device.GetDevice(id)
+}
+
+// GenerateDeviceID generates the deterministic ID for a device using the data contained
+// within a Device definition as well as the DeviceIdentifier function, whether custom or
+// default.
+func (plugin *Plugin) GenerateDeviceID(device *Device) string {
+	component := plugin.pluginHandlers.DeviceIdentifier(device.Data)
+	name := strings.Join([]string{
+		device.Type,
+		device.Handler,
+		component,
+	}, ".")
+
+	device.idName = name
+	device.id = plugin.id.NewNamespacedID(name)
+
+	return device.id
 }
 
 // initialize initializes the plugin and all plugin components.

--- a/sdk/plugin_test.go
+++ b/sdk/plugin_test.go
@@ -715,11 +715,14 @@ func TestPlugin_NewDevice(t *testing.T) {
 
 func TestPlugin_AddDevice(t *testing.T) {
 	handler := DeviceHandler{Name: "foo"}
+	pid := &pluginID{uuid: uuid.NewSHA1(uuid.NameSpaceDNS, []byte("test"))}
 	p := Plugin{
+		pluginHandlers: NewDefaultPluginHandlers(),
+		id:             pid,
 		device: &deviceManager{
 			aliasCache:     NewAliasCache(),
 			tagCache:       NewTagCache(),
-			id:             &pluginID{uuid: uuid.NewSHA1(uuid.NameSpaceDNS, []byte("test"))},
+			id:             pid,
 			pluginHandlers: NewDefaultPluginHandlers(),
 			handlers: map[string]*DeviceHandler{
 				"foo": &handler,
@@ -727,6 +730,7 @@ func TestPlugin_AddDevice(t *testing.T) {
 			devices: map[string]*Device{},
 		},
 	}
+	p.device.p = &p
 	device := Device{
 		Type:    "testtype",
 		Handler: "foo",
@@ -781,4 +785,22 @@ func TestPlugin_GetDevice(t *testing.T) {
 	device := p.GetDevice("123")
 	assert.NotNil(t, device)
 	assert.Equal(t, "123", device.id)
+}
+
+func TestPlugin_GenerateDeviceID(t *testing.T) {
+	p := Plugin{
+		pluginHandlers: NewDefaultPluginHandlers(),
+		id:             &pluginID{uuid: uuid.NewSHA1(uuid.NameSpaceDNS, []byte("test"))},
+	}
+	d := Device{
+		Type:    "foo",
+		Handler: "bar",
+		Data: map[string]interface{}{
+			"key1": "value1",
+			"key2": 2,
+		},
+	}
+
+	devID := p.GenerateDeviceID(&d)
+	assert.Equal(t, "e534b6b2-006e-5f61-93c0-b00ae7535155", devID)
 }


### PR DESCRIPTION
This PR:
- exposes a method off of the Plugin to allow  plugins to generate  device IDs the  same way the plugin does it internally. This is needed by the Juniper plugin in order to correctly create/register  devices and associate readings with those  devices.


These changes  to sort of expose how a lot of the internal connections between components are a bit messy  and could be cleaned up /  improved, but I'll leave that as a future work item.