### PR TITLE
bugfix: fix race condition around template.Parse when called concurrently, add tests

### DIFF
--- a/sdk/tag_test.go
+++ b/sdk/tag_test.go
@@ -1070,6 +1070,8 @@ func TestConcurrentMapWrites(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.tag, func(t *testing.T) {
+			// Run tests in parallel so we hit the case where template.Parse/template.Execute
+			// would be called concurrently.
 			t.Parallel()
 
 			tag, err := NewTag(tc.tag)

--- a/sdk/tag_test.go
+++ b/sdk/tag_test.go
@@ -1030,6 +1030,58 @@ func TestNewTypeTag(t *testing.T) {
 	assert.Equal(t, "system/type:foo", tag.String())
 }
 
+func TestConcurrentMapWrites(t *testing.T) {
+	testCases := []struct {
+		tag      string
+		expected *Tag
+	}{
+		{
+			"a",
+			&Tag{
+				Namespace: "default",
+				Label:     "a",
+			},
+		},
+		{
+			"a/b",
+			&Tag{
+				Namespace: "a",
+				Label:     "b",
+			},
+		},
+		{
+			"a/b:c",
+			&Tag{
+				Namespace:  "a",
+				Annotation: "b",
+				Label:      "c",
+			},
+		},
+		{
+			`a/b:{{ identity "foobar" }}`,
+			&Tag{
+				Namespace:  "a",
+				Annotation: "b",
+				Label:      "foobar",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.tag, func(t *testing.T) {
+			t.Parallel()
+
+			tag, err := NewTag(tc.tag)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected.Namespace, tag.Namespace)
+			assert.Equal(t, tc.expected.Annotation, tag.Annotation)
+			assert.Equal(t, tc.expected.Label, tag.Label)
+
+		})
+	}
+}
+
 //
 // Benchmarks
 //


### PR DESCRIPTION
In the OC plugin, I was occasionally seeing:

```
fatal error: concurrent map writes

goroutine 310 [running]:
runtime.throw(0xbbf525, 0x15)
	/usr/local/go/src/runtime/panic.go:774 +0x72 fp=0xc000453f50 sp=0xc000453f20 pc=0x42f4f2
fatal error: concurrent map writes
runtime.mapassign_faststr(0xac0a60, 0xc0001a0840, 0xbb31a8, 0x4, 0xc00007a158)
	/usr/local/go/src/runtime/map_faststr.go:291 +0x3fe fp=0xc000453fb8 sp=0xc000453f50 pc=0x4133ee
text/template.(*Template).associate(0xc0001a8700, 0xc0001a8700, 0xc0010aaf00, 0xc0017ea401)
	/usr/local/go/src/text/template/template.go:226 +0xb7 fp=0xc000453ff8 sp=0xc000453fb8 pc=0x5b5607
text/template.(*Template).AddParseTree(0xc0001a8700, 0xbb31a8, 0x4, 0xc0010aaf00, 0x0, 0x0, 0x0)
	/usr/local/go/src/text/template/template.go:132 +0xf9 fp=0xc000454048 sp=0xc000453ff8 pc=0x5b4939
text/template.(*Template).Parse(0xc0001a8700, 0xbc32bd, 0x1a, 0x30, 0x8, 0x10)
	/usr/local/go/src/text/template/template.go:207 +0x1df fp=0xc000454148 sp=0xc000454048 pc=0x5b533f
github.com/vapor-ware/synse-sdk/sdk.NewTag(0xbc32bd, 0x1a, 0xbc32bd, 0x1a, 0xc000454720)
	/go/pkg/mod/github.com/vapor-ware/synse-sdk@v0.1.0-alpha.0.20200520170149-c4580c210e37/sdk/tag.go:68 +0x62 fp=0xc000454240 sp=0xc000454148 pc=0x9ffc02
github.com/vapor-ware/synse-sdk/sdk.NewDeviceFromConfig(0xc002101180, 0xc0017e8d20, 0xc00022fb60, 0xb876c0, 0xb7c801, 0xc0017e8d20)
	/go/pkg/mod/github.com/vapor-ware/synse-sdk@v0.1.0-alpha.0.20200520170149-c4580c210e37/sdk/device.go:196 +0x1b62 fp=0xc000454c88 sp=0xc000454240 pc=0x9e64e2
github.com/vapor-ware/synse-sdk/sdk.(*Plugin).NewDevice(...)

```

a race condition where an internal map in the template lib was being concurrently written to, originating from tag generation. makes sense to happen in OC since there is a lot of data, so a lot of tags being generated. 

theres maybe a separate issue around the design of how the template parse/exec is being done that this came up in the first place, but the solution is fairly easy --- just put a mutex around the parse/exec.