### PR TITLE
Handle nil cases for deference nil pointers

### DIFF
--- a/sdk/device_manager.go
+++ b/sdk/device_manager.go
@@ -403,6 +403,9 @@ func (manager *deviceManager) AddDevice(device *Device) error {
 // AddHandlers adds DeviceHandlers to the DeviceManager.
 func (manager *deviceManager) AddHandlers(handlers ...*DeviceHandler) error {
 	for _, handler := range handlers {
+		if handler == nil {
+			continue
+		}
 		if _, exists := manager.handlers[handler.Name]; exists {
 			return fmt.Errorf(
 				"unable to register multiple handlers with duplicate names: %s",

--- a/sdk/device_manager_test.go
+++ b/sdk/device_manager_test.go
@@ -894,6 +894,19 @@ func TestDeviceManager_AddHandlers_err(t *testing.T) {
 	assert.Len(t, m.handlers, 1)
 }
 
+func TestDeviceManager_AddHandlers_nil(t *testing.T) {
+	m := deviceManager{
+		handlers: map[string]*DeviceHandler{},
+	}
+
+	err := m.AddHandlers(
+		&DeviceHandler{Name: "foo"},
+		nil,
+	)
+	assert.NoError(t, err)
+	assert.Len(t, m.handlers, 1)
+}
+
 func TestDeviceManager_GetDevicesForHandler(t *testing.T) {
 	m := deviceManager{
 		handlers: map[string]*DeviceHandler{

--- a/sdk/funcs/functions.go
+++ b/sdk/funcs/functions.go
@@ -42,6 +42,9 @@ func Register(funcs ...*Func) error {
 	multiErr := errors.NewMultiError("func registration")
 
 	for _, f := range funcs {
+		if f == nil {
+			continue
+		}
 		if _, exists := registeredFuncs[f.Name]; exists {
 			multiErr.Add(fmt.Errorf("conflict: Func with name '%s' already exists", f.Name))
 			continue

--- a/sdk/funcs/functions_test.go
+++ b/sdk/funcs/functions_test.go
@@ -93,6 +93,24 @@ func TestRegister_conflict(t *testing.T) {
 	assert.Len(t, registeredFuncs, initLen)
 }
 
+func TestRegister_nil(t *testing.T) {
+	// Copy the map and reset it once we're done so we don't
+	// pollute it for other tests.
+	var registeredCopy = map[string]*Func{}
+	for k, v := range registeredFuncs {
+		registeredCopy[k] = v
+	}
+	defer func() {
+		registeredFuncs = registeredCopy
+	}()
+
+	initLen := len(registeredFuncs)
+
+	err := Register(nil)
+	assert.NoError(t, err)
+	assert.Len(t, registeredFuncs, initLen)
+}
+
 func TestFunc_Call_ok(t *testing.T) {
 	fn := Func{
 		Name: "test",

--- a/sdk/output/output.go
+++ b/sdk/output/output.go
@@ -44,6 +44,9 @@ func Register(output ...*Output) error {
 	multiErr := errors.NewMultiError("output registration")
 
 	for _, o := range output {
+		if o == nil {
+			continue
+		}
 		if _, exists := registeredOutputs[o.Name]; exists {
 			multiErr.Add(fmt.Errorf("conflict: output with name '%s' already exists", o.Name))
 			continue

--- a/sdk/output/output_test.go
+++ b/sdk/output/output_test.go
@@ -92,6 +92,24 @@ func TestRegister_conflict(t *testing.T) {
 	assert.Len(t, registeredOutputs, initLen)
 }
 
+func TestRegister_nil(t *testing.T) {
+	// Copy the map and reset it once we're done so we don't
+	// pollute it for other tests.
+	var registeredCopy = map[string]*Output{}
+	for k, v := range registeredOutputs {
+		registeredCopy[k] = v
+	}
+	defer func() {
+		registeredOutputs = registeredCopy
+	}()
+
+	initLen := len(registeredOutputs)
+
+	err := Register(nil)
+	assert.NoError(t, err)
+	assert.Len(t, registeredOutputs, initLen)
+}
+
 func TestOutput_MakeReading(t *testing.T) {
 	o := Output{
 		Name:      "test-output",

--- a/sdk/plugin.go
+++ b/sdk/plugin.go
@@ -185,6 +185,11 @@ func NewPlugin(options ...PluginOption) (*Plugin, error) {
 // everything is ready, it will run each of its components. The gRPC server is
 // run in the foreground; all other components are run as goroutines.
 func (plugin *Plugin) Run() error {
+	if plugin == nil {
+		log.Error("[plugin] plugin instance not found")
+		return fmt.Errorf("plugin is nil")
+	}
+
 	// Initialize the plugin and its components.
 	if err := plugin.initialize(); err != nil {
 		log.Error("[plugin] failed to initialize plugin")


### PR DESCRIPTION
This code pattern is used three times between output types, plugin handler, and device manager. Might have a few more missing cases, but this addresses possible panics when wiring up plugins.