### PR TITLE
bugfix: exit read/write schedule loops on channel close; add tests for serial/parallel schedule

### DIFF
--- a/sdk/scheduler.go
+++ b/sdk/scheduler.go
@@ -315,7 +315,8 @@ func (scheduler *scheduler) scheduleReads() {
 		select {
 		case <-scheduler.stop:
 			scheduler.isReading = false
-			break
+			log.Info("[scheduler] stop channel closed, terminating scheduleReads")
+			return
 		default:
 			// no stop signal
 		}
@@ -388,7 +389,8 @@ func (scheduler *scheduler) scheduleWrites() {
 		select {
 		case <-scheduler.stop:
 			scheduler.isWriting = false
-			break
+			log.Info("[scheduler] stop channel closed, terminating scheduleWrites")
+			return
 		default:
 			// no stop signal
 		}


### PR DESCRIPTION
This PR:
- fixes two bugs (should be  `return` not `break`) in read/write scheduler. This doesn't really affect the main run logic - but it does affect test logic in being able  to terminate the goroutine.
- adds tests to verify that schedule reads does actually run everything in  serial when  configured for serial and in  parallel when  configured in  parallel