### PR TITLE
feat: add glob matching to device action filters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/creasty/defaults v1.4.0
 	github.com/denisbrodbeck/machineid v1.0.1
+	github.com/gobwas/glob v0.2.3
 	github.com/google/uuid v1.1.1
 	github.com/imdario/mergo v0.3.10
 	github.com/mitchellh/mapstructure v1.3.3

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
+github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=

--- a/sdk/device_manager.go
+++ b/sdk/device_manager.go
@@ -20,6 +20,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/gobwas/glob"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/vapor-ware/synse-sdk/sdk/config"
 	sdkError "github.com/vapor-ware/synse-sdk/sdk/errors"
@@ -473,8 +475,11 @@ func (manager *deviceManager) FilterDevices(filter map[string][]string) ([]*Devi
 		switch k {
 		case "type":
 			check = func(d *Device) bool {
+				var g glob.Glob
+
 				for _, val := range v {
-					if d.Type == val || val == "*" {
+					g = glob.MustCompile(val)
+					if g.Match(d.Type) {
 						return true
 					}
 				}

--- a/sdk/device_manager_test.go
+++ b/sdk/device_manager_test.go
@@ -1404,3 +1404,115 @@ func TestDeviceManager_execDeviceSetupActions_ok3(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 0, counter)
 }
+
+func TestDeviceManager_execDeviceSetupActions_ok4(t *testing.T) {
+	counter := 0
+	p := &Plugin{}
+	m := deviceManager{
+		setupActions: []*DeviceAction{
+			{
+				Name: "ok",
+				Filter: map[string][]string{
+					"type": {"*oo"},
+				},
+				Action: func(p *Plugin, d *Device) error {
+					counter++
+					return nil
+				},
+			},
+		},
+		devices: map[string]*Device{
+			"123": {id: "123", Type: "foo"},
+			"456": {id: "456", Type: "bar"},
+			"678": {id: "678", Type: "foo"},
+		},
+	}
+
+	err := m.execDeviceSetupActions(p)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, counter)
+}
+
+func TestDeviceManager_execDeviceSetupActions_ok5(t *testing.T) {
+	counter := 0
+	p := &Plugin{}
+	m := deviceManager{
+		setupActions: []*DeviceAction{
+			{
+				Name: "ok",
+				Filter: map[string][]string{
+					"type": {"*"},
+				},
+				Action: func(p *Plugin, d *Device) error {
+					counter++
+					return nil
+				},
+			},
+		},
+		devices: map[string]*Device{
+			"123": {id: "123", Type: "foo"},
+			"456": {id: "456", Type: "bar"},
+			"678": {id: "678", Type: "foo"},
+		},
+	}
+
+	err := m.execDeviceSetupActions(p)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, counter)
+}
+
+func TestDeviceManager_execDeviceSetupActions_ok6(t *testing.T) {
+	counter := 0
+	p := &Plugin{}
+	m := deviceManager{
+		setupActions: []*DeviceAction{
+			{
+				Name: "ok",
+				Filter: map[string][]string{
+					"type": {"?ar"},
+				},
+				Action: func(p *Plugin, d *Device) error {
+					counter++
+					return nil
+				},
+			},
+		},
+		devices: map[string]*Device{
+			"123": {id: "123", Type: "foo"},
+			"456": {id: "456", Type: "bar"},
+			"678": {id: "678", Type: "foo"},
+		},
+	}
+
+	err := m.execDeviceSetupActions(p)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, counter)
+}
+
+func TestDeviceManager_execDeviceSetupActions_ok7(t *testing.T) {
+	counter := 0
+	p := &Plugin{}
+	m := deviceManager{
+		setupActions: []*DeviceAction{
+			{
+				Name: "ok",
+				Filter: map[string][]string{
+					"type": {"*temperature"},
+				},
+				Action: func(p *Plugin, d *Device) error {
+					counter++
+					return nil
+				},
+			},
+		},
+		devices: map[string]*Device{
+			"123": {id: "123", Type: "a.temperature"},
+			"456": {id: "456", Type: "foo-temperature"},
+			"678": {id: "678", Type: "temperature"},
+		},
+	}
+
+	err := m.execDeviceSetupActions(p)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, counter)
+}


### PR DESCRIPTION
This PR:
- adds glob matching capabilities to device action filtering, making it more flexible for which devices an action can match against.
- adds unit tests

fixes  #478 


This is needed for  the emulator plugin, where we want to create a device config set which more closely matches what we have running in production. In order for the emulator to register devices correctly with their backends for generating fake metrics, we need to use device setup actions, but the device types for some things we use in production do not match with what the expected filter constraint is (e.g. emulator expects a "fan" type, but we have an  "ecblue.fan" type). By adding in this glob matching,  we can accommodate these kinds of types and achieve a configuration  which more closely  matches  production.