### PR TITLE
bugfix: add missing delay usage for writes

### DIFF
--- a/sdk/scheduler.go
+++ b/sdk/scheduler.go
@@ -750,6 +750,12 @@ func (scheduler *scheduler) write(writeCtx *WriteContext) {
 	}
 	wlog.Debug("[scheduler] successfully wrote to device")
 	writeCtx.transaction.setStatusDone()
+
+	// If a write delay is configured, wait for that period of time before continuing
+	// (and relinquishing the lock, if in serial mode).
+	if delay != 0 {
+		time.Sleep(delay)
+	}
 }
 
 // listen listens to devices to collect readings using a device's Listen function.

--- a/sdk/scheduler_test.go
+++ b/sdk/scheduler_test.go
@@ -792,8 +792,9 @@ func TestScheduler_scheduleWrites_serial_withDelay(t *testing.T) {
 	// should only detect the delay between txn1 and tnx2, but not the delay after txn2.
 	// This means that this test only sees a single delay interval.
 	//
-	// Add a threshold of +/- 10ms to account for leeway in different testing environments.
-	assert.WithinDuration(t, start.Add(100 * time.Millisecond), end, 10 * time.Millisecond)
+	// Add a threshold of +/- 18ms to account for leeway in different testing environments.
+	// In CI, tests run a bit slower.
+	assert.WithinDuration(t, start.Add(100 * time.Millisecond), end, 18 * time.Millisecond)
 
 
 	assert.Equal(t, synse.WriteStatus_DONE, txn1.status, txn1.message)


### PR DESCRIPTION
This PR:
- adds in write delay, which was previously configurable, but its usage was not implemented
- adds regression test

related to #489 